### PR TITLE
Asexual races event

### DIFF
--- a/events/wc_events/wc_race_events.txt
+++ b/events/wc_events/wc_race_events.txt
@@ -7,10 +7,27 @@ WCRAC.10 = {
 	
 	trigger = {
 		NOT = { has_character_flag = race_giving_fired_flag }
+		
+		has_race_trait_trigger = no
 	}
 	
 	immediate = {
-		try_to_set_race_effect = { FLAG = no_gene }
+		copy_race_effect = { CHARACTER = this }
+		
+		if = {
+			limit = {
+				NOT = { has_character_flag = race_giving_fired_flag }
+			
+				has_race_trait_trigger = no
+			}
+		
+			try_to_set_race_effect = { FLAG = no_gene }
+			if = {
+				limit = { game_start_undead_trigger = yes }
+				become_undead_no_notification_effect = yes
+			}
+			scale_age_effect = yes
+		}
 	}
 }
 
@@ -21,10 +38,27 @@ WCRAC.20 = {
 	
 	trigger = {
 		NOT = { has_character_flag = race_giving_fired_flag }
+		
+		has_race_trait_trigger = no
 	}
 	
 	immediate = {
-		try_to_set_race_effect = { FLAG = gene }
+		copy_race_effect = { CHARACTER = this }
+		
+		if = {
+			limit = {
+				NOT = { has_character_flag = race_giving_fired_flag }
+			
+				has_race_trait_trigger = no
+			}
+		
+			try_to_set_race_effect = { FLAG = gene }
+			if = {
+				limit = { game_start_undead_trigger = yes }
+				become_undead_no_notification_effect = yes
+			}
+			scale_age_effect = yes
+		}
 	}
 }
 
@@ -42,15 +76,28 @@ WCRAC.30 = {
 			}
 			#Tries to set race flag based on trait you have
 			copy_race_effect = { CHARACTER = this }
-			try_to_set_race_effect = { FLAG = gene }
+			trigger_event = WCRAC.20
+		}
+		# At the game start life expectancy is ignored
+		if = {
+			limit = {
+				game_start_day_trigger = yes
+				age <= age_50_value
+				age > 50
+			}
+			add_character_modifier = game_start_health
 		}
 		# Old characters become impotent
 		if = {
 			limit = { can_be_impotent_trigger = yes }
 			add_trait = impotent
 		}
+		# Long-lived races slow down their XP
+		set_long_lived_lifestyle_xp_slowdown_event_effect = yes
 	}
 }
+
+
 # Characters of Asexual races are set to Asexual
 WCRAC.40 = {
 	type = character_event

--- a/events/wc_events/wc_race_events.txt
+++ b/events/wc_events/wc_race_events.txt
@@ -7,27 +7,10 @@ WCRAC.10 = {
 	
 	trigger = {
 		NOT = { has_character_flag = race_giving_fired_flag }
-		
-		has_race_trait_trigger = no
 	}
 	
 	immediate = {
-		copy_race_effect = { CHARACTER = this }
-		
-		if = {
-			limit = {
-				NOT = { has_character_flag = race_giving_fired_flag }
-			
-				has_race_trait_trigger = no
-			}
-		
-			try_to_set_race_effect = { FLAG = no_gene }
-			if = {
-				limit = { game_start_undead_trigger = yes }
-				become_undead_no_notification_effect = yes
-			}
-			scale_age_effect = yes
-		}
+		try_to_set_race_effect = { FLAG = no_gene }
 	}
 }
 
@@ -38,27 +21,10 @@ WCRAC.20 = {
 	
 	trigger = {
 		NOT = { has_character_flag = race_giving_fired_flag }
-		
-		has_race_trait_trigger = no
 	}
 	
 	immediate = {
-		copy_race_effect = { CHARACTER = this }
-		
-		if = {
-			limit = {
-				NOT = { has_character_flag = race_giving_fired_flag }
-			
-				has_race_trait_trigger = no
-			}
-		
-			try_to_set_race_effect = { FLAG = gene }
-			if = {
-				limit = { game_start_undead_trigger = yes }
-				become_undead_no_notification_effect = yes
-			}
-			scale_age_effect = yes
-		}
+		try_to_set_race_effect = { FLAG = gene }
 	}
 }
 
@@ -76,23 +42,32 @@ WCRAC.30 = {
 			}
 			#Tries to set race flag based on trait you have
 			copy_race_effect = { CHARACTER = this }
-			trigger_event = WCRAC.20
-		}
-		# At the game start life expectancy is ignored
-		if = {
-			limit = {
-				game_start_day_trigger = yes
-				age <= age_50_value
-				age > 50
-			}
-			add_character_modifier = game_start_health
+			try_to_set_race_effect = { FLAG = gene }
 		}
 		# Old characters become impotent
 		if = {
 			limit = { can_be_impotent_trigger = yes }
 			add_trait = impotent
 		}
-		# Long-lived races slow down their XP
-		set_long_lived_lifestyle_xp_slowdown_event_effect = yes
+	}
+}
+# Characters of Asexual races are set to Asexual
+WCRAC.40 = {
+	type = character_event
+	hidden = yes
+	immediate = {
+		if = {
+			limit = {
+				OR = {
+					has_trait = creature_nraqi
+					has_trait = creature_annihilan 
+					has_trait = creature_ancient_war
+					has_trait = creature_ancient_lore
+					has_trait = creature_ancient_wind
+				}
+			}
+			#listed races become asexual
+			set_sexuality = asexual
+		}
 	}
 }


### PR DESCRIPTION
Set all Asexual Races in the game to be asexual

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added event to set asexual races to be asexual

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Created a limit which searches for a specific trait instead of a flag for the trait

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
