### PR TITLE
Undead Trait Fix

### DIFF
--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -30,7 +30,6 @@
 	
 	###Scripted colors
 	being_undead_sylvanas = {
-		base = being_undead_basic
 		traits = {
 			being_undead
 		}
@@ -59,7 +58,6 @@
 		}
 	}
 	being_undead_nathanos = {
-		base = being_undead_basic
 		traits = {
 			being_undead
 		}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Removed `base = being_undead_basic` from Nathanos and Sylvanas as their body types should not be affected by the trait.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Make sure this doesn't break anything.