### PR TITLE
Golmash Hellscream + Dragon Lifespans

### DIFF
--- a/common/nicknames/wc_nicknames.txt
+++ b/common/nicknames/wc_nicknames.txt
@@ -43,6 +43,7 @@ nick_the_slitherer = {}
 nick_the_whacked = {}
 nick_the_darkener = {}
 nick_the_virulent = {}
+nick_the_giantslayer = {}
 
 ### From Lifestyle
 nick_the_ice_hearted = {}

--- a/common/traits/wc_race_traits.txt
+++ b/common/traits/wc_race_traits.txt
@@ -229,6 +229,8 @@ creature_red_dragon = {
 	}
 	shown_in_ruler_designer = no
 
+	life_expectancy = 10000
+
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance
 }
@@ -248,6 +250,8 @@ creature_blue_dragon = {
 		}
 	}
 	shown_in_ruler_designer = no
+
+	life_expectancy = 10000
 
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance
@@ -269,6 +273,8 @@ creature_green_dragon = {
 	}
 	shown_in_ruler_designer = no
 
+	life_expectancy = 10000
+
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance
 }
@@ -288,6 +294,8 @@ creature_black_dragon = {
 		}
 	}
 	shown_in_ruler_designer = no
+
+	life_expectancy = 10000
 
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance
@@ -921,6 +929,8 @@ creature_bronze_dragon = {
 	}
 	shown_in_ruler_designer = no
 
+	life_expectancy = 10000
+
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance
 }
@@ -1171,6 +1181,8 @@ creature_infinite_dragon = {
 		}
 	}
 	shown_in_ruler_designer = no
+
+	life_expectancy = 10000
 
 	inherit_chance = @race_inherit_chance
 	both_parent_has_trait_inherit_chance = @both_parent_race_inherit_chance

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -687,6 +687,7 @@
 	# trait=class_warrior_8
 	trait=wrathful trait=brave trait=impatient 
 	disallow_random_traits = yes
+	father = golmash
 	545.2.21={ birth=yes trait=creature_orc effect = { make_important_lore_character_effect = yes } }
 	545.2.21 = {
 		effect = {
@@ -713,6 +714,28 @@ garrosh = { # Used for DNA copying
 	20.1.1 = {
 		death = yes
 	}
+}
+golmash = {
+	name = Golmash
+	dynasty_house = house_hellscream
+	culture = warsong
+	religion = orcish_shamanism
+	martial=10 diplomacy=6 stewardship=5 intrigue=5 learning=5
+	trait = education_martial_4
+	trait = stubborn
+	trait = brave
+	trait = arrogant 
+	disallow_random_traits = yes
+	505.1.1={ 
+		birth=yes
+		trait=creature_orc
+	}
+	523.1.1={
+		give_nickname = nick_the_giantslayer
+	}	
+	571.1.1={
+		death = { death_reason = death_battle }
+	}	
 }
 
 # dynasty=2400

--- a/localization/english/wc_nicknames_l_english.yml
+++ b/localization/english/wc_nicknames_l_english.yml
@@ -23,6 +23,7 @@
  nick_the_hungering:0 "the Hungering"
  nick_the_godslayer:0 "the Godslayer"
  nick_the_divine:0 "the Divine"
+ nick_the_giantslayer:0 "the Giantslayer"
 
  ### Titans names
  #nick_the_highfather:0 "the Highfather"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added **[Golmash Hellscream](https://wowpedia.fandom.com/wiki/Golmash_Hellscream)** (ID: `golmash`) as a character.
- Added _'the Giantslayer'_ nickname for Golmash.
- Increased lifespan for dragon races to 10,000 years.

<details><summary>Click to expand</summary>

**Custom DNA for Golmash will be made on another branch.**
![image](https://user-images.githubusercontent.com/78575425/130539621-dd0af937-fc1f-484c-8cdd-825f0f85b6e5.png)
![image](https://user-images.githubusercontent.com/78575425/130539678-283d038c-75d9-4dd3-871c-45f0ffc58466.png)

</details>

### Golmash Personality Traits
**1. Stubborn**
> His death came in battle, crushed to death in the jaws of a hulking gronn. But **Golmash still found the strength** to stab with his axe, Gorehowl, into the gronn's eye, bringing it down with him.

Inches away from death, he was still stubborn enough to claim his victory over the gronn.

**2. Arrogant**
> "**You dare approach the Giantslayer?** I will cleave your head from your body!"
— Golmash Hellscream

Refers to himself in the third person and mocks his opponent for "daring" to challenge him, indicating some level of vanity.

**3. Brave**

Golmash earned his nickname, _the Giantslayer_, for his tendency to challenge gronns to battle. It takes some bravery to willingly fight against creatures three to four times one's own size.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:

- Provide feedback on the additions and make sure there are no errors.