### PR TITLE
Hairless and Beardless Lore Characters Fix

### DIFF
--- a/gfx/portraits/portrait_modifiers/50_beards_scripted_characters.txt
+++ b/gfx/portraits/portrait_modifiers/50_beards_scripted_characters.txt
@@ -4,6 +4,45 @@ beards_scripted_characters = {
 
     usage = game
     selection_behavior = weighted_random
+	
+	# Warcraft
+	no_beard = {
+        dna_modifiers = {
+            accessory = {
+                mode = add
+                gene = beards
+                template = no_beard
+                range = { 0 1 } # For the randomness to work correctly
+            }
+        }   
+        weight = {
+			base = 0
+			modifier = {
+				add = 200
+				OR = {
+					is_edwin_trigger = yes
+					is_arthas_trigger = yes
+					is_anduin_wrynn_trigger = yes
+					is_khadgar_trigger = yes
+					is_varian_trigger = yes
+					is_darkhan_trigger = yes
+					is_illidan_trigger = yes
+					is_tortheldrin_trigger = yes
+					is_maim_trigger = yes
+					is_grommash_trigger = yes
+					is_garrosh_trigger = yes
+					is_rexxar_trigger = yes
+					is_rastakhan_trigger = yes
+					is_malakk_trigger = yes
+					is_easteregg1_trigger = yes
+					is_easteregg9_trigger = yes
+					is_easteregg3_trigger = yes
+					is_easteregg6_trigger = yes
+					is_easteregg8_trigger = yes
+				}
+			}
+        }
+    }
 
     male_beard_western_01 = { # "Full Beard"
         dna_modifiers = {

--- a/gfx/portraits/portrait_modifiers/50_hairstyles_scripted_characters.txt
+++ b/gfx/portraits/portrait_modifiers/50_hairstyles_scripted_characters.txt
@@ -4,6 +4,33 @@ hairstyles_scripted_characters = {
 
     usage = game
     selection_behavior = weighted_random
+	
+	# Warcraft
+	no_hairstyles = {
+        dna_modifiers = {
+            accessory = {
+                mode = add
+                gene = hairstyles
+                template = no_hairstyles
+                range = { 0 1 } # For the randomness to work correctly
+            }
+        }   
+        weight = {
+			base = 0
+			modifier = {
+				add = 200
+				OR = {
+					is_antonidas_trigger = yes
+					is_garithos_trigger = yes
+					is_orgrim_trigger = yes
+					is_kilrogg_trigger = yes
+					is_garrosh_trigger = yes
+					is_rexxar_trigger = yes
+					is_easteregg1_trigger = yes
+				}
+			}
+        }
+    }
 
     male_hair_western_01 = { # "Bowl"
         dna_modifiers = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
# Changelog:
- Fixed hairless and beardless lore characters to have random beards and hairs.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
# Developer changelog:
- Added this thing.
- Changed that thing.

# Notes:
Had beards:
- Edwin
- Arthas
- Anduin Wrynn
- Khadgar
- Varian
- Dar'Khan
- Illidan
- Tortheldrin
- Maim
- Grommash
- Garrosh
- Rexxar
- Rastakhan
- Malakk
- Easter Egg 1
- Easter Egg 9 (@ercarp check please)
- Easter Egg 3 (@ercarp check please)
- Easter Egg 6 (@ercarp check please)
- Easter Egg 8 (@ercarp check please)
Had hairs:
- Antonidas
- Garithos
- Orgrim
- Kilrogg
- Garrosh
- Rexxar
- Easter Egg 1

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
# Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
