### PR TITLE
Removed Orc Vassal of Kul Tiras

### DIFF
--- a/history/titles/00_k_tol_barad.txt
+++ b/history/titles/00_k_tol_barad.txt
@@ -94,7 +94,10 @@ c_crestfall = {
 	544.07.16={holder=48076} #Tetbert[26000]
 	575.04.16={holder=48080} #Daelin[26000]
 	# Humans abandoned, undead orcs settled
-	590.1.1={holder=10060} #Dilik[2002]
+	590.1.1={
+		holder = 10060 #Dilik[2002]
+		liege = 0
+	}
 }
 c_tol_ronal = {
 # k_kul_tiras


### PR DESCRIPTION


<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
Crestfall is no longer a vassal of Kul Tiras by 603 and 605 bookmarks.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
Per #841 

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)