### PR TITLE
Undead Elf Modifier

### DIFF
--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -34,6 +34,9 @@
 		}
 		trigger = {
 			is_elf_trigger = yes
+			NOT = {
+				is_sylvanas_trigger = yes
+			}
 		}
 		dna_modifiers = {
 			color = {

--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -46,7 +46,7 @@
 				mode = replace
 				gene = eye_color
 				x = { 0.024 0.024 }
-				y = { 0.612 0.612 }
+				y = { 0.565 0.600 }
 			}
 			color = {
 				mode = replace
@@ -58,7 +58,7 @@
                 mode = replace
                 gene = special_eyes
                 template = magic_no_pupils_eyes
-                value = 1
+                value = 0.5
 			}
 			morph = {
                 mode = replace

--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -51,7 +51,7 @@
 			color = {
 				mode = replace
 				gene = skin_color
-				x = { 0.667 0.741 }
+				x = { 0.600 0.741 }
 				y = { 0.150 0.255 }
 			}
 			morph = {
@@ -64,7 +64,7 @@
                 mode = replace
                 gene = gene_skin_value
                 template = skin_value_neg
-                value = { 0 0.15 }
+                value = { 0 0 }
 			}
 			morph = {
 				mode = add

--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -1,89 +1,4 @@
 ﻿being_undead = {
-	being_undead_basic = {
-		traits = {
-			being_undead
-		}
-		trigger = {
-			always = no
-		}
-		dna_modifiers = {
-			morph = {
-				mode = replace
-				gene = special_eyes
-				template = magic_no_pupils_eyes
-				value = 0.5
-			}
-			morph = {
-				mode = add
-				gene = gene_bs_body_type
-				template = body_fat_head_fat_low
-				value = { 0 0.15 }
-			}
-			morph = {
-				mode = add
-				gene = gene_bs_body_shape
-				template = body_shape_average
-				value = { 0 0.15 }
-			}
-		}
-	}
-
-	being_undead_elf = {
-		traits = {
-			being_undead
-		}
-		trigger = {
-			is_elf_trigger = yes
-			NOT = {
-				is_sylvanas_trigger = yes
-			}
-		}
-		dna_modifiers = {
-			color = {
-				mode = replace
-				gene = hair_color
-				x = { 0 0 }
-				y = { 0 0.051 }
-			}
-			color = {
-				mode = replace
-				gene = eye_color
-				x = { 0.024 0.024 }
-				y = { 0.565 0.600 }
-			}
-			color = {
-				mode = replace
-				gene = skin_color
-				x = { 0.600 0.741 }
-				y = { 0.150 0.255 }
-			}
-			morph = {
-                mode = replace
-                gene = special_eyes
-                template = magic_no_pupils_eyes
-                value = 0.5
-			}
-			morph = {
-                mode = replace
-                gene = gene_skin_value
-                template = skin_value_neg
-                value = { 0 0 }
-			}
-			morph = {
-				mode = add
-				gene = gene_bs_body_type
-				template = body_fat_head_fat_low
-				value = { 0 0.15 }
-			}
-			morph = {
-				mode = add
-				gene = gene_bs_body_shape
-				template = body_shape_average
-				value = { 0 0.15 }
-			}
-		}
-	}
-	
 	###Scripted colors
 	being_undead_sylvanas = {
 		traits = {
@@ -159,7 +74,6 @@
 			}
 		}
 	}
-	
 	being_undead_arthas = {
 		traits = {
 			being_undead
@@ -201,8 +115,59 @@
 		}
 	}
 	
+	being_undead_elf = {
+		traits = {
+			being_undead
+		}
+		trigger = {
+			is_elf_trigger = yes
+		}
+		dna_modifiers = {
+			color = {
+				mode = replace
+				gene = hair_color
+				x = { 0 0 }
+				y = { 0 0.051 }
+			}
+			color = {
+				mode = replace
+				gene = eye_color
+				x = { 0.024 0.024 }
+				y = { 0.565 0.600 }
+			}
+			color = {
+				mode = replace
+				gene = skin_color
+				x = { 0.600 0.741 }
+				y = { 0.150 0.255 }
+			}
+			morph = {
+                mode = replace
+                gene = special_eyes
+                template = magic_no_pupils_eyes
+                value = 0.5
+			}
+			morph = {
+                mode = replace
+                gene = gene_skin_value
+                template = skin_value_neg
+                value = { 0 0 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_type
+				template = body_fat_head_fat_low
+				value = { 0 0.15 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_shape
+				template = body_shape_average
+				value = { 0 0.15 }
+			}
+		}
+	}
 	being_undead = {
-		base = being_undead_basic
 		traits = {
 			being_undead
 		}
@@ -223,6 +188,24 @@
 				gene = eye_color
 				x = { 0.133 0.247 }
 				y = { 0.373 0.482 }
+			}
+			morph = {
+				mode = replace
+				gene = special_eyes
+				template = magic_no_pupils_eyes
+				value = 0.5
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_type
+				template = body_fat_head_fat_low
+				value = { 0 0.15 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_shape
+				template = body_shape_average
+				value = { 0 0.15 }
 			}
 		}
 	}

--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -27,6 +27,59 @@
 			}
 		}
 	}
+
+	being_undead_elf = {
+		traits = {
+			being_undead
+		}
+		trigger = {
+			is_elf_trigger = yes
+		}
+		dna_modifiers = {
+			color = {
+				mode = replace
+				gene = hair_color
+				x = { 0 0 }
+				y = { 0 0.051 }
+			}
+			color = {
+				mode = replace
+				gene = eye_color
+				x = { 0.024 0.024 }
+				y = { 0.612 0.612 }
+			}
+			color = {
+				mode = replace
+				gene = skin_color
+				x = { 0.667 0.741 }
+				y = { 0.150 0.255 }
+			}
+			morph = {
+                mode = replace
+                gene = special_eyes
+                template = magic_no_pupils_eyes
+                value = 1
+			}
+			morph = {
+                mode = replace
+                gene = gene_skin_value
+                template = skin_value_neg
+                value = { 0 0.15 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_type
+				template = body_fat_head_fat_low
+				value = { 0 0.15 }
+			}
+			morph = {
+				mode = add
+				gene = gene_bs_body_shape
+				template = body_shape_average
+				value = { 0 0.15 }
+			}
+		}
+	}
 	
 	###Scripted colors
 	being_undead_sylvanas = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added a separate `being_undead` visual modifier for elves (High Elves, Night Elves, Nightborne, and Highborne) to better represent how undead elves are depicted in _World of Warcraft_. 
  - This modifier gives them pale gray, greenish, or purple skin; red eyes; and either white, gray, or dark gray hair.

**CK3 Screenshots**
<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/78575425/132959329-fad43989-34f2-46b9-ab70-b92dd4758e2f.png)
![image](https://user-images.githubusercontent.com/78575425/132959330-13991c03-6a3b-4f4b-9d52-21c19e0ff2f8.png)
![image](https://user-images.githubusercontent.com/78575425/132959336-3d7c4c47-ad0a-409f-bef1-a546cbaa2dd6.png)
![image](https://user-images.githubusercontent.com/78575425/132959344-933246b7-3200-44fe-a702-78e3a6c9f885.png)
![image](https://user-images.githubusercontent.com/78575425/132959350-1bc9cd51-a24b-4b53-b0f1-e58c09f68d83.png)
![image](https://user-images.githubusercontent.com/78575425/132959360-a1bc28e3-81db-4c35-bc98-8c530d6703e5.png)

</details>

**WoW Screenshots**
<details><summary>Click to expand</summary>

**Delaryn Summermoon**
![image](https://user-images.githubusercontent.com/78575425/132959277-e0895523-7030-44c5-9023-a4a7497fe33a.png)

**Sira Moonwarden**
![image](https://user-images.githubusercontent.com/78575425/132959285-47c4e3ed-81ab-4611-8b8e-a1584c357474.png)

**Dark Rangers**
![image](https://user-images.githubusercontent.com/78575425/132959287-88b778d5-3f54-4934-b4b4-2be420d8d668.png)
![image](https://user-images.githubusercontent.com/78575425/132959290-0b4dcb08-d8d8-477a-a741-2e6f3c726fa7.png)
![image](https://user-images.githubusercontent.com/78575425/132959298-3e8953f5-7867-407c-9fae-efaee77b4a01.png)
![image](https://user-images.githubusercontent.com/78575425/132959308-ea54a213-ae87-4052-a275-abdc56035efb.png)

</details>

## Known issues:

- ~~The undead elf modifier is currently overwriting Sylvanas's own custom modifier. Need to add an exception for her.~~
  - Fixed in 1f1b42a2c326435b382f32d5c2b3967f96522a05.

## Tasks:

- [x] Fix the issue with the undead elf modifier overwriting Sylvanas's custom modifier.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:

- Open up the game in [Debug Mode](https://ck3.paradoxwikis.com/Console_commands#Enabling_debug_mode) and use the console command `add_trait being_undead ID` on any elf character.
  - Provide general feedback on this change.
