### PR TITLE
Baldness Crash

### DIFF
--- a/gfx/models/portraits/female_head/female_head.asset
+++ b/gfx/models/portraits/female_head/female_head.asset
@@ -526,6 +526,9 @@ entity = {
 	#### Blend shapes used on other body parts than the face, therefore using the neutral face blend
 	attribute = { name = "teeth_bs_lower_down"		blend_shape = "female_bs_neutral" }
 	attribute = { name = "teeth_bs_lower_up"		blend_shape = "female_bs_neutral" }
+	
+	# Warcraft
+	attribute = { name = "bs_baldness" 					blend_shape = "male_bs_neutral" }
 
 	### Animations
 	default_state = "none"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed the Portrait Editor crashing due to the females lacking the baldness attribute.

# How to test:
Confirm it doesn't crash.
