### PR TITLE
Uther Birth Year Fix

### DIFF
--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -889,8 +889,8 @@
 	martial=5 diplomacy=6 stewardship=3 intrigue=4 learning=8
 	trait=education_martial_4 trait=physique_good_3 trait=education_martial_prowess_4 trait=generous trait=just trait=chaste trait=patient trait=intellect_good_1
 	disallow_random_traits=yes
-	548.2.26={ birth=yes trait=creature_human }
-	564.2.26={
+	539.2.26={ birth=yes trait=creature_human }
+	555.2.26={
 		trait = class_warrior_9
 	}
 	588.5.1={


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Changed Uther's birth year from 548 to 539 so it's more accurate to the lore.

_According to the [Warcraft III Game Manual](https://wow.gamepedia.com/Warcraft_III:_Reign_of_Chaos_Game_Manual#Uther_the_Lightbringer), Uther was 64 years old during the Third War (year 603 in the mod). **603-64=539**._

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Make sure the change doesn't cause any problems with titles or other in-game events tied to Uther's character.