### PR TITLE
try_to_set_race_effect Memory Leak

### DIFF
--- a/common/casus_belli_types/00_religious_war.txt
+++ b/common/casus_belli_types/00_religious_war.txt
@@ -3139,7 +3139,7 @@ undirected_great_holy_war = {
 
 				# Warcraft
 				scope:title_recipient = {
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 				}
 
 				scope:the_faith.great_holy_war = {

--- a/common/on_action/child_birth_on_actions.txt
+++ b/common/on_action/child_birth_on_actions.txt
@@ -43,6 +43,9 @@ on_birth_real_father = {
 # scope:is_bastard, true if a known bastard
 on_birth_child = {
 	events = {
+		# Sets race trait (gene)
+		WCRAC.20
+		
 		# Warcraft
 		# middle_east_decisions.0012 #Saoshyant Descendants.
 
@@ -56,9 +59,6 @@ on_birth_child = {
 		debug.0010 # Disease data tracking
 	}
 	effect = {
-		# Warcraft
-		try_to_set_race_effect = { FLAG = gene }
-		
 		# Make sure that children aren't Lowborn if one of their parents are, in fact, of noble stock
 		if = {
 			limit = {

--- a/common/on_action/court_maintenance_on_actions.txt
+++ b/common/on_action/court_maintenance_on_actions.txt
@@ -5,7 +5,7 @@
 # scope:old_employer is their old employer (if they had one; otherwise unset)
 on_join_court = {
 	events = {
-		# Race trait adding
+		# Sets race trait (no gene)
 		# I hate Paradox, delay is needed due to lags on 1.4.2
 		delay = { days = 1 }
 		WCRAC.10

--- a/common/on_action/courtier_guest_management_on_actions.txt
+++ b/common/on_action/courtier_guest_management_on_actions.txt
@@ -9,7 +9,7 @@ on_courtier_decided_to_move_to_pool = {
 	effect = {
 		# Warcraft
 		# Caused lags on 1.4.2
-		# try_to_set_race_effect = { FLAG = no_gene }
+		# trigger_race_giving_no_gene_effect = yes
 	}
 }
 
@@ -37,7 +37,7 @@ on_guest_arrived_from_pool = {
 	effect = {
 		# Warcraft
 		# Caused lags on 1.4.2
-		# try_to_set_race_effect = { FLAG = no_gene }
+		# trigger_race_giving_no_gene_effect = yes
 	}
 }
 

--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -114,21 +114,7 @@ on_game_start_after_lobby = {
 	effect = {
 		# Warcraft
 		every_living_character = {
-			if = {
-				limit = {
-					NOT = { has_character_flag = race_giving_fired_flag }
-				
-					has_race_trait_trigger = no
-				}
-				#Tries to set race flag based on trait you have
-				copy_race_effect = { CHARACTER = this }
-				try_to_set_race_effect = { FLAG = gene }
-			}
-			# Old characters become impotent
-			if = {
-				limit = { can_be_impotent_trigger = yes }
-				add_trait = impotent
-			}
+			trigger_on_game_start_effect = yes
 		}
 		
 		### GAME RULE: VIEW ON SAME-SEX RELATIONS

--- a/common/on_action/title_on_actions.txt
+++ b/common/on_action/title_on_actions.txt
@@ -249,9 +249,12 @@ on_explicit_claim_lost = {
 # root = character ranking up
 # scope:title = old primary title
 on_rank_up = { # Will not fire during history execution or for dying characters
+	events = {
+		# Sets race trait (no gene)
+		WCRAC.10
+	}
 	effect = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }
 		
 		add_achievement_flag_effect = { FLAG = achievement_moving_up_in_the_world_flag }
 		update_embassies_effect = yes

--- a/common/scripted_character_templates/00_foundling_templates.txt
+++ b/common/scripted_character_templates/00_foundling_templates.txt
@@ -10,6 +10,6 @@ peasant_villager_foundling_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_holy_order_character_templates.txt
+++ b/common/scripted_character_templates/00_holy_order_character_templates.txt
@@ -117,7 +117,7 @@
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -317,6 +317,6 @@ religious_leader_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_lifestyle_friend_templates.txt
+++ b/common/scripted_character_templates/00_lifestyle_friend_templates.txt
@@ -16,7 +16,7 @@ diplomacy_foreign_affairs_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -37,7 +37,7 @@ diplomacy_majesty_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -58,7 +58,7 @@ diplomacy_family_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -80,7 +80,7 @@ martial_strategy_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -100,7 +100,7 @@ martial_authority_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -121,7 +121,7 @@ martial_chivalry_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -143,7 +143,7 @@ stewardship_wealth_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -164,7 +164,7 @@ stewardship_domain_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -184,7 +184,7 @@ stewardship_duty_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -207,7 +207,7 @@ intrigue_skulduggery_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -227,7 +227,7 @@ intrigue_temptation_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -247,7 +247,7 @@ intrigue_intimidation_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -269,7 +269,7 @@ learning_medicine_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -289,7 +289,7 @@ learning_scholarship_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -309,7 +309,7 @@ learning_theology_focus_friend_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 

--- a/common/scripted_character_templates/00_mystic_templates.txt
+++ b/common/scripted_character_templates/00_mystic_templates.txt
@@ -21,6 +21,6 @@
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_officials_templates.txt
+++ b/common/scripted_character_templates/00_officials_templates.txt
@@ -13,6 +13,6 @@ tax_collector_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_peasant_faction_leader_template.txt
+++ b/common/scripted_character_templates/00_peasant_faction_leader_template.txt
@@ -63,6 +63,6 @@ peasant_faction_leader_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_peasant_leader_templates.txt
+++ b/common/scripted_character_templates/00_peasant_leader_templates.txt
@@ -24,7 +24,7 @@
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -55,6 +55,6 @@ peasant_leader_martial_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_peasants_template.txt
+++ b/common/scripted_character_templates/00_peasants_template.txt
@@ -17,7 +17,7 @@
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -36,7 +36,7 @@ servant_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -139,7 +139,7 @@ witchy_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -170,7 +170,7 @@ merchant_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -217,7 +217,7 @@ hunter_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -251,6 +251,6 @@ detective_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_pool_repopulation_character_templates.txt
+++ b/common/scripted_character_templates/00_pool_repopulation_character_templates.txt
@@ -64,7 +64,7 @@ pool_repopulate_prowess = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -118,7 +118,7 @@ pool_repopulate_diplomacy = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -164,7 +164,7 @@ pool_repopulate_martial = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -222,7 +222,7 @@ pool_repopulate_stewardship = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -275,7 +275,7 @@ pool_repopulate_intrigue = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -333,7 +333,7 @@ pool_repopulate_learning = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		if = {
 			limit = {
@@ -471,7 +471,7 @@ pool_repopulate_spouse = {
 	dynasty = none
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 
 		if = {
 			limit = {
@@ -539,7 +539,7 @@ pool_repopulate_local_flavor = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 
 		if = {
 			limit = {

--- a/common/scripted_character_templates/00_priest_character_template.txt
+++ b/common/scripted_character_templates/00_priest_character_template.txt
@@ -18,7 +18,7 @@
 	}
 
 	after_creation = {
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		add_character_flag = {
 			flag = need_priest_outfit

--- a/common/scripted_character_templates/00_saharan_nomad_template.txt
+++ b/common/scripted_character_templates/00_saharan_nomad_template.txt
@@ -63,6 +63,6 @@ saharan_clan_leader_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_scholar_template.txt
+++ b/common/scripted_character_templates/00_scholar_template.txt
@@ -19,7 +19,7 @@ scholar_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -55,6 +55,6 @@ writer_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/00_soldier_character_templates.txt
+++ b/common/scripted_character_templates/00_soldier_character_templates.txt
@@ -49,7 +49,7 @@ soldier_friend_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -97,7 +97,7 @@ new_commander_character = {
 
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		#Chance of receiving an extra commander trait
 		random = {
@@ -197,7 +197,7 @@ new_warrior_character = {
 
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		#Chance of receiving an extra commander trait
 		random = {
@@ -255,7 +255,7 @@ new_siege_engineer = {
 
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		#Chance of receiving an extra commander trait
 		random = {
@@ -328,6 +328,6 @@ new_berserker_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/01_fp1_character_templates.txt
+++ b/common/scripted_character_templates/01_fp1_character_templates.txt
@@ -58,7 +58,7 @@ fp1_ms_godi_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -113,7 +113,7 @@ fp1_ms_reformed_missionary_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -161,7 +161,7 @@ fp1_ms_nithing_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -202,7 +202,7 @@ fp1_ms_warrior_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -269,7 +269,7 @@ fp1_ms_vagrant_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -337,7 +337,7 @@ fp1_western_warrior_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -402,7 +402,7 @@ fp1_eastern_warrior_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -465,7 +465,7 @@ fp1_deceitful_warrior_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -519,7 +519,7 @@ fp1_deceitful_explorer_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -573,7 +573,7 @@ fp1_truthful_explorer_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -640,7 +640,7 @@ fp1_capital_county_nithing_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -675,7 +675,7 @@ fp1_capital_county_orphan_character = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -731,7 +731,7 @@ fp1_trade_partner_merchant = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -894,7 +894,7 @@ fp1_trade_partner_priest = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -951,7 +951,7 @@ fp1_trade_partner_spy = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -1010,7 +1010,7 @@ fp1_trade_partner_warrior = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }
 
@@ -1048,6 +1048,6 @@ old_country_local_warlord_template = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 	}
 }

--- a/common/scripted_character_templates/wc_draenor_templates.txt
+++ b/common/scripted_character_templates/wc_draenor_templates.txt
@@ -32,7 +32,7 @@
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		random_list = {
 			90 = { set_character_faith = faith:naaru }
@@ -75,7 +75,7 @@ draenor_arakkoa_refugee = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		random_list = {
 			50 = { set_character_faith = faith:anzuism }
@@ -119,7 +119,7 @@ draenor_ogre_refugee = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		random_list = {
 			90 = { set_character_faith = faith:gorgog_worship }
@@ -206,7 +206,7 @@ draenor_orc_refugee = {
 	
 	after_creation = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		random_list = {
 			75 = { set_character_faith = faith:orcish_shamanism }

--- a/common/scripted_effects/00_councillor_effects.txt
+++ b/common/scripted_effects/00_councillor_effects.txt
@@ -28,7 +28,7 @@ got_council_position_effect = {
 	}
 	
 	# Warcraft
-	try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+	trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 }
 
 fired_from_council_position_effect = {

--- a/common/scripted_effects/00_faction_effects.txt
+++ b/common/scripted_effects/00_faction_effects.txt
@@ -307,7 +307,7 @@ split_noncontiguous_counties_from_revolt_effect = {
 			
 			# Warcraft
 			scope:new_county_holder = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 				
 			create_title_and_vassal_change = {

--- a/common/scripted_effects/00_game_rule_effects.txt
+++ b/common/scripted_effects/00_game_rule_effects.txt
@@ -29,7 +29,7 @@ game_rule_create_spouse_and_children = {
 			# Warcraft
 			scope:spouse = {
 				# Warcraft
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 
 			if = {
@@ -100,7 +100,7 @@ game_rule_create_spouse_and_children = {
 			# Warcraft
 			scope:child_1 = {
 				# Warcraft
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 
@@ -134,7 +134,7 @@ game_rule_create_spouse_and_children = {
 			# Warcraft
 			scope:child_2 = {
 				# Warcraft
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 
@@ -168,7 +168,7 @@ game_rule_create_spouse_and_children = {
 			# Warcraft
 			scope:child_3 = {
 				# Warcraft
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 	}
@@ -1083,7 +1083,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}
@@ -1406,7 +1406,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}
@@ -1700,7 +1700,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}
@@ -2018,7 +2018,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}
@@ -2328,7 +2328,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}
@@ -2616,7 +2616,7 @@ game_rule_exclave_independence_effect = {
 				}
 				scope:backup_character = {
 					# Warcraft
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					
 					add_to_list = potential_holders
 				}

--- a/common/scripted_effects/00_stewardship_lifestyle_effects.txt
+++ b/common/scripted_effects/00_stewardship_lifestyle_effects.txt
@@ -284,7 +284,7 @@ stewardship_duty_1062_create_philosopher_effect = {
 	}
 	scope:$CLIENT_SCOPE$ = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		add_character_flag = governance_1062_philosopher_flag
 		add_character_flag = {
@@ -313,7 +313,7 @@ stewardship_duty_1062_create_gardener_effect = {
 	}
 	scope:$CLIENT_SCOPE$ = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		add_character_flag = governance_1062_gardener_flag
 		add_character_flag = {
@@ -341,7 +341,7 @@ stewardship_duty_1062_create_poet_effect = {
 	}
 	scope:$CLIENT_SCOPE$ = {
 		# Warcraft
-		try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+		trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		
 		add_character_flag = governance_1062_poet_flag
 		add_character_flag = {

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -1,4 +1,14 @@
-﻿try_to_set_race_effect = {
+﻿trigger_race_giving_gene_effect = {
+	trigger_event = WCRAC.20
+}
+trigger_race_giving_no_gene_effect = {
+	trigger_event = WCRAC.10
+}
+trigger_on_game_start_effect = {
+	trigger_event = WCRAC.30
+}
+
+try_to_set_race_effect = {
 	if = {
 		limit = {
 			NOT = { has_character_flag = race_giving_fired_flag }

--- a/events/activities/hunt_activity/hunt_events.txt
+++ b/events/activities/hunt_activity/hunt_events.txt
@@ -3495,7 +3495,7 @@ hunt.4008 = {
 		
 		# Warcraft
 		scope:peasant = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 		
 		unknown_murder_effect = {
@@ -6333,7 +6333,7 @@ hunt.7001 = {
 		
 		# Warcraft
 		scope:peasant = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 	}
 

--- a/events/activities/pilgrimage_activity/pilgrimage_events.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events.txt
@@ -1787,7 +1787,7 @@ pilgrimage.2501 = {
 		
 		# Warcraft
 		scope:beggar = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 
 		scope:activity = {
@@ -2512,7 +2512,7 @@ pilgrimage.3001 = {
 		
 		# Warcraft
 		scope:zealous_priest = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 		
 		scope:activity = {
@@ -2611,7 +2611,7 @@ pilgrimage.3003 = {
 		
 		# Warcraft
 		scope:doomsayer = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 		
 		scope:activity = {
@@ -3058,7 +3058,7 @@ pilgrimage.3301 = {
 		
 		# Warcraft
 		scope:wanderer = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 		
 		scope:activity = {

--- a/events/dlc/fp1/fp1_other_decision_events.txt
+++ b/events/dlc/fp1/fp1_other_decision_events.txt
@@ -3100,7 +3100,7 @@ scripted_effect fp1_apply_stele_effects = {
 		# Kill them off.
 		scope:carver = {
 			# Warcraft
-			try_to_set_race_effect = { FLAG = no_gene }
+			trigger_race_giving_no_gene_effect = yes
 			
 			death = { death_reason = death_vanished }
 		}

--- a/events/government_events/clan_events.txt
+++ b/events/government_events/clan_events.txt
@@ -931,7 +931,7 @@ clan.1201 = {
 		
 		# Warcraft
 		scope:petitioner = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 	}
 

--- a/events/health_events.txt
+++ b/events/health_events.txt
@@ -4968,7 +4968,7 @@ health.3001 = {
 							}
 							scope:excellent_skill_option = {
 								# Warcraft
-								try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+								trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 								
 								add_trait = physician_2
 							}
@@ -5019,7 +5019,7 @@ health.3001 = {
 					
 					# Warcraft
 					scope:high_skill_option = {
-						try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+						trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 					}
 				}
 
@@ -5168,7 +5168,7 @@ health.3001 = {
 				
 				# Warcraft
 				scope:low_skill_option = {
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 				}
 			}
 		}

--- a/events/lifestyles/governance_lifestyle/stewardship_general_events.txt
+++ b/events/lifestyles/governance_lifestyle/stewardship_general_events.txt
@@ -145,7 +145,7 @@ stewardship_general.1054 = {
 				
 				# Warcraft
 				scope:witch = {
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 				}
 			}
 		}

--- a/events/lifestyles/governance_lifestyle/stewardship_wealth_events.txt
+++ b/events/lifestyles/governance_lifestyle/stewardship_wealth_events.txt
@@ -864,7 +864,7 @@ stewardship_wealth.1051 = {
 			
 			# Warcraft
 			scope:freeman = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 	}

--- a/events/lifestyles/intrigue_lifestyle/intrigue_scheming_events.txt
+++ b/events/lifestyles/intrigue_lifestyle/intrigue_scheming_events.txt
@@ -273,7 +273,7 @@ intrigue_scheming.1012 = {
 		
 		# Warcraft
 		scope:cryptographer = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 	}
 
@@ -713,7 +713,7 @@ intrigue_scheming.1202 = {
 		}
 		scope:hired_spy = {
 			# Warcraft
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			
 			add_character_flag = {
 				flag = use_stealth_clothes
@@ -1448,7 +1448,7 @@ intrigue_scheming.2101 = {
 		}
 		scope:sneaky_person = {
 			# Warcraft
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			
 			add_character_flag = {
 				flag = use_stealth_clothes

--- a/events/lifestyles/scholarship_lifestyle/learning_medicine_events.txt
+++ b/events/lifestyles/scholarship_lifestyle/learning_medicine_events.txt
@@ -1266,7 +1266,7 @@ learning_medicine.2023 = { #by Mathilda Bjarnehed
 								
 								# Warcraft
 								scope:foreign_father = {
-									try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+									trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 								}
 							}
 							scope:spouse = {
@@ -3742,7 +3742,7 @@ learning_medicine_special.2100 = {
 		
 		# Warcraft
 		scope:fish_alchemist = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 	}
 

--- a/events/lifestyles/warfare_lifestyle/martial_authority_events.txt
+++ b/events/lifestyles/warfare_lifestyle/martial_authority_events.txt
@@ -1675,7 +1675,7 @@ martial_authority_special.1501 = {
 			
 			# Warcraft
 			scope:deserting_soldier = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 	}

--- a/events/lifestyles/warfare_lifestyle/martial_chivalry_events.txt
+++ b/events/lifestyles/warfare_lifestyle/martial_chivalry_events.txt
@@ -90,7 +90,7 @@ martial_chivalry.0001 = {
 			
 			# Warcraft
 			scope:duel_opponent = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 	}

--- a/events/lifestyles/warfare_lifestyle/martial_strategy_events.txt
+++ b/events/lifestyles/warfare_lifestyle/martial_strategy_events.txt
@@ -3486,7 +3486,7 @@ martial_strategy_special.1405 = {
 		
 		# Warcraft
 		scope:zealot = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 	}
 

--- a/events/religion_events/faith_creation_events.txt
+++ b/events/religion_events/faith_creation_events.txt
@@ -103,7 +103,7 @@ faith_creation.0002 = {
 			
 			# Warcraft
 			scope:new_religious_head = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 		
@@ -250,7 +250,7 @@ faith_creation.0012 = {
 			
 			# Warcraft
 			scope:new_religious_head = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 		}
 

--- a/events/story_cycles/peasant_affair/story_cycle_peasant_affair_events.txt
+++ b/events/story_cycles/peasant_affair/story_cycle_peasant_affair_events.txt
@@ -40,7 +40,7 @@ peasant_affair.0001 = {
 
 				# Warcraft
 				scope:peasant_child = {
-					try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+					trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 				}
 
 				set_variable = {

--- a/events/stress_events/stress_threshold_prison_events.txt
+++ b/events/stress_events/stress_threshold_prison_events.txt
@@ -1141,7 +1141,7 @@ stress_threshold_prison.3001 = {
 		
 		# Warcraft
 		scope:fictional_friend = {
-			try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+			trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 		}
 		
 		stress_threshold_event_post_immediate = yes

--- a/events/stress_events/stress_threshold_special_events.txt
+++ b/events/stress_events/stress_threshold_special_events.txt
@@ -735,7 +735,7 @@ stress_threshold_special.2001 = {
 
 			# Warcraft
 			scope:target = {
-				try_to_set_race_effect = { FLAG = no_gene }			#Assigns race trait
+				trigger_race_giving_no_gene_effect = yes			#Assigns race trait
 			}
 
 			set_local_variable = {

--- a/events/wc_events/wc_race_events.txt
+++ b/events/wc_events/wc_race_events.txt
@@ -1,10 +1,53 @@
 ﻿namespace = WCRAC
 
+# Sets race not looking at genes
 WCRAC.10 = {
 	type = character_event
 	hidden = yes
 	
+	trigger = {
+		NOT = { has_character_flag = race_giving_fired_flag }
+	}
+	
 	immediate = {
 		try_to_set_race_effect = { FLAG = no_gene }
+	}
+}
+
+# Sets race looking at genes
+WCRAC.20 = {
+	type = character_event
+	hidden = yes
+	
+	trigger = {
+		NOT = { has_character_flag = race_giving_fired_flag }
+	}
+	
+	immediate = {
+		try_to_set_race_effect = { FLAG = gene }
+	}
+}
+
+# Sets race on game start
+WCRAC.30 = {
+	type = character_event
+	hidden = yes
+	
+	immediate = {
+		if = {
+			limit = {
+				NOT = { has_character_flag = race_giving_fired_flag }
+			
+				has_race_trait_trigger = no
+			}
+			#Tries to set race flag based on trait you have
+			copy_race_effect = { CHARACTER = this }
+			try_to_set_race_effect = { FLAG = gene }
+		}
+		# Old characters become impotent
+		if = {
+			limit = { can_be_impotent_trigger = yes }
+			add_trait = impotent
+		}
 	}
 }


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- `try_to_set_race_effect` took too much space in RAM, 2 GB. Putting it in an event fixed a problem.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Run the CK3, open the [Task Manager](https://en.wikipedia.org/wiki/Task_Manager_(Windows)) to check the RAM. Upon the main menu loading, CK3 should use about 3GB of RAM.

<details>
<summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/46384992/125331251-cbc14400-e358-11eb-93ff-c8e02604807a.png)

</details>