### PR TITLE
Relative Old

### DIFF
--- a/common/on_action/birthday.txt
+++ b/common/on_action/birthday.txt
@@ -6,11 +6,6 @@ on_birthday = {
 		on_birthday_childhood
 		on_graceful_aging_birthday
 	}
-	# Warcraft 
-	random_events = {
-		65 = 0
-		35 = WCNIC.1
-	}
 }
 
 on_specific_birthday = {

--- a/common/on_action/yearly_on_actions.txt
+++ b/common/on_action/yearly_on_actions.txt
@@ -85,6 +85,9 @@ three_year_playable_pulse = {
 	random_events = {
 		800 = 0
 		
+		# Warcraft 
+		100 = WCNIC.1 # Nickname for when the character rule long
+		
 		# Warcraft
 		# 200 = global_culture.3011
 		# 600 = global_culture.3012

--- a/events/nickname_events/wc_nickname_events.txt
+++ b/events/nickname_events/wc_nickname_events.txt
@@ -4,8 +4,8 @@
 
 namespace = WCNIC
 
-### the Old Murkeye
-WCNIC.1 = { # Nickname for when the character rule long
+### Nickname for when the character rule long
+WCNIC.1 = {
 	type = character_event
 	title = WCNIC.1.t
 	

--- a/events/nickname_events/wc_nickname_events.txt
+++ b/events/nickname_events/wc_nickname_events.txt
@@ -109,7 +109,7 @@ WCNIC.1 = {
 			text = {
 				first_valid = {
 					triggered_desc = {
-						limit = { has_culture_group = culture_group:murloc_group }
+						trigger = { has_culture_group = culture_group:murloc_group }
 						desc = WCNIC.1.b.m
 					}
 					desc = WCNIC.1.b.h

--- a/events/nickname_events/wc_nickname_events.txt
+++ b/events/nickname_events/wc_nickname_events.txt
@@ -10,12 +10,11 @@ WCNIC.1 = { # Nickname for when the character rule long
 	title = WCNIC.1.t
 	
 	desc = {
-		triggered_desc = {
-			trigger = { has_culture_group = culture_group:murloc_group }
-			desc = WCNIC.1.desc.m
-		}
-		triggered_desc = {
-			trigger = { has_culture_group = culture_group:human_group }
+		first_valid = {
+			triggered_desc = {
+				trigger = { has_culture_group = culture_group:murloc_group }
+				desc = WCNIC.1.desc.m
+			}
 			desc = WCNIC.1.desc.h
 		}
 	}
@@ -34,27 +33,22 @@ WCNIC.1 = { # Nickname for when the character rule long
 			has_character_flag = denied_nickname_event_the_old
 		}
 		
-		OR = {
-			has_culture_group = culture_group:human_group
-			has_culture_group = culture_group:murloc_group
-		}
-		
 		has_any_nickname = no
 		NOT = {
 			primary_title = { recent_history = { years = 10 } }
 		}
-		age >= 45
+		age >= age_45_value
 	}
 	
 	weight_multiplier = {
 		base = 1
 		modifier = {
 			factor = 1.5
-			age >= 55
+			age >= age_55_value
 		}
 		modifier = {
 			factor = 2
-			age >= 65
+			age >= age_65_value
 		}
 		modifier = {
 			factor = 1.5
@@ -97,9 +91,8 @@ WCNIC.1 = { # Nickname for when the character rule long
 	
 	option = { # the Old
 		name = WCNIC.1.a.h
-		
 		trigger = {
-			has_culture_group = culture_group:human_group
+			NOT = { has_culture_group = culture_group:murloc_group }
 		}
 		
 		set_nickname_effect = { NICKNAME = nick_the_old }
@@ -113,20 +106,15 @@ WCNIC.1 = { # Nickname for when the character rule long
 	
 	option = { # None
 		name = {
-			trigger = {
-				has_culture_group = culture_group:murloc_group
+			text = {
+				first_valid = {
+					triggered_desc = {
+						limit = { has_culture_group = culture_group:murloc_group }
+						desc = WCNIC.1.b.m
+					}
+					desc = WCNIC.1.b.h
+				}
 			}
-			
-			text = WCNIC.1.b.m
-			# flavor = WCNIC.1.tt.b.m
-		}
-		
-		name = {
-			trigger = {
-				has_culture_group = culture_group:human_group
-			}
-			
-			text = WCNIC.1.b.h
 		}
 		
 		remove_character_flag = had_nickname_event


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Even the elves can have the Old nickname now because we use relative age: `age_45_value`, etc.
- Moved `WCNIC.1` to `three_year_playable_pulse` for performance reasons: it fires only for playable rulers.
- Made `WCNIC.1` rarer.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Check the changes, tell if you approve them.