### PR TITLE
Jandice Trait Update

### DIFF
--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -332,13 +332,12 @@
 	culture=lordaeronian religion=holy_light
 	martial=4 diplomacy=4 stewardship=4 intrigue=8 learning=8
 	trait=education_learning_4 trait=lustful trait=deceitful trait=sadistic trait=arrogant
-	trait=magic_good_3
 	disallow_random_traits = yes
 	father=60009	#Alexei
 	mother=60010	#Illucia
 	570.4.14={ birth=yes trait=creature_human }
 	586.4.14={
-		trait = class_mage_5
+		trait = class_mage_8
 	}
 	601.1.1={
 		effect = {
@@ -348,7 +347,7 @@
 		trait = shrewd
 	}
 	603.6.1={
-		remove_trait = class_mage_5
+		remove_trait = class_mage_8
 		trait = class_necromancer_5
 		trait = being_undead
 		religion = death_god

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -337,18 +337,18 @@
 	mother=60010	#Illucia
 	570.4.14={ birth=yes trait=creature_human }
 	586.4.14={
-		trait = class_mage_8
+		# trait = class_mage_8
 	}
 	601.1.1={
-		effect = {
-			join_society_cult_of_the_damned_effect = yes
-			society_rank_up = 1
-		}
+		# effect = {
+			# join_society_cult_of_the_damned_effect = yes
+			# society_rank_up = 1
+		# }
 		trait = shrewd
 	}
 	603.6.1={
-		remove_trait = class_mage_8
-		trait = class_necromancer_5
+		# remove_trait = class_mage_8
+		# trait = class_necromancer_5
 		trait = being_undead
 		religion = death_god
 		# effect={ set_graphical_culture = human_undead }

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -331,7 +331,8 @@
 	dynasty=30002
 	culture=lordaeronian religion=holy_light
 	martial=4 diplomacy=4 stewardship=4 intrigue=8 learning=8
-	trait=education_learning_4 trait=chaste trait=patient trait=sadistic
+	trait=education_learning_4 trait=lustful trait=deceitful trait=sadistic trait=arrogant
+	trait=magic_good_3
 	disallow_random_traits = yes
 	father=60009	#Alexei
 	mother=60010	#Illucia
@@ -344,6 +345,7 @@
 			join_society_cult_of_the_damned_effect = yes
 			society_rank_up = 1
 		}
+		trait = shrewd
 	}
 	603.6.1={
 		remove_trait = class_mage_5


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Changed the personality traits of **Jandice Barov** (ID: `60011`) to **_Lustful_**, **_Deceitful_**, **_Sadistic_**, and **_Arrogant_**.
  - Old traits were **_Chaste_**, **_Patient_**, and **_Sadistic_**.
- Gave her **_Shrewd_** and ~~**_Otherworldly_** (`magic_good_3`)~~ as well.
  - As per @MemeWizard's suggestion, removed the proposal of `magic_good_3` and changed her `class_mage_5` to `class_mage_8` instead.

### Reasoning

**Lustful**
Pretty much everything about the way Jandice dresses, speaks, and behaves just screams Lustful to me.
- I don't understand why she had Chaste instead of Lustful. If there is a reason for this and we should keep it instead of adding Lustful, please help me understand it because I genuinely think that's the wrong trait for her.

**Deceitful**
Jandice was a master illusionist. Illusions are deceptive by their nature, therefore Deceitful suits her very well.

**Arrogant**
She mocks her opponent for challenging her and refers to herself in the third person while using her full title. Pretty arrogant if you ask me.
> **Jandice Barov yells**: Ooh, it takes some real stones to challenge the Mistress of Illusion. Well? Show me what you've got!

**Shrewd & Otherworldly**
Jandice was an archmage and a powerful illusionist, and she is described as having a vast knowledge of illusions, being a valued educator, and having developed a spell that was "almost infallible". I think these make a very good case for both Shrewd and Otherworldly.
> Her **vast knowledge of illusions** has made her both **a valued educator and a dangerous opponent** to anyone foolish enough to draw her ire.
>
> Jandice Barov **was once an archmage of Dalaran and a powerful illusionist**. In life, she developed a spell that "displayed several images of her body that were nearly indistinguishable from her real form. These images duplicated her actions from different locations, making it nearly impossible for her enemies to find her. **It was almost infallible**."

## Implemented Suggestions:

- ef1820450274e4853090641084fa82510c3ee512: As per @MemeWizard's suggestion, removed the proposal of `magic_good_3` and changed her `class_mage_5` to `class_mage_8` instead.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Provide feedback on the trait changes.