### PR TITLE
Sons of Lothar Death Dates

### DIFF
--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -12742,7 +12742,7 @@
 			give_job_title = job_spiritual
 		}
 	}
-	590.11.1={
+	589.11.1={
 		employer=8 #Varian Wrynn
 	}
 	620.4.29={ death=yes }
@@ -15574,7 +15574,7 @@
 		employer=2 #Llane Wrynn
 	}
 	# Joins the service of the Twilight's Hammer
-	590.11.1={
+	589.11.1={
 		employer = 52000
 		religion = cthun_worship
 		trait = class_shaman_5

--- a/history/characters/22000_wildhammer.txt
+++ b/history/characters/22000_wildhammer.txt
@@ -44,7 +44,7 @@
 	378.3.25={
 		trait = class_warrior_7
 	}
-	591.4.6={ death = { death_reason = death_vanished } }
+	591.11.1={ death = { death_reason = death_vanished } }
 }
 #dynasty=4401
 22003={

--- a/history/characters/38000_arathorian.txt
+++ b/history/characters/38000_arathorian.txt
@@ -80,7 +80,7 @@
 		# effect = { add_character_modifier = { name = hero_power_4 duration = -1 } }
 		trait = class_warrior_7
 	}
-	591.4.6={ death = { death_reason = death_vanished } }
+	591.11.1={ death = { death_reason = death_vanished } }
 }
 
 #dynasty=16001

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1297,7 +1297,7 @@
 			set_relation_lover=character:60247			#Turalyon
 		}
 	}
-	591.4.6={ death = { death_reason = death_vanished } }
+	591.11.1={ death = { death_reason = death_vanished } }
 }
 42087={
 	name=Vereesa

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -83,7 +83,7 @@
 	586.1.1 = { # This is the date when he starts training under Medivh ("aged 17") but it's also the same date when Medivh dies so idk
 		trait = shrewd # I think dealing with Medivh made him big smart
 	}
-	591.4.6={ death = { death_reason = death_vanished } } # Presumed deceased (Alliance Expedition goes to Outland)
+	591.11.1={ death = { death_reason = death_vanished } } # Presumed deceased (Alliance Expedition goes to Outland)
 }
 
 # Archmage during the events of Gnoll War

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -2948,7 +2948,7 @@
 			type = turalyon
 		}		
 	}
-	591.4.6={ death = { death_reason = death_vanished } }
+	591.11.1={ death = { death_reason = death_vanished } }
 }
 #dynasty=30033
 60248={

--- a/history/provinces/00_k_ahnqiraj.txt
+++ b/history/provinces/00_k_ahnqiraj.txt
@@ -75,7 +75,7 @@
 	religion = cthun_worship
 	holding = castle_holding
 	
-	590.11.1={
+	589.11.1={
 		culture = twilights_hammer
 	}
 }

--- a/history/provinces/00_k_black_morass.txt
+++ b/history/provinces/00_k_black_morass.txt
@@ -9,7 +9,7 @@
 		culture = blackrock
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		culture=dalaranian
 		religion=kirin_tor
 		holding = castle_holding
@@ -35,7 +35,7 @@
 		culture = blackrock
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		culture=dalaranian
 		religion=kirin_tor
 		holding = castle_holding
@@ -67,7 +67,7 @@
 		culture = blackrock
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		culture=dalaranian
 		religion=kirin_tor
 		holding = castle_holding
@@ -96,7 +96,7 @@
 		culture = stormreaver
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		culture=dalaranian
 		religion=kirin_tor
 		holding = castle_holding
@@ -124,7 +124,7 @@
 		culture = blackrock
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		culture=dalaranian
 		religion=kirin_tor
 		holding = castle_holding
@@ -154,7 +154,7 @@
 		religion = orcish_fel
 		special_building = dark_portal_02
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor
@@ -187,7 +187,7 @@
 		culture = twilights_hammer
 		religion = cthun_worship
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor
@@ -219,7 +219,7 @@
 		culture = bleeding_hollow
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor
@@ -252,7 +252,7 @@
 		culture = bleeding_hollow
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor
@@ -282,7 +282,7 @@
 		culture = bleeding_hollow
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor
@@ -316,7 +316,7 @@
 		culture = stormreaver
 		religion = orcish_fel
 	}
-	590.11.1={
+	589.11.1={
 		holding = castle_holding
 		culture=dalaranian
 		religion=kirin_tor

--- a/history/provinces/00_k_blackrock.txt
+++ b/history/provinces/00_k_blackrock.txt
@@ -24,7 +24,7 @@
 	355.1.1 = {
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = black_dragon
 		religion = nzoth_worship
 	}
@@ -46,7 +46,7 @@
 	355.1.1 = {
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = blackrock
 		religion = orcish_fel
 		holding = tribal_holding
@@ -72,7 +72,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = ogre
 		religion = orcish_fel
 		holding = tribal_holding
@@ -94,7 +94,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = blackrock
 		religion = orcish_fel
 		holding = tribal_holding
@@ -120,7 +120,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = blackrock
 		religion = orcish_fel
 		holding = tribal_holding
@@ -150,7 +150,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = blackrock
 		religion = orcish_fel
 		holding = tribal_holding
@@ -178,7 +178,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = amani
 		religion = orcish_fel
 		holding = tribal_holding
@@ -201,7 +201,7 @@
 		religion = fire_cult
 		holding = castle_holding
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = black_dragon
 		religion = nzoth_worship
 	}
@@ -223,7 +223,7 @@
 		religion = fire_cult
 		holding = castle_holding
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = black_dragon
 		religion = nzoth_worship
 	}
@@ -244,7 +244,7 @@
 		culture = dark_iron
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = amani
 		religion = orcish_fel
 		holding = tribal_holding
@@ -269,7 +269,7 @@
 	355.1.1 = {
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = black_dragon
 		religion = nzoth_worship
 	}
@@ -305,7 +305,7 @@
 	355.1.1 = {
 		religion = fire_cult
 	}
-	590.11.1 = {
+	589.11.1 = {
 		culture = black_dragon
 		religion = nzoth_worship
 	}

--- a/history/provinces/00_k_silithus.txt
+++ b/history/provinces/00_k_silithus.txt
@@ -165,7 +165,7 @@
 	religion = cthun_worship
 	holding = castle_holding
 	
-	590.11.1={
+	589.11.1={
 		culture = twilights_hammer
 	}
 }
@@ -189,7 +189,7 @@
 	religion = cthun_worship
 	holding = castle_holding
 	
-	590.11.1={
+	589.11.1={
 		culture = twilights_hammer
 	}
 }
@@ -209,7 +209,7 @@
 	religion = cthun_worship
 	holding = castle_holding
 	
-	590.11.1={
+	589.11.1={
 		culture = twilights_hammer
 	}
 }

--- a/history/provinces/00_k_wetlands.txt
+++ b/history/provinces/00_k_wetlands.txt
@@ -323,7 +323,7 @@
 	religion = shamanism
 	holding = tribal_holding
 
-	590.11.1 = {
+	589.11.1 = {
 		culture = dragonmaw
 		religion = orcish_fel
 	}

--- a/history/titles/000_wc_other_titles.txt
+++ b/history/titles/000_wc_other_titles.txt
@@ -130,7 +130,7 @@ e_horde = {
 		}
     }
     586.2.1={holder=10050} #Orgrim[2001]
-    590.11.1={holder=0}
+    589.11.1={holder=0}
     # 603.1.1={holder=10021} # Go'el[2200]
 	# # Join the Horde
 	# 603.1.1 = {
@@ -160,7 +160,7 @@ k_orc_blackrock = {
         holder=10000
     }
     586.2.1={holder=10050} #Orgrim[2001]
-    590.11.1={holder=10002 liege=0} #Dal'rend[2000]
+    589.11.1={holder=10002 liege=0} #Dal'rend[2000]
     595.1.1={
 	    liege=e_black_dragonflight
     }
@@ -209,7 +209,7 @@ d_twilights_hammer = {
     583.1.1={
     	holder=52000 #Cho'gall[2050]
     }
-	590.11.1={
+	589.11.1={
 		liege = 0
 	}
 }
@@ -237,7 +237,7 @@ d_dragonmaw = {
     	liege=e_horde
     }  
     588.2.1={holder=10300} # Zuluhed[2401]
-    590.11.1={
+    589.11.1={
 	    liege=0
 	    holder=10250 #Nekros
     }
@@ -373,7 +373,7 @@ d_witherbark = {
 	539.1.22 = { holder = amani21 } #Miguza[8054]
 	573.1.1={holder=54000} #Zalas [8150]
 	573.1.1 = {liege = k_zulaman}  #united under Zul'jin
-	590.11.1 = {liege = 0} #divided after Zul'jin's disappearance
+	589.11.1 = {liege = 0} #divided after Zul'jin's disappearance
 }
 
 d_vilebranch = {
@@ -389,14 +389,14 @@ d_vilebranch = {
 	#New dynasty
 	537.4.9 = {holder=33000} #Xunash[8180]
 	573.1.1 = {liege = k_zulaman} #united under Zul'jin
-	590.11.1 = {liege = 0} #divided after Zul'jin's disappearance
+	589.11.1 = {liege = 0} #divided after Zul'jin's disappearance
 	599.4.13={holder=33002} #Hexx[8180]
 }
 
 d_revantusk = {
 	572.1.1={holder=55000}
 	573.1.1 = {liege = k_zulaman} #united under Zul'jin
-	590.11.1 = {liege = 0} #divided after Zul'jin's disappearance
+	589.11.1 = {liege = 0} #divided after Zul'jin's disappearance
 	600.3.11={holder=55002}
 }
 
@@ -408,7 +408,7 @@ d_mossflayer = {
 	590.8.14={
 		holder=56006 #Vex'tul
 	}
-	590.11.1 = {liege = 0} #divided after Zul'jin's disappearance
+	589.11.1 = {liege = 0} #divided after Zul'jin's disappearance
 }
 
 d_darkspear = {
@@ -441,7 +441,7 @@ d_darkspear = {
 }
 
 d_smoulderthorn = {
-	590.11.1={
+	589.11.1={
 		holder=9020
 		liege=k_orc_blackrock
 	}
@@ -815,7 +815,7 @@ e_gorian_empire = {
 }
 
 d_spirestone = {
-	590.11.1={
+	589.11.1={
 		holder=52310
 		liege=k_orc_blackrock
 	}
@@ -954,7 +954,7 @@ k_shado_pan = {
 
 # Nethergarde
 d_nethergarde = {
-	590.11.1={
+	589.11.1={
 		liege=k_dalaran
 		holder=59005
 	}

--- a/history/titles/00_k_ahnqiraj.txt
+++ b/history/titles/00_k_ahnqiraj.txt
@@ -35,8 +35,8 @@ c_scarab_wall = {
 c_haasra = {
 	10.2.19 = { holder = qiraji35 } #Qaloldu[qiraji8]
 	# d_twilights_hammer
-	590.11.1={holder=52000} #Cho'gall[2050]
-	590.11.1={
+	589.11.1={holder=52000} #Cho'gall[2050]
+	589.11.1={
 		liege=d_twilights_hammer
 	}
 }

--- a/history/titles/00_k_black_morass.txt
+++ b/history/titles/00_k_black_morass.txt
@@ -21,7 +21,7 @@ c_nether_hill = {
 		holder=10000
 	}
 	586.2.1={holder=10050} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -38,7 +38,7 @@ c_rockard = {
 		liege=k_orc_blackrock
 		holder=310050 #Kanath[patron]
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -61,7 +61,7 @@ c_rosestone = {
 		liege=d_frostwolf
 		holder=10019
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -90,7 +90,7 @@ d_dulzin = {
 		liege = k_orc_blackrock
 		holder=10050
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -117,7 +117,7 @@ c_dreadmaul = {
 		liege=d_stormreaver
 		holder=10015
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -148,7 +148,7 @@ c_dulzin = {
 	583.1.1={
 		holder=10050
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -171,7 +171,7 @@ c_dark_portal = {
 		liege=d_stormreaver
 		holder=10015
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -194,7 +194,7 @@ c_deihsei = {
 		holder=52000 #Cho'Gall
 		liege=d_twilights_hammer
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -227,7 +227,7 @@ c_xoojith = {
 		liege=d_bleeding_hollow
 		holder=10005
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -258,7 +258,7 @@ c_binanu = {
 		liege=d_bleeding_hollow
 	}
 	583.1.1={holder=310570}	#Lucky[patron]
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -285,7 +285,7 @@ c_surwich = {
 		liege=d_bleeding_hollow
 		holder=10005
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}
@@ -309,7 +309,7 @@ c_dead_ravine = {
 		liege=d_frostwolf
 		holder=10019
 	}
-	590.11.1={
+	589.11.1={
 		liege = d_nethergarde
 		holder=59005
 	}

--- a/history/titles/00_k_blackrock.txt
+++ b/history/titles/00_k_blackrock.txt
@@ -11,7 +11,7 @@
 	}
 	533.2.3={holder=12002} #Dagran[4010]
 	589.1.1={holder=0}
-	590.11.1={holder=12002} #Dagran[4010]
+	589.11.1={holder=12002} #Dagran[4010]
 }
 d_blackrock_mountain = {
 	10.1.1={holder=12000} #Thaurissan[4010]
@@ -26,7 +26,7 @@ d_blackrock_mountain = {
 	}
 	533.2.3={holder=12002} #Dagran[4010]
 	589.1.1={holder=10050 liege=k_orc_blackrock} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 	}
 }
@@ -48,7 +48,7 @@ c_blackrock_depths = {
 	589.1.1={
 		holder=10050 #Orgrim[2001]
 	}
-	590.11.1={holder=12002 liege=k_blackrock} #Dagran[4010]
+	589.11.1={holder=12002 liege=k_blackrock} #Dagran[4010]
 }
 c_blackrock_spire = {
 	1.1.1={
@@ -66,7 +66,7 @@ c_blackrock_spire = {
 	}
 	533.2.3={holder=12002} #Dagran[4010]
 	589.1.1={holder=10050} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 		liege=k_orc_blackrock
 	}
@@ -87,7 +87,7 @@ c_redhelm = {
 		holder=10050 
 		liege=k_orc_blackrock #Orgrim[2001]	
 	}
-	590.11.1={holder=10002} #Dal'rend[2000]
+	589.11.1={holder=10002} #Dal'rend[2000]
 }
 c_khalfok = {
 	1.1.1={
@@ -122,7 +122,7 @@ c_khalfok = {
 		holder=10050 
 		liege=k_orc_blackrock #Orgrim[2001]
 	}
-	590.11.1={holder=52310} #Urok[42007]
+	589.11.1={holder=52310} #Urok[42007]
 }
 c_joumindan = {
 	1.1.1={
@@ -143,7 +143,7 @@ c_joumindan = {
 		holder=10050 #Orgrim[2001]
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=10002} #Dal'rend[2000]
+	589.11.1={holder=10002} #Dal'rend[2000]
 }
 c_borual = {
 	1.1.1={
@@ -167,7 +167,7 @@ c_borual = {
 		holder=10050 #Orgrim[2001]
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=10002} #Dal'rend[2000]
+	589.11.1={holder=10002} #Dal'rend[2000]
 }
 c_ogderm = {
 	1.1.1={
@@ -188,7 +188,7 @@ c_ogderm = {
 		holder=10050 #Orgrim[2001]
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=10002} #Dal'rend[2000]
+	589.11.1={holder=10002} #Dal'rend[2000]
 }
 d_burning_steppes = {
 	1.1.1={
@@ -240,7 +240,7 @@ c_redpath = {
 		holder=10050 #Orgrim[2001]
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=9020} #Voon[8410]
+	589.11.1={holder=9020} #Voon[8410]
 }
 c_cavefall = {
 	300.1.1={
@@ -253,7 +253,7 @@ c_cavefall = {
 		holder=11009
 	}
 	589.1.1={holder=10050 liege=k_orc_blackrock} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 	}
 	595.1.1={
@@ -272,7 +272,7 @@ c_morborimm = {
 		holder=11009
 	}
 	589.1.1={holder=10050 liege=k_orc_blackrock} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 	}
 	595.1.1={
@@ -313,7 +313,7 @@ c_chiselgrip = {
 		holder=10050 #Orgrim[2001]
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=9020} #Voon[8410]
+	589.11.1={holder=9020} #Voon[8410]
 }
 c_thaurissan = {
 	1.1.1={
@@ -333,7 +333,7 @@ c_thaurissan = {
 		holder=12002
 	}
 	589.1.1={holder=10050 liege=k_orc_blackrock} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 	}
 	595.1.1={
@@ -357,7 +357,7 @@ c_dulbihr = {
 		holder=11017
 	}
 	589.1.1={holder=10050 liege=k_orc_blackrock} #Orgrim[2001]
-	590.11.1={
+	589.11.1={
 		holder=10002 #Dal'rend[2000]
 	}
 	595.1.1={
@@ -376,7 +376,7 @@ d_searing_gorge = {
 		holder=11009 #Grimdor Craggrip
 	}
 	589.1.1={holder=10050} #Orgrim[2001]
-	590.11.1={holder=12002} #Dagran[4010]
+	589.11.1={holder=12002} #Dagran[4010]
 }
 c_bhurdak = {
 	1.1.1={
@@ -389,7 +389,7 @@ c_bhurdak = {
 		holder=11009 #Grimdor Craggrip
 	}
 	589.1.1={holder=10050} #Orgrim[2001]
-	590.11.1={holder=12002} #Dagran[4010]
+	589.11.1={holder=12002} #Dagran[4010]
 }
 c_brudarn = {
 	1.1.1={
@@ -416,7 +416,7 @@ c_rondagg = {
 		holder=11009 #Grimdor Craggrip
 	}
 	589.1.1={holder=10050} #Orgrim[2001]
-	590.11.1={holder=12002} #Dagran[4010]
+	589.11.1={holder=12002} #Dagran[4010]
 }
 c_domdith = {
 	1.1.1={
@@ -424,7 +424,7 @@ c_domdith = {
 	}
 	300.2.3={holder=11300}	# Patron character
 	589.1.1={holder=10050} #Orgrim[2001]
-	590.11.1={holder=11300}	# Patron character
+	589.11.1={holder=11300}	# Patron character
 }
 d_drognur = {
 }

--- a/history/titles/00_k_silithus.txt
+++ b/history/titles/00_k_silithus.txt
@@ -64,24 +64,24 @@ c_hiveashi = {
 c_crystalvale = {
 	1.8.12 = { holder = qiraji5 } #Mazzalan[qiraji2]
 	# d_twilights_hammer
-	590.11.1={holder=52000} #Cho'gall[2050]
-	590.11.1={
+	589.11.1={holder=52000} #Cho'gall[2050]
+	589.11.1={
 		liege=d_twilights_hammer
 	}
 }
 c_ishrak = {
 	1.8.12 = { holder = qiraji5 } #Mazzalan[qiraji2]
 	# d_twilights_hammer
-	590.11.1={holder=52000} #Cho'gall[2050]
-	590.11.1={
+	589.11.1={holder=52000} #Cho'gall[2050]
+	589.11.1={
 		liege=d_twilights_hammer
 	}
 }
 c_yosagonn = {
 	1.6.23 = { holder = qiraji10 } #Hesuktu[qiraji3]
 	# d_twilights_hammer
-	590.11.1={holder=52000} #Cho'gall[2050]
-	590.11.1={
+	589.11.1={holder=52000} #Cho'gall[2050]
+	589.11.1={
 		liege=d_twilights_hammer
 	}
 }

--- a/history/titles/00_k_stormwind.txt
+++ b/history/titles/00_k_stormwind.txt
@@ -17,7 +17,7 @@
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 	# Joined the Alliance
 	591.1.1={
 		effect = {
@@ -44,7 +44,7 @@ d_stormwind = {
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 }
 c_stormwind = {
 	1.1.1={
@@ -68,7 +68,7 @@ c_stormwind = {
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 }
 c_khagrihm = {
 	1.1.1={
@@ -92,7 +92,7 @@ c_khagrihm = {
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 }
 c_crowgate = {
 	1.1.1={
@@ -116,7 +116,7 @@ c_crowgate = {
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 }
 d_northwoods = {
 	1.1.1={
@@ -140,7 +140,7 @@ d_northwoods = {
 	565.1.1={holder=2} #Llane[1]
 	586.1.1={holder=8} #Varian[1]
 	587.10.1={holder=0}
-	590.11.1={holder=8} #Varian[1]
+	589.11.1={holder=8} #Varian[1]
 }
 c_goldshire = {
 	1.1.1={
@@ -166,7 +166,7 @@ c_goldshire = {
 	# Conquered by the Horde
 	587.10.1={holder=10050} #Orgrim[2001]
 	# Retaken by Stormwind
-	590.11.1={holder=175} #Gregor[2]
+	589.11.1={holder=175} #Gregor[2]
 	608.1.1={holder=176} #Aldous[2]
 }
 c_northshire = {
@@ -229,7 +229,7 @@ c_westbrook = {
 	# Conquered by the Horde
 	587.10.1={holder=10050} #Orgrim[2001]
 	# Retaken by Stormwind
-	590.11.1={holder=175} #Gregor[2]
+	589.11.1={holder=175} #Gregor[2]
 	608.1.1={holder=176} #Aldous[2]
 }
 c_southmead = {
@@ -264,7 +264,7 @@ c_stonefield = {
 	# Conquered by the Horde
 	587.10.1={holder=10050} #Orgrim[2001]
 	# Retaken by Stormwind
-	590.11.1={holder=310070} #Valeriia[310070]
+	589.11.1={holder=310070} #Valeriia[310070]
 	# Defias Stronghold
 	604.1.15 = {
 		holder = 5815 #Klaven
@@ -401,7 +401,7 @@ c_diassall = {
 	# Conquered by the Horde
 	587.10.1={holder=10050} #Orgrim[2001]
 	# Retaken by Stormwind
-	590.11.1={holder=310240} #Elendur[patron]
+	589.11.1={holder=310240} #Elendur[patron]
 }
 d_moonbrook = {
 	# Conquered by Stormwind
@@ -624,7 +624,7 @@ c_three_corners = {
 		government = tribal_government
 	}
 	# Retaken by Stormwind
-	590.11.1={
+	589.11.1={
 		holder=310350 #Sim[patron character]
 		government = feudal_government
 	} 
@@ -667,7 +667,7 @@ c_alther = {
 	579.07.16={holder=373} #Anson[4]
 	582.11.13={holder=378} #Remington[4]
 	# Old Horde Occupation
-	590.11.1={
+	589.11.1={
 		holder = 10555 #Tharil'zun[2149]
 		liege = k_orc_blackrock
 		government = tribal_government
@@ -739,7 +739,7 @@ c_shalewind = {
 	589.1.1={
 		liege=k_orc_blackrock
 	}
-	590.11.1={holder=10555} #Tharil'zun[2149]
+	589.11.1={holder=10555} #Tharil'zun[2149]
 }
 c_highland_path = {
 	499.5.11={

--- a/history/titles/00_k_wetlands.txt
+++ b/history/titles/00_k_wetlands.txt
@@ -297,8 +297,8 @@ c_direforge = {
 	333.1.1={
 		holder=22003
 	}
-	590.11.1={holder=10300} # Zuluhed[2401]
-	590.11.1={
+	589.11.1={holder=10300} # Zuluhed[2401]
+	589.11.1={
 		government = tribal_government
 		liege=d_dragonmaw
 	}

--- a/history/titles/00_k_zulaman.txt
+++ b/history/titles/00_k_zulaman.txt
@@ -11,7 +11,7 @@ k_zulaman = {
 	513.6.27 = { holder = amani33 } #Tish[8055]
 	555.11.28 = { holder = amani34 } #Tanmbu[8055]
 	573.1.1={holder=57000} #Zul'jin[8220]
-	590.11.1={holder=57160} #Daakara[8259]
+	589.11.1={holder=57160} #Daakara[8259]
 }
 d_zulaman = {
 	10.10.11 = { holder = amani24 } #Ruzanjo[8055]
@@ -26,7 +26,7 @@ d_zulaman = {
 	513.6.27 = { holder = amani33 } #Tish[8055]
 	555.11.28 = { holder = amani34 } #Tanmbu[8055]
 	573.1.1={holder=57000} #Zul'jin[8220]
-	590.11.1={holder=57160} #Daakara[8259]
+	589.11.1={holder=57160} #Daakara[8259]
 }
 c_peleahjin = {
 	1.1.1={
@@ -44,7 +44,7 @@ c_peleahjin = {
 	513.6.27 = { holder = amani33 } #Tish[8055]
 	555.11.28 = { holder = amani34 } #Tanmbu[8055]
 	573.1.1={holder=57000} #Zul'jin[8220]
-	590.11.1={holder=57160} #Daakara[8259]
+	589.11.1={holder=57160} #Daakara[8259]
 }
 c_amani_pass = {
 	1.1.1={
@@ -86,7 +86,7 @@ c_janalai = {
 	513.6.27 = { holder = amani33 } #Tish[8055]
 	555.11.28 = { holder = amani34 } #Tanmbu[8055]
 	573.1.1={holder=57000} #Zul'jin[8220]
-	590.11.1={holder=57160} #Daakara[8259]
+	589.11.1={holder=57160} #Daakara[8259]
 }
 c_halazzi = {
 	# k_zulaman
@@ -105,7 +105,7 @@ c_halazzi = {
 	513.6.27 = { holder = amani33 } #Tish[8055]
 	555.11.28 = { holder = amani34 } #Tanmbu[8055]
 	573.1.1={holder=57000} #Zul'jin[8220]
-	590.11.1={holder=57160} #Daakara[8259]
+	589.11.1={holder=57160} #Daakara[8259]
 }
 d_greenrush = {
 	800.1.1={


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Changed the death dates for Sons of Lothar from `591.4.6` to `591.11.1` to match with the date given in the dates spreadsheet for Draenor's destruction.

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/78575425/131414433-6a0223d1-ba27-4359-bed6-18736e0bace3.png)

</details>

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)