### PR TITLE
Infusion Modifiers

### DIFF
--- a/common/traits/wc_infusion_traits.txt
+++ b/common/traits/wc_infusion_traits.txt
@@ -11,7 +11,7 @@
 			desc = trait_being_undead_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_undead_illegal
@@ -23,6 +23,10 @@
 		opinion_modifier = being_undead_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	diplomacy = -1
+	prowess = 2
+	dread_baseline_add = 15
 	
 	life_expectancy = 25000	# Instead of immortality because immortality locks you from aging
 	
@@ -42,7 +46,7 @@ being_demon = {
 			desc = trait_being_demon_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_demon_illegal
@@ -54,6 +58,11 @@ being_demon = {
 		opinion_modifier = being_demon_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	diplomacy = -2
+	intrigue = 1
+	prowess = 4
+	dread_baseline_add = 8
 	
 	life_expectancy = 25000 # Instead of immortality because immortality locks you from aging
 	
@@ -73,7 +82,7 @@ being_void = {
 			desc = trait_being_void_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_void_illegal
@@ -85,6 +94,11 @@ being_void = {
 		opinion_modifier = being_void_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	diplomacy = -1
+	intrigue = 1
+	prowess = 2
+	dread_baseline_add = 12
 	
 	life_expectancy = 130 # Mantid don't live that long
 }
@@ -102,7 +116,7 @@ being_life = {
 			desc = trait_being_life_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_life_illegal
@@ -114,6 +128,12 @@ being_life = {
 		opinion_modifier = being_life_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	diplomacy = 1
+	intrigue = -2
+	prowess = 2
+	fertility = 0.05
+	stress_gain_mult = -0.15
 	
 	life_expectancy = 25000 # Instead of immortality because immortality locks you from aging
 }
@@ -131,7 +151,7 @@ being_order = {
 			desc = trait_being_order_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_order_illegal
@@ -143,6 +163,11 @@ being_order = {
 		opinion_modifier = being_order_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	intrigue = -1
+	learning = 2
+	prowess = 1
+	monthly_county_control_change_factor = 0.15
 	
 	life_expectancy = 25000 # Instead of immortality because immortality locks you from aging
 }
@@ -160,7 +185,7 @@ being_light = {
 			desc = trait_being_light_desc
 		}
 	}
-	shown_in_ruler_designer = yes
+	shown_in_ruler_designer = no
 	
 	triggered_opinion = {
 		parameter = being_light_illegal
@@ -172,6 +197,11 @@ being_light = {
 		opinion_modifier = being_light_intolerant
 		ignore_opinion_value_if_same_trait = yes
 	}
+	
+	diplomacy = 2
+	intrigue = -3
+	learning = 2
+	prowess = 4
 	
 	life_expectancy = 130 # The same as being_void
 }

--- a/common/traits/wc_infusion_traits.txt
+++ b/common/traits/wc_infusion_traits.txt
@@ -25,8 +25,9 @@
 	}
 	
 	diplomacy = -1
-	prowess = 2
-	dread_baseline_add = 15
+	prowess = 1
+	dread_baseline_add = 10
+	scheme_discovery_chance_mult = 0.05
 	
 	life_expectancy = 25000	# Instead of immortality because immortality locks you from aging
 	
@@ -59,10 +60,10 @@ being_demon = {
 		ignore_opinion_value_if_same_trait = yes
 	}
 	
-	diplomacy = -2
+	diplomacy = -1
 	intrigue = 1
-	prowess = 4
-	dread_baseline_add = 8
+	prowess = 2
+	dread_baseline_add = 12
 	
 	life_expectancy = 25000 # Instead of immortality because immortality locks you from aging
 	

--- a/common/traits/wc_infusion_traits.txt
+++ b/common/traits/wc_infusion_traits.txt
@@ -200,9 +200,9 @@ being_light = {
 	}
 	
 	diplomacy = 2
-	intrigue = -3
+	intrigue = -1
 	learning = 2
-	prowess = 4
+	prowess = 2
 	
 	life_expectancy = 130 # The same as being_void
 }


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Assigned modifiers to Infusion traits: Undead, Demon, Void Being, Nature Being, Order Being, Light Being.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Open the game, open the Encyclopedia (`F9` hotkey), open `Traits` tab, search for the mentioned traits and their effects.

Tell if you want to rebalance it or give new effects.