### PR TITLE
Barov and Sylvanas Makeup Fix

### DIFF
--- a/gfx/portraits/portrait_modifiers/wc_facial_markings.txt
+++ b/gfx/portraits/portrait_modifiers/wc_facial_markings.txt
@@ -62,6 +62,7 @@
 			modifier = {
 				add = 100
 				is_sylvanas_trigger = yes
+				has_trait = being_undead
 				can_have_markings_trigger = yes
 			}
 		}
@@ -1025,6 +1026,12 @@
 		}
 		weight = {
 			base = 0
+			modifier = {
+				add = 100
+				is_alexei_trigger = yes
+				has_trait = being_undead
+				can_have_markings_trigger = yes
+			}
 		}
 		
 		is_valid_custom = {
@@ -1042,6 +1049,18 @@
 		}
 		weight = {
 			base = 0
+			modifier = {
+				add = 100
+				is_illucia_trigger = yes
+				has_trait = being_undead
+				can_have_markings_trigger = yes
+			}
+			modifier = {
+				add = 100
+				is_jandice_trigger = yes
+				has_trait = being_undead
+				can_have_markings_trigger = yes
+			}
 		}
 		
 		is_valid_custom = {
@@ -1059,6 +1078,11 @@
 		}
 		weight = {
 			base = 0
+			modifier = {
+				add = 100
+				is_rexxar_trigger = yes
+				can_have_markings_trigger = yes
+			}
 		}
 		
 		is_valid_custom = {
@@ -1076,6 +1100,11 @@
 		}
 		weight = {
 			base = 0
+			modifier = {
+				add = 100
+				is_ysera_trigger = yes
+				can_have_markings_trigger = yes
+			}
 		}
 		
 		is_valid_custom = {
@@ -1139,6 +1168,18 @@ facial_markings_2 = {
 		}
 		weight = {
 			base = 0
+			modifier = {
+				add = 100
+				is_illucia_trigger = yes
+				has_trait = being_undead
+				can_have_markings_trigger = yes
+			}
+			modifier = {
+				add = 100
+				is_jandice_trigger = yes
+				has_trait = being_undead
+				can_have_markings_trigger = yes
+			}
 		}
 		
 		is_valid_custom = {

--- a/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
+++ b/gfx/portraits/trait_portrait_modifiers/wc_undead_modifier.txt
@@ -27,12 +27,6 @@
 				y = { 0.200 0.200 }
 			}
 			morph = {
-                mode = add
-                gene = gene_facial_markings
-                template = sylvanas_makeup
-                value = 1
-			}
-			morph = {
                 mode = replace
                 gene = special_eyes
                 template = magic_pupils_eyes
@@ -153,12 +147,6 @@
 			#	template = body_fat_head_fat_low
 			#	value = 0.25
 			#}
-			morph = {
-                mode = add
-                gene = gene_facial_markings
-                template = barov_markings
-                value = 1
-			}
 		}
 	}
 	being_undead_illucia = {
@@ -193,18 +181,6 @@
 			#	template = body_fat_head_fat_low
 			#	value = 0.25
 			#}
-			morph = {
-                mode = add
-                gene = gene_facial_markings
-                template = barov_markings_2
-                value = 1
-			}
-			morph = {
-                mode = add
-                gene = gene_facial_markings_2
-                template = nathrezim_lipstick
-                value = 0.7
-			}
 		}
 	}
 	being_undead_jandice = {
@@ -239,18 +215,6 @@
 			#	template = body_fat_head_fat_low
 			#	value = 0.25
 			#}
-			morph = {
-                mode = add
-                gene = gene_facial_markings
-                template = barov_markings_2
-                value = 1
-			}
-			morph = {
-                mode = add
-                gene = gene_facial_markings_2
-                template = nathrezim_lipstick
-                value = 0.7
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed Barovs not having makeup.
- Fixed Sylvanas having dripping mascara in the living form.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

# Notes:
Don't assign markings outside `wc_facial_markings.txt` and `wc_body_markings.txt`.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Check they have them.
