### PR TITLE
Silver Hand Order

### DIFF
--- a/common/decisions/00_holy_order_decisions.txt
+++ b/common/decisions/00_holy_order_decisions.txt
@@ -159,14 +159,6 @@
 				limit = {
 					exists = scope:leader
 				}
-				scope:leader = {
-					add_gold = 100 #So that they have some money to lend out
-					add_piety_level = 2
-					add_gold = holy_order_starting_gold
-					every_courtier = {
-						add_trait = order_member
-					}
-				}
 				
 				# Messages
 				send_interface_toast = {
@@ -216,7 +208,7 @@
 			# }
 
 		}
-		create_holy_order_effect = yes
+		create_holy_order_effect = { LEADER = scope:leader }
 	}
 	
 	ai_potential = {

--- a/common/landed_titles/wc_holy_orders.txt
+++ b/common/landed_titles/wc_holy_orders.txt
@@ -10,14 +10,6 @@ d_brotherhood_of_the_horse = {
 	
 	definite_form = yes
 }
-d_order_of_the_silver_hand = {
-	color={ 73 113 210 }
-	color2={ 255 255 255 }
-
-	capital = c_lights_hope
-	
-	definite_form = yes
-}
 d_order_of_embers = {
 	color={ 215 120 0 }
 	color2={ 255 255 255 }

--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -171,6 +171,9 @@ on_game_start_after_lobby = {
 	}
 
 	events = {
+		# Warcraft
+		wc_holy_order.10	# Order of the Silver Hand history
+		
 		game_rule.1000	#Autopopulate families.
 
 		# Warcraft

--- a/common/scripted_effects/00_decisions_effects.txt
+++ b/common/scripted_effects/00_decisions_effects.txt
@@ -9,7 +9,7 @@ create_holy_order_effect = {
 		}
 		faith.religious_head = {
 			add_opinion = {
-				target = root
+				target = prev
 				modifier = founded_holy_order_opinion
 			}
 		}
@@ -25,6 +25,15 @@ create_holy_order_effect = {
 	}
 	faith = {
 		change_fervor = 10
+	}
+	
+	$LEADER$ = {
+		add_gold = 100 #So that they have some money to lend out
+		add_piety_level = 2
+		add_gold = holy_order_starting_gold
+		every_courtier = {
+			add_trait = order_member
+		}
 	}
 }
 

--- a/common/scripted_effects/wc_religious_effects.txt
+++ b/common/scripted_effects/wc_religious_effects.txt
@@ -1,0 +1,64 @@
+﻿create_historical_holy_order_effect = {
+	save_temporary_scope_as = leader
+	
+	$COUNTY$ = {
+		random_county_province = {
+			limit = { barony = { barony_is_valid_for_holy_order_lease_trigger = { CHARACTER = $SPONSOR$ } } }
+			barony = {
+				save_temporary_scope_as = barony
+				if = {
+					limit = { NOT = { holder = $SPONSOR$ } }
+					create_title_and_vassal_change = {
+						type = leased_out
+						save_scope_as = change
+						add_claim_on_loss = no
+					}
+					change_title_holder_include_vassals = {
+						holder = $SPONSOR$
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+			}
+		}
+	}
+	if = {
+		limit = { exists = scope:barony }
+		$SPONSOR$ = {
+			create_holy_order = {
+				leader = scope:leader
+				capital = scope:barony
+				save_scope_as = new_holy_order
+			}
+			create_holy_order_effect = { LEADER = scope:leader }
+		}
+		scope:new_holy_order.title = {
+			set_coa = title:$ORDER$
+			set_title_name = $ORDER$
+			set_title_prefix = $ORDER$_article
+		}
+	}
+}
+historical_lease_out_effect = {
+	$COUNTY$ = {
+		random_county_province = {
+			limit = { barony = { barony_is_valid_for_holy_order_lease_trigger = { CHARACTER = $COUNTY$.holder } } }
+			barony = {
+				if = {
+					limit = { NOT = { holder = $COUNTY$.holder } }
+					create_title_and_vassal_change = {
+						type = leased_out
+						save_scope_as = change
+						add_claim_on_loss = no
+					}
+					change_title_holder_include_vassals = {
+						holder = $COUNTY$.holder
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+				lease_out_to = $ORDER$
+			}
+		}
+	}
+}

--- a/events/religion_events/wc_holy_order_events.txt
+++ b/events/religion_events/wc_holy_order_events.txt
@@ -1,0 +1,46 @@
+﻿namespace = wc_holy_order
+
+# Order of the Silver Hand history
+wc_holy_order.10 = {
+	type = empty
+	hidden = yes
+	
+	trigger = {
+		game_start_date >= 588.5.1
+		game_start_date < 605.9.9
+	}
+
+	immediate = {
+		title:c_lights_hope = { save_scope_as = county }
+		if = {
+			limit = { exists = title:e_lordaeron.holder }
+			title:e_lordaeron.holder = { save_temporary_scope_as = sponsor }
+		}
+		else = {
+			scope:county.holder = { save_temporary_scope_as = sponsor }
+		}
+		
+		if = {
+			limit = { game_start_date >= 603.5.1 }
+			character:60017 = { save_scope_as = leader }	# Alexandros Mograine
+		}
+		else = {
+			character:60036 = { save_scope_as = leader }	# Uther
+		}
+		
+		scope:leader = {
+			create_historical_holy_order_effect = { SPONSOR = scope:sponsor COUNTY = scope:county ORDER = d_order_of_the_silver_hand }
+			historical_lease_out_effect = { COUNTY = title:c_whispering_gardens ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_maplechill ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_venomweb ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_hearthglen ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_hearthglen_way ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_northridge ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_tyrs_hand ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_hasic ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_cliffwallow ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_new_avalon ORDER = scope:new_holy_order }
+			historical_lease_out_effect = { COUNTY = title:c_havenshire ORDER = scope:new_holy_order }
+		}
+	}
+}

--- a/history/titles/000_wc_other_titles.txt
+++ b/history/titles/000_wc_other_titles.txt
@@ -878,21 +878,6 @@ e_pantheon = {
 ### HOLY ORDERS ###
 
 # Order of the Silver Hand
-d_order_of_the_silver_hand = {
-	588.5.1={
-		holder=60036
-	}
-	603.1.1={
-		liege=e_lordaeron
-	}
-	603.5.1={
-		liege=0
-		holder=60017
-	}
-	605.9.9={
-		holder=0
-	}
-}
 
 # Wardens
 d_wardens = {

--- a/history/titles/00_k_lordaeron.txt
+++ b/history/titles/00_k_lordaeron.txt
@@ -454,7 +454,6 @@ c_solliden = {
 }
 d_whispering_gardens = {
 	603.5.1={
-		holder=60017 #Alexandros Mograine
 	}
 }
 c_whispering_gardens = {
@@ -464,10 +463,11 @@ c_whispering_gardens = {
 	}
 	596.8.31={
 		holder=60085
-		liege=d_order_of_the_silver_hand
 	}
 	603.5.1={
-		holder=60017 #Alexandros Mograine
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.9.9={
 		liege=d_scarlet_crusade
@@ -480,7 +480,9 @@ c_maplechill = {
 	}
 	596.8.31={
 		holder=60085
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.1.1={
 		holder=60019 #Renault Mograine
@@ -517,7 +519,9 @@ c_venomweb = {
 		liege = k_lordaeron
 	}
 	603.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.1.1={
 		holder=60020 #Darion Mograine
@@ -793,7 +797,9 @@ c_hearthglen = {
 		holder=60014
 	}
 	598.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.1.1={
 		holder=60016
@@ -809,7 +815,9 @@ c_hearthglen_way = {
 		holder=60014
 	}
 	598.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.1.1={
 		holder=60016
@@ -825,7 +833,9 @@ c_northridge = {
 		holder=60014
 	}
 	598.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.1.1={
 		holder=60016

--- a/history/titles/00_k_stratholme.txt
+++ b/history/titles/00_k_stratholme.txt
@@ -374,7 +374,9 @@ c_tyrs_hand = {
 		holder=60550
 	}
 	603.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	604.1.1={
 		holder=60560
@@ -394,8 +396,9 @@ c_lights_hope = {
 		holder=60245
 	}
 	598.3.3={
-		holder=60036
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	604.9.19={	
 		holder=60625
@@ -414,8 +417,8 @@ c_hasic = {
 	581.7.16={
 		holder=60159
 	}
-	604.1.1={
-		liege=d_order_of_the_silver_hand
+	603.5.1 = {
+		liege = 0
 	}
 	605.9.9={
 		liege=d_scarlet_crusade
@@ -434,8 +437,8 @@ c_cliffwallow = {
 	581.7.16={
 		holder=60159
 	}
-	604.1.1={
-		liege=d_order_of_the_silver_hand
+	603.5.1 = {
+		liege = 0
 	}
 	605.9.9={
 		liege=d_scarlet_crusade
@@ -458,7 +461,9 @@ c_new_avalon = {
 	}
 	573.5.17={holder=310000} #Aberthol[patron]
 	590.1.1={
-	 liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.9.9={
 		liege=d_scarlet_crusade
@@ -492,7 +497,9 @@ c_havenshire = {
 	583.1.1={holder=310030} #Tibault[patron]
 
 	590.1.1={
-		liege=d_order_of_the_silver_hand
+	}
+	603.5.1 = {
+		liege = 0
 	}
 	605.9.9={
 		liege=d_scarlet_crusade


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Made the Knights of the Silver Hand a holy order instead of theocracy in the year 603 and 605.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Confirm it's a holy order.