### PR TITLE
Junkwatt Flag

### DIFF
--- a/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
+++ b/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
@@ -351,7 +351,7 @@ k_mechagon = {
 	}
 }
 
-d_rustbolt = {
+d_junkwatt = {
 	pattern = "pattern_solid.dds" 
 	color1 = rgb { 26 46 53 } 
 	colored_emblem = {


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Junkwatt Duchy uses Rustbolt flag since it was deleted.