### PR TITLE
Skin Value

### DIFF
--- a/common/ethnicities/00_ethnicities_templates.txt
+++ b/common/ethnicities/00_ethnicities_templates.txt
@@ -89,6 +89,12 @@ ethnicity_template = {
 		# Black
 		30 = { @brown_color_x_min @black_color_y_min @brown_color_x_max @black_color_y_max }
 	}
+	gene_skin_saturation = {
+		1 = { name = skin_saturation    range = { 0.5 0.5 }    }
+	}
+	gene_skin_value = {
+		1 = { name = skin_value    range = { 0.5 0.5 }    }
+	}
 	
     gene_chin_forward = {
         1 = { name = chin_forward_neg    range = { @neg3_min @neg3_max }    }

--- a/common/ethnicities/00_ethnicities_templates.txt
+++ b/common/ethnicities/00_ethnicities_templates.txt
@@ -89,9 +89,9 @@ ethnicity_template = {
 		# Black
 		30 = { @brown_color_x_min @black_color_y_min @brown_color_x_max @black_color_y_max }
 	}
-	gene_skin_saturation = {
-		1 = { name = skin_saturation    range = { 0.5 0.5 }    }
-	}
+	# gene_skin_saturation = {
+		# 1 = { name = skin_saturation    range = { 0.5 0.5 }    }
+	# }
 	gene_skin_value = {
 		1 = { name = skin_value    range = { 0.5 0.5 }    }
 	}

--- a/common/genes/01_genes_morph.txt
+++ b/common/genes/01_genes_morph.txt
@@ -340,26 +340,26 @@ age_presets = {
 
 morph_genes = {
 	# Warcraft
-	gene_skin_saturation = {
-		index = 111
-		group = body
-		skin_saturation = {
-			index = 0
-			male = {
-				skin_hsv_shift_curve = {
-					curve = {
-						{ 0   { 0 -1 0 } }
-						{ 1   { 0 1 0 } }
-					}
-				}
-			}
-			female = male
-			boy = male
-			girl = male
-		}
-	}
+	# gene_skin_saturation = {
+		# index = 111
+		# group = body
+		# skin_saturation = {
+			# index = 0
+			# male = {
+				# skin_hsv_shift_curve = {
+					# curve = {
+						# { 0   { 0 -1 0 } }
+						# { 1   { 0 1 0 } }
+					# }
+				# }
+			# }
+			# female = male
+			# boy = male
+			# girl = male
+		# }
+	# }
 	gene_skin_value = {
-		index = 112
+		index = 111
 		group = body
 		skin_value = {
 			index = 0

--- a/common/genes/01_genes_morph.txt
+++ b/common/genes/01_genes_morph.txt
@@ -339,6 +339,43 @@ age_presets = {
 }
 
 morph_genes = {
+	# Warcraft
+	gene_skin_saturation = {
+		index = 111
+		group = body
+		skin_saturation = {
+			index = 0
+			male = {
+				skin_hsv_shift_curve = {
+					curve = {
+						{ 0   { 0 -1 0 } }
+						{ 1   { 0 1 0 } }
+					}
+				}
+			}
+			female = male
+			boy = male
+			girl = male
+		}
+	}
+	gene_skin_value = {
+		index = 112
+		group = body
+		skin_value = {
+			index = 0
+			male = {
+				skin_hsv_shift_curve = {
+					curve = {
+						{ 0   { 0 0 -1 } }
+						{ 1   { 0 0 1 } }
+					}
+				}
+			}
+			female = male
+			boy = male
+			girl = male
+		}
+	}
 	
 	gene_chin_forward = {
 		index = 3

--- a/localization/english/wc_portraits_l_english.yml
+++ b/localization/english/wc_portraits_l_english.yml
@@ -84,3 +84,6 @@
  dark_troll_ethnicity:0 "Dark Trollish"
  forest_troll_ethnicity:0 "Forest Trollish"
  zandalari_troll_ethnicity:0 "Zandalari Trollish"
+ 
+ gene_skin_saturation:0 "Skin Saturation"
+ gene_skin_value:0 "Skin Value"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added the skin value slider.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
We need to keep only one slider pick one. I'm for the Value. Here's why:

There are Hue, Saturation, and Value.

<details>
<summary>Saturation Pallete</summary>

![image](https://user-images.githubusercontent.com/46384992/111118312-0caf7480-8582-11eb-9a72-a94d355e1e9c.png)

</details>
<details>
<summary>Value Pallete</summary>

![image](https://user-images.githubusercontent.com/46384992/111118330-12a55580-8582-11eb-9758-0a813b582a58.png)

</details>

Basically, our current palette is combined out of these 2 pallets.

And thus there's a problem: when the value is set to 0.5 and more, it doesn't affect the upper part of our pallet because it's maxed out there. The saturation is vice versa, 0.5 and more doesn't affect the bottom part.

So why would I prefer the value? Most of our skin colors aren't dark and picked from the upper part and the Value affects it the most creating the dark version of not-saturated colors like the greenish color of the gray orcs.

<details>
<summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/46384992/111119010-fb1a9c80-8582-11eb-93f4-a1ccecbfa1f9.png)

</details>

Test it and tell your opinion.