### PR TITLE
Update wc_title_replacements_l_english.yml

### DIFF
--- a/localization/replace/english/wc_title_replacements_l_english.yml
+++ b/localization/replace/english/wc_title_replacements_l_english.yml
@@ -139,4 +139,5 @@
  b_icecrown:0 "Icecrown"
  c_south_islands:0 "Jaguero"
  c_south_islands_adj:0 "Jaguero"
- 
+ e_zulfarrak:0 "Farraki"
+ k_gurubashi:0 "Zul'Gurub"

--- a/localization/replace/english/wc_title_replacements_l_english.yml
+++ b/localization/replace/english/wc_title_replacements_l_english.yml
@@ -140,4 +140,13 @@
  c_south_islands:0 "Jaguero"
  c_south_islands_adj:0 "Jaguero"
  e_zulfarrak:0 "Farraki"
+ k_zulfarrak:0 "Zul'Farrak"
+ d_zulfarrak:0 "Zul'Farrak"
+ c_zulfarrak:0 "Zul'Farrak"
  k_gurubashi:0 "Zul'Gurub"
+ d_zulgurub:0 "Zul'Gurub"
+ c_zulgurub:0 "Zul'Gurub"
+ k_zulaman:0 "Zul'Aman"
+ d_zulaman:0 "Zul'Aman"
+ k_zuldrak:0 "Zul'Drak"
+ 


### PR DESCRIPTION
## Changelog:
- Fixed some flavor for some troll titles.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
Added names "Farraki" and "Zul'Gurub" in for e_zulfarrak and k_gurubashi.
Added names for Zul'Farrak, Zul'Drak, Zul'Aman to have capital letters on suffix like.
 
in: wowlocalization/replace/english/wc_title_replacements_l_english.yml
<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
boot up game, see if names for Empire of Farraki and Kingdom of Zul'gurub are right, see if 'Gurub etc are capitalized in character viewer or outside of map