### PR TITLE
Gender equal zandalari

### DIFF
--- a/common/religion/religions/loa_group.txt
+++ b/common/religion/religions/loa_group.txt
@@ -257,7 +257,8 @@
 			
 			#Main Group
 			doctrine = doctrine_pluralism_pluralistic
-
+			doctrine = doctrine_gender_equal
+			
 			doctrine = tenet_adaptive
 			doctrine = tenet_ancestor_worship
 			doctrine = tenet_literalism


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- The default Zandalari faith Zan'Atali now has the religious doctrine of gender equality by default.

