### PR TITLE
Fel Orc Trait Modifier

### DIFF
--- a/gfx/portraits/trait_portrait_modifiers/wc_fel_orc_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_fel_orc_modifier.txt
@@ -1,0 +1,31 @@
+﻿fel_orc = {
+	fel_orc = {
+		traits = { creature_fel_orc }
+		dna_modifiers = {
+			accessory = {
+				mode = add
+				gene = special_eyes
+				template = magic_eyes
+				value = 1
+			}
+			color = {
+				gene = eye_color
+				mode = replace
+				x = 0
+				y = 0.5
+			}
+			color = {
+				gene = skin_color
+				mode = replace
+				x = { 0 0.031 }
+				y = { 0.537 0.700 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_shape
+				template = body_shape_triangle_full
+				value = { 0.75 1 }
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Anyone with the **_Fel Orc_** trait gets red skin, glowing red eyes, and a stronger physique—as per the description of their appearance on [Wowpedia](https://wow.gamepedia.com/Fel_orc#Appearance_and_characteristics):

> [Fel orcs] are easily distinguishable from regular orcs by their **red skin, glowing red eyes**

> Upon their second consumption of Mannoroth's blood, the orcs were transformed into fel orcs, turning red skinned and **larger**

## Screenshots:

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/78575425/108646244-e2f0b980-74bd-11eb-8ee7-d5257dfcee0e.png)
![image](https://user-images.githubusercontent.com/78575425/108646255-e7b56d80-74bd-11eb-80bb-821bacf315bc.png)

</details>

## FAQ:

**Q: What's the deal with WoD fel orcs looking different? Should those be implemented as well?**
**A:** I'm open to feedback on this, but as a general rule I would say we shouldn't touch the alternate universe stuff since the current bookmarks are focused on the canon, main timeline. To quote [Wowpedia](https://wow.gamepedia.com/Fel_orc#Appearance_and_characteristics):

> On the alternate Draenor, Gul'dan and his followers were described as fel orcs, but had green skin rather than red skin and mutations. **Sean Copeland clarified that these orcs are fel-corrupted but not true "fel orcs."**

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Provide feedback on this change. Is it a good change or a bad one? Should something be done differently or would there be a better way of doing this altogether?