### PR TITLE
Orgrim now has appropriate claims & Bronzebeard brothers are no longer half brothers

### DIFF
--- a/history/characters/100000_vrykul.txt
+++ b/history/characters/100000_vrykul.txt
@@ -35,7 +35,7 @@
 	trait=arbitrary trait=content trait=arrogant trait=chaste
 	1.1.1={ birth=yes trait=creature_vrykul effect = { add_character_modifier = hibernated_modifier } }
 	20.1.1={
-		add_claim=c_gjalerbron
+		add_pressed_claim=c_gjalerbron
 		trait = class_shaman_5
 		effect = { set_character_flag = is_angerboda_flag }
 	}

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -610,8 +610,8 @@
 		employer = 10000
 		add_prestige = 750		# Should be able to invite clans when he's Warchief
 		add_piety = 375
-		add_claim = e_horde
-		add_claim = k_orc_blackrock
+		add_pressed_claim = e_horde
+		add_pressed_claim = k_orc_blackrock
 		give_job_title=job_marshal
 	}
 	601.11.1={ death=yes }

--- a/history/characters/11000_dark_iron.txt
+++ b/history/characters/11000_dark_iron.txt
@@ -1077,8 +1077,8 @@
 		add_spouse = 12001
 	}
 	350.1.1={
-		add_claim=k_ironforge
-		add_claim=c_ironforge
+		add_pressed_claim=k_ironforge
+		add_pressed_claim=c_ironforge
 	}
 	353.1.1={
 		effect = { character_event = { id = WCSHM.7995 days = 180 random = 180 } } # Summoning of Ragnaros

--- a/history/characters/16000_gnome.txt
+++ b/history/characters/16000_gnome.txt
@@ -1221,10 +1221,10 @@
 	disallow_random_traits = yes
 	1.9.2={ birth=yes trait=creature_gnome immortal_age=18 }
 	200.1.1={
-		add_claim=k_gnomeregan
-		add_claim=d_gnomeregan
-		add_claim=d_new_tinkertown
-		add_claim=c_gnomeregan
+		add_pressed_claim=k_gnomeregan
+		add_pressed_claim=d_gnomeregan
+		add_pressed_claim=d_new_tinkertown
+		add_pressed_claim=c_gnomeregan
 	}
 	630.9.29={ death=yes }
 }

--- a/history/characters/17000_28000_bronzebeard.txt
+++ b/history/characters/17000_28000_bronzebeard.txt
@@ -382,7 +382,7 @@
 	culture=bronzebeard religion=khazism
 	trait=education_diplomacy_3
 	add_spouse = 17042
-	275.2.12={ birth=yes trait=creature_dwarf immortal_age=18 }
+	275.2.12={ birth=yes trait=creature_dwarf }
 	513.7.17={ death=yes }
 }
 # dynasty=4239

--- a/history/characters/17000_28000_bronzebeard.txt
+++ b/history/characters/17000_28000_bronzebeard.txt
@@ -24,6 +24,7 @@
 	martial=8 diplomacy=8 stewardship=6 intrigue=4 learning=6
 	trait=education_martial_4 trait=patient trait=generous trait=compassionate trait=honest
 	father=17042	#Horhunn
+	mother=17043
 	disallow_random_traits = yes
 	365.4.16={
 		birth=yes	
@@ -42,6 +43,7 @@
 	martial=8 diplomacy=6 stewardship=6 intrigue=5 learning=8
 	trait=education_martial_4 trait=trusting trait=brave trait=honest trait=compassionate
 	father=17042	#Horhunn
+	mother=17043
 	disallow_random_traits = yes
 	382.4.16={ birth=yes trait=creature_dwarf immortal_age=18 }
 	400.4.16={
@@ -311,6 +313,7 @@
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=8
 	trait=education_learning_4 trait=brave trait=patient trait=diligent
 	father=17042	#Horhunn
+	mother=17043
 	disallow_random_traits = yes
 	413.1.1={ birth=yes trait=creature_dwarf immortal_age=18 }
 	431.1.1={
@@ -368,10 +371,20 @@
 	trait=education_martial_3 trait=paranoid trait=cynical trait=patient
 	trait=arrogant
 	father=17041	#Grundar
+	add_spouse = 17043
 	271.9.10={ birth=yes trait=creature_dwarf immortal_age=18 }
 	511.7.14={ death=yes }
 }
 
+17043={
+	name = Kusahe
+	female = yes
+	culture=bronzebeard religion=khazism
+	trait=education_diplomacy_3
+	add_spouse = 17042
+	275.2.12={ birth=yes trait=creature_dwarf immortal_age=18 }
+	513.7.17={ death=yes }
+}
 # dynasty=4239
 # Ruler of Farson Hold on Tol Barad
 17050={

--- a/history/characters/17000_28000_bronzebeard.txt
+++ b/history/characters/17000_28000_bronzebeard.txt
@@ -2119,8 +2119,8 @@
 	trait=ambitious trait=brave trait=stubborn trait=arbitrary
 	320.3.21={ birth=yes trait=creature_dwarf immortal_age=18 }
 	600.1.1={
-		add_claim=c_alterac_valley
-		add_claim=c_headland
+		add_pressed_claim=c_alterac_valley
+		add_pressed_claim=c_headland
 	}
 	753.10.31={ death=yes }
 }

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -13597,10 +13597,10 @@
 	father=5177	#Tito
 	581.7.2={
 		birth=yes trait=creature_human
-		add_claim = d_burning_steppes
-		add_claim = c_redpath
-		add_claim = c_chiselgrip
-		add_claim = c_khalfok
+		add_pressed_claim = d_burning_steppes
+		add_pressed_claim = c_redpath
+		add_pressed_claim = c_chiselgrip
+		add_pressed_claim = c_khalfok
 	}
 	694.6.14={ death=yes }
 }
@@ -15395,7 +15395,7 @@
 		trait=class_rogue_6
 		religion=masonry
 		trait=peasant_leader
-		add_claim=k_stormwind
+		add_pressed_claim=k_stormwind
 		effect = {
 			# Well-balanced troops
 			spawn_colonial_troops_effect = yes

--- a/history/characters/22000_wildhammer.txt
+++ b/history/characters/22000_wildhammer.txt
@@ -25,7 +25,6 @@
 	culture=wildhammer religion=shamanism
 	martial=5 diplomacy=3 stewardship=6 intrigue=3 learning=6
 	trait=education_martial_4 trait=honest trait=just trait=brave
-	father=22052	#Thoryl
 	400.3.25={ birth=yes trait=creature_dwarf effect = { make_important_lore_character_effect = yes } }
 	420.3.25={
 		trait = class_warrior_5

--- a/history/characters/29000_gnoll.txt
+++ b/history/characters/29000_gnoll.txt
@@ -1547,7 +1547,7 @@
   father=29217
   trait=education_diplomacy_3 trait=stubborn trait=intellect_bad_1 trait=arrogant
   524.9.2={ birth=yes trait=creature_gnoll }
-	533.5.25={ employer=29038 add_claim=c_dawning_isles }
+	533.5.25={ employer=29038 add_pressed_claim=c_dawning_isles }
   584.8.9={ death=yes }
 }
 29219={
@@ -1557,7 +1557,7 @@
   martial=7 diplomacy=3 stewardship=6 intrigue=5 learning=6
   trait=education_martial_1 trait=gregarious trait=craven trait=wrathful
   father=29218
-  564.2.17={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+  564.2.17={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
   584.10.25={ death=yes }
 }
 29220={
@@ -1568,7 +1568,7 @@
   trait=education_martial_2 trait=physique_good_3 trait=sadistic trait=just trait=class_warrior_5 trait=content
 	disallow_random_traits = yes
   father=29219
-  584.6.9={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+  584.6.9={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
   603.7.1={
     trait=being_undead
@@ -1589,7 +1589,7 @@
 	trait=education_intrigue_2 trait=compassionate
   father=29217
 	527.5.14={ birth=yes trait=creature_gnoll }
-	533.5.25={ employer=29038 add_claim=c_dawning_isles }
+	533.5.25={ employer=29038 add_pressed_claim=c_dawning_isles }
 	563.5.3={ death=yes }
 }
 29222={
@@ -1601,7 +1601,7 @@
   father=29217
 	female=yes
 	507.12.6={ birth=yes trait=creature_gnoll }
-	533.5.25={ employer=29038 add_claim=c_dawning_isles }
+	533.5.25={ employer=29038 add_pressed_claim=c_dawning_isles }
 	561.3.19={ death=yes }
 }
 29223={
@@ -1611,7 +1611,7 @@
 	martial=4 diplomacy=6 stewardship=3 intrigue=5 learning=2
 	trait=education_learning_2 trait=brave trait=class_warrior_6
 	father=29221
-	546.6.21={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	546.6.21={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	585.1.7={ death=yes }
 }
 29224={
@@ -1621,7 +1621,7 @@
 	martial=4 diplomacy=2 stewardship=3 intrigue=9 learning=1
 	trait=education_intrigue_1 trait=deceitful trait=lazy
 	father=29221
-	549.10.12={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	549.10.12={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
   603.7.1={
     trait=being_undead
@@ -1641,7 +1641,7 @@
 	disallow_random_traits=yes
 	father=29223
 	female=yes
-	571.7.28={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	571.7.28={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
   603.7.1={
     trait=being_undead
@@ -1659,7 +1659,7 @@
 	trait=gregarious
 	disallow_random_traits=yes
 	father=29223
-	574.2.10={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	574.2.10={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
   603.7.1={ employer=29025 }
 	618.5.18={ death=yes }
@@ -1672,7 +1672,7 @@
 	trait=education_martial_2 trait=diligent trait=shy trait=wrathful
 	father=29224
 	female=yes
-	570.5.14={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	570.5.14={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
   603.7.1={
     trait=being_undead
@@ -1690,7 +1690,7 @@
 	trait=education_martial_2
 	father=29218
 	female=yes
-	567.5.14={ birth=yes trait=creature_gnoll employer=29038 add_claim=c_dawning_isles }
+	567.5.14={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
 	597.4.24={ employer=29039 }
 	601.6.19={ death=yes }
 }

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1107,17 +1107,17 @@
 		add_gold = 300 #Military budget
 
 		# Claims Balnazzar's lands in Lordaeron
-		add_claim=k_lordaeron
-		add_claim=c_lordaeron
-		add_claim=c_balnir
-		add_claim=c_bastion
+		add_pressed_claim=k_lordaeron
+		add_pressed_claim=c_lordaeron
+		add_pressed_claim=c_balnir
+		add_pressed_claim=c_bastion
 		# Claims Windrunner estate
-		add_claim=d_shalandis
-		add_claim=c_windrunner
-		add_claim=c_silverfury
-		add_claim=c_ghost_forest
-		add_claim=c_rest_hollow
-		add_claim=c_underlight
+		add_pressed_claim=d_shalandis
+		add_pressed_claim=c_windrunner
+		add_pressed_claim=c_silverfury
+		add_pressed_claim=c_ghost_forest
+		add_pressed_claim=c_rest_hollow
+		add_pressed_claim=c_underlight
 		effect = {
 			set_character_flag = is_sylvanas
 			set_relation_rival = character:60003 #Arthas

--- a/history/characters/57000_amani.txt
+++ b/history/characters/57000_amani.txt
@@ -8,12 +8,12 @@
 	disallow_random_traits = yes
 	565.7.24={ birth=yes trait=creature_troll effect = { make_important_lore_character_effect = yes } }
 	565.7.24={
-		add_claim = d_sungraze_peak
-		add_claim = d_thalassian_pass
-		add_claim = d_shalandis
-		add_claim = d_tranquillien
-		add_claim = d_living_wood
-		add_claim = d_golden_strand
+		add_pressed_claim = d_sungraze_peak
+		add_pressed_claim = d_thalassian_pass
+		add_pressed_claim = d_shalandis
+		add_pressed_claim = d_tranquillien
+		add_pressed_claim = d_living_wood
+		add_pressed_claim = d_golden_strand
 	}
 	581.7.24={
 		# trait = class_rogue

--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -28,9 +28,9 @@
 				reverse_opinion = { modifier = opinion_dislike who = ROOT years = 50 }
 			}
 		}
-		add_claim = c_tarren_mill
-		add_claim = c_sorrow_hill
-		add_claim = c_darrow_hill
+		add_pressed_claim = c_tarren_mill
+		add_pressed_claim = c_sorrow_hill
+		add_pressed_claim = c_darrow_hill
 	}
 	603.1.12={ 
 		death = {
@@ -64,8 +64,8 @@
 		trait = class_rogue_4
 	}
 	590.1.1={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	617.5.11={ death=yes }
 }
@@ -84,8 +84,8 @@
 		trait = class_mage_4
 	}
 	590.1.1={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	613.6.9={ death=yes }
 }
@@ -98,8 +98,8 @@
 	father=58006	#Malatar
 	540.4.16={ birth=yes trait=creature_human }
 	555.3.17={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	562.6.19={ death=yes }
 }
@@ -112,8 +112,8 @@
 	father=58004	#Horrace
 	560.7.16={ birth=yes trait=creature_human }
 	562.6.19={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	591.1.1={
 		employer = 46001	# Genn Greymane
@@ -160,8 +160,8 @@
 	father=58008	#Hildebald
 	450.8.19={ birth=yes trait=creature_human }
 	461.4.11={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	521.11.27={ death=yes }
 }
@@ -174,8 +174,8 @@
 	father=58009	#Malavai
 	483.7.8={ birth=yes trait=creature_human }
 	521.11.27={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	551.5.6={ death=yes }
 }
@@ -188,8 +188,8 @@
 	father=58010	#Lysander
 	519.4.21={ birth=yes trait=creature_human }
 	551.5.6={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	564.12.17={ death=yes }
 }
@@ -204,8 +204,8 @@
 	father=58011	#Gedalbert
 	563.5.16={ birth=yes trait=creature_human }
 	564.12.17={
-		add_claim=k_alterac
-		add_claim=c_alterac
+		add_pressed_claim=k_alterac
+		add_pressed_claim=c_alterac
 	}
 	630.2.11={ death=yes }
 }

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -107,10 +107,10 @@
 	}
 	605.5.21={
 		# Claims Balnazzar's lands in Lordaeron
-		add_claim=k_lordaeron
-		add_claim=c_lordaeron
-		add_claim=c_balnir
-		add_claim=c_bastion
+		add_pressed_claim=k_lordaeron
+		add_pressed_claim=c_lordaeron
+		add_pressed_claim=c_balnir
+		add_pressed_claim=c_bastion
 	}
 	# Ner'zhul calls him
 	605.6.6={
@@ -147,10 +147,10 @@
 	603.5.1 = {
 		employer = 53053 # Fled to Southshore during the Fall of Capital City
 		# Claims Balnazzar's lands in Lordaeron
-		add_claim=k_lordaeron
-		add_claim=c_lordaeron
-		add_claim=c_balnir
-		add_claim=c_bastion
+		add_pressed_claim=k_lordaeron
+		add_pressed_claim=c_lordaeron
+		add_pressed_claim=c_balnir
+		add_pressed_claim=c_bastion
 	}
 	605.1.1 = {
 		trait = class_priest_5
@@ -809,10 +809,10 @@
 	605.1.1 = {
 		add_gold = 300 #Military budget
 		# Claims Balnazzar's lands in Lordaeron
-		add_claim=k_lordaeron
-		add_claim=c_lordaeron
-		add_claim=c_balnir
-		add_claim=c_bastion
+		add_pressed_claim=k_lordaeron
+		add_pressed_claim=c_lordaeron
+		add_pressed_claim=c_balnir
+		add_pressed_claim=c_bastion
 		capital = c_undernelly
 	}
 	605.10.25={


### PR DESCRIPTION
## Changelog:
- Gave Orgrim a pressed claim to the Horde title and the kingdom level title of Blackrock;
- Orgrim can now challenge the Warchief to a Mak'gora;
- Magni, Muradin and Brann are now listed as brothers. Couldn't find any information on their mother so I added a random one with a dwarven female name;
- Kurdran and Falstad are no longer brothers;
- Replaced all `add_claim` references with `add_pressed_claim`.

Fixed #509 and #405