### PR TITLE
[Issue #807] Ner'zhul keeps Orc trait

### DIFF
--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -334,7 +334,6 @@
 	591.11.1={
 		culture=scourge religion=death_god
 		trait = being_undead
-		remove_trait = creature_orc
 		trait = creature_lich
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value } }
 		trait = lich_king

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -335,7 +335,6 @@
 		culture=scourge religion=death_god
 		trait = being_undead
 		remove_trait = creature_orc
-		trait = creature_lich
 		effect = { add_trait_force_tooltip = creature_lich }
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value } }
 		trait = lich_king
@@ -434,8 +433,8 @@
 	}
 	588.1.1={
 		remove_trait = creature_orc
-		trait = creature_human
 		trait = being_undead
+		effect = { add_trait_force_tooltip = creature_human }
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
 			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
@@ -616,8 +615,8 @@
 	}
 	588.1.1={
 		remove_trait = creature_orc
-		trait = creature_human
 		trait = being_undead
+		effect = { add_trait_force_tooltip = creature_human }
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
 			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -335,7 +335,7 @@
 		culture=scourge religion=death_god
 		trait = being_undead
 		remove_trait = creature_orc
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value } }
 		trait = lich_king
 		trait = in_ice_prison
@@ -434,7 +434,7 @@
 	588.1.1={
 		remove_trait = creature_orc
 		trait = being_undead
-		effect = { add_trait_force_tooltip = creature_human }
+		add_trait = creature_human
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
 			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
@@ -616,7 +616,7 @@
 	588.1.1={
 		remove_trait = creature_orc
 		trait = being_undead
-		effect = { add_trait_force_tooltip = creature_human }
+		add_trait = creature_human 
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
 			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -334,7 +334,9 @@
 	591.11.1={
 		culture=scourge religion=death_god
 		trait = being_undead
+		remove_trait = creature_orc
 		trait = creature_lich
+		effect = { add_trait_force_tooltip = creature_lich }
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value } }
 		trait = lich_king
 		trait = in_ice_prison

--- a/history/characters/110000_scourge.txt
+++ b/history/characters/110000_scourge.txt
@@ -14,7 +14,7 @@
 		culture=scourge religion=death_god
 		remove_trait=creature_orc
 		trait=being_undead
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_4_magic_trait_value } }
 	}
 	610.1.1={ death=yes }

--- a/history/characters/110000_scourge.txt
+++ b/history/characters/110000_scourge.txt
@@ -13,7 +13,6 @@
 	591.1.1 = {
 		culture=scourge religion=death_god
 		remove_trait=creature_orc
-		trait=creature_lich
 		trait=being_undead
 		effect = { add_trait_force_tooltip = creature_lich }
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_4_magic_trait_value } }

--- a/history/characters/110000_scourge.txt
+++ b/history/characters/110000_scourge.txt
@@ -15,6 +15,7 @@
 		remove_trait=creature_orc
 		trait=creature_lich
 		trait=being_undead
+		effect = { add_trait_force_tooltip = creature_lich }
 		effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_4_magic_trait_value } }
 	}
 	610.1.1={ death=yes }

--- a/history/characters/260000_northern.txt
+++ b/history/characters/260000_northern.txt
@@ -5396,6 +5396,7 @@
 		trait = creature_lich
 		remove_trait = creature_human
 		trait = being_undead
+		effect = { add_trait_force_tooltip = creature_lich }
 		effect={ change_variable = { name = wc_death_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		give_nickname = nick_the_summoner
 	}		

--- a/history/characters/260000_northern.txt
+++ b/history/characters/260000_northern.txt
@@ -5393,7 +5393,6 @@
 		religion = death_god
 	}
 	600.1.1={
-		trait = creature_lich
 		remove_trait = creature_human
 		trait = being_undead
 		effect = { add_trait_force_tooltip = creature_lich }

--- a/history/characters/260000_northern.txt
+++ b/history/characters/260000_northern.txt
@@ -5395,7 +5395,7 @@
 	600.1.1={
 		remove_trait = creature_human
 		trait = being_undead
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich
 		effect={ change_variable = { name = wc_death_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		give_nickname = nick_the_summoner
 	}		

--- a/history/characters/330000_highborne.txt
+++ b/history/characters/330000_highborne.txt
@@ -59,7 +59,7 @@
 	40.1.1={
 		trait=being_void
 		remove_trait=creature_highborne
-		trait=creature_naga
+		effect = { add_trait_force_tooltip = creature_naga }
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
 			set_variable = { name = wc_dexterity_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }

--- a/history/characters/330000_highborne.txt
+++ b/history/characters/330000_highborne.txt
@@ -59,7 +59,7 @@
 	40.1.1={
 		trait=being_void
 		remove_trait=creature_highborne
-		effect = { add_trait_force_tooltip = creature_naga }
+		add_trait = creature_naga 
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
 			set_variable = { name = wc_dexterity_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }

--- a/history/characters/38000_arathorian.txt
+++ b/history/characters/38000_arathorian.txt
@@ -430,7 +430,7 @@
 		effect={ change_variable = { name = wc_order_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		trait = being_undead
 		remove_trait = creature_human
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich 
 		religion = death_god
 	}
 	608.10.9={ death=yes }

--- a/history/characters/38000_arathorian.txt
+++ b/history/characters/38000_arathorian.txt
@@ -431,6 +431,7 @@
 		trait = being_undead
 		remove_trait = creature_human
 		trait = creature_lich
+		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 	}
 	608.10.9={ death=yes }

--- a/history/characters/38000_arathorian.txt
+++ b/history/characters/38000_arathorian.txt
@@ -430,7 +430,6 @@
 		effect={ change_variable = { name = wc_order_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		trait = being_undead
 		remove_trait = creature_human
-		trait = creature_lich
 		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 	}

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -192,7 +192,7 @@
 	603.8.7={
 		trait=being_undead
 		remove_trait=creature_human
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich 
 		effect={
 			set_relation_friend = character:60003 #Arthas
 		}

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -191,7 +191,6 @@
 	}
 	603.8.7={
 		trait=being_undead
-		trait=creature_lich
 		remove_trait=creature_human
 		effect = { add_trait_force_tooltip = creature_lich }
 		effect={

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -193,6 +193,7 @@
 		trait=being_undead
 		trait=creature_lich
 		remove_trait=creature_human
+		effect = { add_trait_force_tooltip = creature_lich }
 		effect={
 			set_relation_friend = character:60003 #Arthas
 		}

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -4258,6 +4258,7 @@
 		trait = being_undead
 		remove_trait = creature_human
 		trait = creature_lich
+		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 		effect = {
 			give_nickname=nick_the_summoner
@@ -4312,6 +4313,7 @@
 		trait = being_undead
 		remove_trait = creature_human
 		trait = creature_lich
+		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 		trait = zealous
 	}

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -4257,7 +4257,7 @@
 	603.2.21={
 		trait = being_undead
 		remove_trait = creature_human
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich 
 		religion = death_god
 		effect = {
 			give_nickname=nick_the_summoner
@@ -4311,7 +4311,7 @@
 		effect={ change_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		trait = being_undead
 		remove_trait = creature_human
-		effect = { add_trait_force_tooltip = creature_lich }
+		add_trait = creature_lich 
 		religion = death_god
 		trait = zealous
 	}

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -4257,7 +4257,6 @@
 	603.2.21={
 		trait = being_undead
 		remove_trait = creature_human
-		trait = creature_lich
 		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 		effect = {
@@ -4312,7 +4311,6 @@
 		effect={ change_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable add = wc_perks_given_for_magical_level_up_value } }
 		trait = being_undead
 		remove_trait = creature_human
-		trait = creature_lich
 		effect = { add_trait_force_tooltip = creature_lich }
 		religion = death_god
 		trait = zealous


### PR DESCRIPTION
## Changelog:
- Orc racial trait was being changed when Ner'zhul is lich king. This version removed that instruction.
- Close #807

![image](https://user-images.githubusercontent.com/35965798/148702992-a6a87ae2-0071-41c7-9370-fb70f51ec1bb.png)

