### PR TITLE
Satyr, Dryad Immortality

### DIFF
--- a/common/traits/wc_race_traits.txt
+++ b/common/traits/wc_race_traits.txt
@@ -760,7 +760,6 @@ creature_satyr = {
 	}
 	shown_in_ruler_designer = no
 	
-	immortal = yes
 	life_expectancy = 2000
 
 	inherit_chance = 50
@@ -1377,8 +1376,7 @@ creature_dryad = {
 	}
 	shown_in_ruler_designer = no
 	
-	immortal = yes
-	life_expectancy = 2000
+	life_expectancy = 25000
 
 	inherit_chance = 50
 	both_parent_has_trait_inherit_chance = 100
@@ -1398,8 +1396,7 @@ creature_frostnymph = {
 	}
 	shown_in_ruler_designer = no
 	
-	immortal = yes
-	life_expectancy = 2000
+	life_expectancy = 25000
 
 	inherit_chance = 50
 	both_parent_has_trait_inherit_chance = 100


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Satyrs, dryads aren't immortal now because it forced their child don't age so they stayed child forever.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Observe satyr and dryad children.