### PR TITLE
176 Albino Shouldn't Override Undead

### DIFF
--- a/gfx/portraits/trait_portrait_modifiers/00_trait_modifiers.txt
+++ b/gfx/portraits/trait_portrait_modifiers/00_trait_modifiers.txt
@@ -161,6 +161,10 @@ albino = {
 		trigger = {
 			# Warcraft
 			has_no_portrait_trigger = no
+
+			NOT = {
+				has_trait = being_undead
+			}
 		}
 		traits = { albino }
 		dna_modifiers = {


### PR DESCRIPTION
Resolves #176

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Characters that are both undead and albino now look undead instead of albino

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Albino appearance will no longer trigger if you posses undead trait

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Make a character both albino and undead ("being_undead")