### PR TITLE
[Issue #805] Stormwind name now appears

### DIFF
--- a/localization/english/religion/wc_holy_sites_l_english.yml
+++ b/localization/english/religion/wc_holy_sites_l_english.yml
@@ -79,6 +79,8 @@
  holy_site_thunder_bluff_effect_name:0 "From [holy_site|E] #weak ($holy_site_thunder_bluff_name$)#!"
  holy_site_northshire_name:0 "$c_northshire$"
  holy_site_northshire_effect_name:0 "From [holy_site|E] #weak ($holy_site_northshire_name$)#!"
+ holy_site_stormwind_name:0 "$c_stormwind$"
+ holy_site_stormwind_effect_name:0 "From [holy_site|E] #weak ($holy_site_stormwind_name$)#!"
  holy_site_stromgarde_name:0 "$c_stromgarde$"
  holy_site_stromgarde_effect_name:0 "From [holy_site|E] #weak ($holy_site_stromgarde_name$)#!"
  holy_site_tyrs_hand_name:0 "$c_tyrs_hand$"

--- a/localization/french/religion/wc_holy_sites_l_french.yml
+++ b/localization/french/religion/wc_holy_sites_l_french.yml
@@ -79,6 +79,8 @@
  holy_site_thunder_bluff_effect_name:0 "From [holy_site|E] #weak ($holy_site_thunder_bluff_name$)#!"
  holy_site_northshire_name:0 "$c_northshire$"
  holy_site_northshire_effect_name:0 "From [holy_site|E] #weak ($holy_site_northshire_name$)#!"
+ holy_site_stormwind_name:0 "$c_stormwind$"
+ holy_site_stormwind_effect_name:0 "From [holy_site|E] #weak ($holy_site_stormwind_name$)#!"
  holy_site_stromgarde_name:0 "$c_stromgarde$"
  holy_site_stromgarde_effect_name:0 "From [holy_site|E] #weak ($holy_site_stromgarde_name$)#!"
  holy_site_tyrs_hand_name:0 "$c_tyrs_hand$"

--- a/localization/german/religion/wc_holy_sites_l_german.yml
+++ b/localization/german/religion/wc_holy_sites_l_german.yml
@@ -79,6 +79,8 @@
  holy_site_thunder_bluff_effect_name:0 "Von [holy_site|E] #weak ($holy_site_thunder_bluff_name$)#!"
  holy_site_northshire_name:0 "$c_northshire$"
  holy_site_northshire_effect_name:0 "Von [holy_site|E] #weak ($holy_site_northshire_name$)#!"
+ holy_site_stormwind_name:0 "$c_stormwind$"
+ holy_site_stormwind_effect_name:0 "Von [holy_site|E] #weak ($holy_site_stormwind_name$)#!"
  holy_site_stromgarde_name:0 "$c_stromgarde$"
  holy_site_stromgarde_effect_name:0 "Von [holy_site|E] #weak ($holy_site_stromgarde_name$)#!"
  holy_site_tyrs_hand_name:0 "$c_tyrs_hand$"


### PR DESCRIPTION
## Changelog:
- Stormwind holy site name for "Masonry" now appears correctly.
- Close #805 

![image](https://user-images.githubusercontent.com/35965798/148704472-de949f13-5217-405f-aabb-93ab07708496.png)

