### PR TITLE
Virtue and Sin Rows

### DIFF
--- a/gui/window_faith.gui
+++ b/gui/window_faith.gui
@@ -390,6 +390,7 @@ window = {
 								}
 
 								widget = {
+									# Warcraft
 									size = { 250 80 }
 
 									vbox = {
@@ -398,6 +399,8 @@ window = {
 											datamodel = "[FaithWindow.GetSins]"
 											flipdirection = yes
 											datamodel_wrap = 6
+
+											# Warcraft
 											layoutpolicy_vertical = expanding
 
 											item = {
@@ -450,13 +453,17 @@ window = {
 								}
 
 								widget = {
+									# Warcraft
 									size = { 250 80 }
+
 									vbox = {
 										dynamicgridbox = {
 											name = "virtues_grid"
 											datamodel = "[FaithWindow.GetVirtues]"
 											flipdirection = yes
 											datamodel_wrap = 6
+
+											# Warcraft
 											layoutpolicy_vertical = expanding
 
 											item = {

--- a/gui/window_faith.gui
+++ b/gui/window_faith.gui
@@ -398,6 +398,7 @@ window = {
 											datamodel = "[FaithWindow.GetSins]"
 											flipdirection = yes
 											datamodel_wrap = 6
+											layoutpolicy_vertical = expanding
 
 											item = {
 												icon = {
@@ -456,6 +457,7 @@ window = {
 											datamodel = "[FaithWindow.GetVirtues]"
 											flipdirection = yes
 											datamodel_wrap = 6
+											layoutpolicy_vertical = expanding
 
 											item = {
 												icon = {

--- a/gui/window_faith.gui
+++ b/gui/window_faith.gui
@@ -390,7 +390,7 @@ window = {
 								}
 
 								widget = {
-									size = { 250 40 }
+									size = { 250 80 }
 
 									vbox = {
 										dynamicgridbox = {
@@ -449,7 +449,7 @@ window = {
 								}
 
 								widget = {
-									size = { 250 40 }
+									size = { 250 80 }
 									vbox = {
 										dynamicgridbox = {
 											name = "virtues_grid"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- The Faith interface fits 2 virtue and sin rows.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Open the Goblin faith. It has 2 rows of virtues.