### PR TITLE
Blood Troll Flavorization

### DIFF
--- a/common/flavorization/wc_title_holders.txt
+++ b/common/flavorization/wc_title_holders.txt
@@ -4,7 +4,7 @@
 @county_cultural_prio = 18
 @barony_cultural_prio = 7
 
-blood_troll_patriarch_male = {
+blood_troll_male = {
 	type = character
 	gender = male
 	special = holder
@@ -14,10 +14,44 @@ blood_troll_patriarch_male = {
 	religions = { ghuun_worship }
 }
 
-blood_troll_matriarch_female = {
+blood_troll_count_female = {
 	type = character
 	gender = female
 	special = holder
+	tier = county
+	priority = 400
+	top_liege = no
+	cultures = { blood_troll }
+	religions = { ghuun_worship }
+}
+
+blood_troll_duke_female = {
+	type = character
+	gender = female
+	special = holder
+	tier = duchy
+	priority = 400
+	top_liege = no
+	cultures = { blood_troll }
+	religions = { ghuun_worship }
+}
+
+blood_troll_queen_female = {
+	type = character
+	gender = female
+	special = holder
+	tier = kingdom
+	priority = 400
+	top_liege = no
+	cultures = { blood_troll }
+	religions = { ghuun_worship }
+}
+
+blood_troll_empress_female = {
+	type = character
+	gender = female
+	special = holder
+	tier = empire
 	priority = 400
 	top_liege = no
 	cultures = { blood_troll }

--- a/common/flavorization/wc_title_holders.txt
+++ b/common/flavorization/wc_title_holders.txt
@@ -4,6 +4,26 @@
 @county_cultural_prio = 18
 @barony_cultural_prio = 7
 
+blood_troll_patriarch_male = {
+	type = character
+	gender = male
+	special = holder
+	priority = 400
+	top_liege = no
+	cultures = { blood_troll }
+	religions = { ghuun_worship }
+}
+
+blood_troll_matriarch_female = {
+	type = character
+	gender = female
+	special = holder
+	priority = 400
+	top_liege = no
+	cultures = { blood_troll }
+	religions = { ghuun_worship }
+}
+
 high_priest_kaldorei_male = {
 	type = character
 	gender = male

--- a/localization/english/culture/wc_culture_titles_l_english.yml
+++ b/localization/english/culture/wc_culture_titles_l_english.yml
@@ -28,5 +28,8 @@
  lord_nightborne_male:0 "Lord"
  lady_nightborne_female:0 "Lady"
 
- blood_troll_patriarch_male:0 "#"
- blood_troll_matriarch_female:0 "Grand Ma'da"
+ blood_troll_male:0 "#"
+ blood_troll_count_female:0 "Warmother"
+ blood_troll_duke_female:0 "Grand Ma'da"
+ blood_troll_queen_female:0 "Queen Ma'da"
+ blood_troll_empress_female:0 "Divine Ma'da"

--- a/localization/english/culture/wc_culture_titles_l_english.yml
+++ b/localization/english/culture/wc_culture_titles_l_english.yml
@@ -26,4 +26,7 @@
  principality_nightborne:0 "Principality"
 
  lord_nightborne_male:0 "Lord"
- lady_nightborne_female:0 "Lady" 
+ lady_nightborne_female:0 "Lady"
+
+ blood_troll_patriarch_male:0 "#"
+ blood_troll_matriarch_female:0 "Grand Ma'da"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Gave female blood trolls title flavorization for every realm tier:
  - **County**: Warmother _(suggested by @Remerod)_
  - **Duchy**: Grand Ma'da
  - **Kingdom**: Queen Ma'da _(suggested by @Remerod)_
  - **Empire**: Divine Ma'da _(suggested by @Remerod)_
- Flavorization is only active if the character has the **_G'huuni_** faith and **_Nazmani_** culture.
- Disabled titles from male blood trolls completely (this applies to every tier).

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Give feedback on the chosen title flavorization. Should any of them be changed?