### PR TITLE
Goblin Body Type Fix

### DIFF
--- a/common/ethnicities/wc_ethnicities_goblin.txt
+++ b/common/ethnicities/wc_ethnicities_goblin.txt
@@ -364,7 +364,6 @@
 	#Body
 	gene_bs_body_type = {
         25 = { name = body_fat_head_fat_low    range = { 0.3 0.4	  }    }
-		25 = { name = body_average    range = { 0.25 0.4	  }    }
 		25 = { name = body_fat_head_fat_medium    range = { 0.25 0.4	  }    }
 		25 = { name = body_fat_head_fat_full   range = { 0.25 0.4	  }    }
 		1 = { name = body_fat_head_fat_full   range = { 0.85 1	  }    } # "Gallywix Gene"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Removed `body_average` from goblin ethnicity so they can gain weight.

