### PR TITLE
Fixed younger races spawning very old

### DIFF
--- a/common/script_values/wc_age_values.txt
+++ b/common/script_values/wc_age_values.txt
@@ -13,7 +13,7 @@
 		multiply = 22
 	}
 	else_if = {
-		limit = { is_nightborn_elf_trigger = yes }
+		limit = { is_nightborne_elf_trigger = yes }
 		multiply = 22
 	}
 	else_if = {


### PR DESCRIPTION
Resolves #323

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed younger races spawning very old

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Misspelled trigger caused the game to pull out a value out of the ether instead. Said value was way too high, causing all characters to spawn wayyyy too old.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
