### PR TITLE
Mountain Dweller modifier

### DIFF
--- a/common/modifiers/00_province_modifiers.txt
+++ b/common/modifiers/00_province_modifiers.txt
@@ -110,5 +110,5 @@ winter_harsh_modifier = {
 #Warcraft
 mountain_dwellers_modifier = {
 	icon = county_modifier_development_positive
-	development_growth_factor = .25
+	development_growth_factor = 0.25
 }

--- a/common/modifiers/00_province_modifiers.txt
+++ b/common/modifiers/00_province_modifiers.txt
@@ -106,3 +106,9 @@ winter_harsh_modifier = {
 	defender_winter_advantage = 5
 	hard_casualty_winter = -0.2
 }
+
+#Warcraft
+mountain_dwellers_modifier = {
+	icon = county_modifier_development_positive
+	development_growth_factor = .25
+}

--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -9,7 +9,6 @@ on_game_start = {
 
 	effect = {
 		# Warcraft
-
 		### RELIGIOUS THINGS ###
 		# Warcraft
 		every_religion_global = {
@@ -100,7 +99,7 @@ on_game_start = {
 				}
 			}
 		}
-		
+
 		# Warcraft
 	}
 	# Warcraft
@@ -112,6 +111,9 @@ on_game_start = {
 # Like on_game_start, except it is called once the host (or player, in single player) exits the lobby. Good for anything where you need to know who the players are, or what the game rules are
 on_game_start_after_lobby = {
 	effect = {
+		### Scripted effect
+		mountain_dwellers_scripted_effect = yes
+
 		### GAME RULE: VIEW ON SAME-SEX RELATIONS
 		if = {
 			limit = { has_game_rule = accepted_same_sex_relations }

--- a/common/on_action/title_on_actions.txt
+++ b/common/on_action/title_on_actions.txt
@@ -38,6 +38,8 @@ on_title_destroyed = {
 # scope:previous_holder = previous holder. Might be dead
 on_title_gain = {
 	effect = {
+		##Scripted Effect
+		mountain_dwellers_scripted_effect = yes
 		if = {
 			limit = {
 				scope:title = { is_holy_order = yes }

--- a/common/scripted_effects/wc_history_effects.txt
+++ b/common/scripted_effects/wc_history_effects.txt
@@ -2,3 +2,306 @@
 	set_to_lowborn = yes
 	death = { death_reason = death_vanished }
 }
+mountain_dwellers_scripted_effect = {
+	if = {
+		limit = {
+			OR = {
+				culture_group = culture_group:gnome_group
+				culture_group = culture_group:dwarf_group
+				culture_group = culture_group:trogg_group
+			}
+		}
+	}
+	#Central Dun Morogh#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_central_dun_morogh }
+		}
+		title:c_ironforge = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_hiding_valley = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_storm_ravine = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#East Dun Morogh#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_east_dun_morogh }
+		}
+		title:c_helms_bed = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_amberroad = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_golbolar = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_northgate = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_tundrid_hills = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Kharanos#	
+	if = {
+		limit = {
+			this = { completely_controls = title:d_kharanos }
+		}
+		title:c_kharanos = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_coldridge_pass = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_ice_pass = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_irongate = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_shimmer_ridge = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Krensen#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_krensen }
+		}
+		title:c_hidden_ravine = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_greenhills = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_narrowhill = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_stonyglade = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Loch Modan#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_loch_modan }
+		}
+		title:c_thelsamar = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_southgate = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_stonesplinter_valley = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_valley_of_kings = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Stonewrought#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_stonewrought }
+		}
+		title:c_stonewrought_dam = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_loch_islands = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_north_crossroads = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_silverstream = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Gnomeregan#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_gnomeregan }
+		}
+		title:c_gnomeregan = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_tinkerboom = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_wrenchport = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#New Tinkertown#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_new_tinkertown }
+		}
+		title:c_icewind_pass = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_frostmane  = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_icewind_valley = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_new_tinkertown = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+	#Blackrock Mountain#
+	if = {
+		limit = {
+			this = { completely_controls = title:d_blackrock_mountain }
+		}
+		title:c_blackrock_depths = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+		title:c_blackrock_spire = {
+			title_province = {
+				add_province_modifier = {
+					modifier = mountain_dwellers_modifier
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- GDC if useless

## Changelog:
- Adds modifier to Gnomes/Dwarfs/Troggs living in Khaz Modan, so that their dev isn't because they live in a mountain province.

## Dev Changelog:
- Added a trigger in the game_start and the on_title_gain files to mention the new effect

## Need to add:
- Pick and choose the provinces mentioned more accurately.
- Add more cultures to get the modifier, like Black Iron and so on.
- Get the modifier to work...