### PR TITLE
Maiev no longer abuses Illidan in prison

### DIFF
--- a/common/character_interactions/00_prison_interactions.txt
+++ b/common/character_interactions/00_prison_interactions.txt
@@ -984,6 +984,14 @@ move_to_dungeon_interaction = {
 				}
 			}
 		}
+		
+		# Warcraft
+		# Maiev will not move Illidan to dungeon
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 }
 	
@@ -1520,7 +1528,15 @@ ransom_interaction = {
 				scope:recipient = { is_at_war = yes }
 				scope:secondary_recipient = { has_character_flag = character_ransom_refused_by_player }
 			}
-		}		
+		}
+		
+		# Warcraft
+		# Maiev will not ransom Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 
 	# Needs to be after all other send options so we only default to it if everything else is blocked
@@ -3377,6 +3393,14 @@ release_from_prison_interaction = {
 				is_child_of = scope:actor
 			}
 		}
+		
+		# Warcraft
+		# Maiev will not release Illidan
+		modifier = {
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 }
 
@@ -3529,6 +3553,14 @@ execute_prisoner_interaction = {
 				}
 			}
 		}
+		
+		# Warcraft
+		# Maiev will not execute Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 	
 	is_shown = {
@@ -3546,26 +3578,7 @@ execute_prisoner_interaction = {
 				NOT = { has_character_flag = is_being_tortured }
 			}
 		}
-		# Warcraft
-		# Elunic Kaldorei AI will not execute Kaldorei Illidari prisoners # Hotfix until new criminal doctrines
-		trigger_if = {
-			limit = { 
-				scope:actor = { is_ai = yes }
-				scope:actor.faith = faith:kaldorei_religion 
-				scope:actor = { has_trait = creature_night_elf }
-				scope:actor.culture = scope:recipient.culture 
-				scope:recipient.faith = faith:illidari 
-			}
-			NOR = {
-				scope:recipient = { 
-					has_trait = being_demon	
-				}
-				scope:recipient = { 
-					has_trait = creature_night_elf 
-				}
-			}
-		}
-	}	
+	}
 	
 	on_accept = {
 		if = {
@@ -3785,25 +3798,6 @@ torture_interaction = {
 				NOT = { has_character_flag = is_being_tortured }
 			}
 		}
-		# Warcraft
-		# Elunic Kaldorei AI will not torture Kaldorei Illidari prisoners # Hotfix until new criminal doctrines
-		trigger_if = {
-			limit = { 
-				scope:actor = { is_ai = yes }
-				scope:actor.faith = faith:kaldorei_religion 
-				scope:actor = { has_trait = creature_night_elf }
-				scope:actor.culture = scope:recipient.culture 
-				scope:recipient.faith = faith:illidari 
-			}
-			NOR = {
-				scope:recipient = { 
-					has_trait = being_demon	
-				}
-				scope:recipient = { 
-					has_trait = creature_night_elf 
-				}
-			}
-		}
 	}
 
 	is_highlighted = {
@@ -3924,7 +3918,15 @@ torture_interaction = {
 			opinion_target = scope:recipient
 			multiplier = -0.25
 		}
-	}	
+		
+		# Warcraft
+		# Maiev will not torture Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
+	}
 }
 
 castrate_interaction = {

--- a/common/character_interactions/00_prison_interactions.txt
+++ b/common/character_interactions/00_prison_interactions.txt
@@ -3546,31 +3546,26 @@ execute_prisoner_interaction = {
 				NOT = { has_character_flag = is_being_tortured }
 			}
 		}
-	}
-	
-	is_valid = {
 		# Warcraft
-		# Elunic Kaldorei AI will not execute Kaldorei Illidari prisoners, mortal or demon
-		NOT = {
-			AND = { 
-				scope:actor = { 
-					is_ai = yes 
-					has_faith = faith:kaldorei_religion 
+		# Elunic Kaldorei AI will not execute Kaldorei Illidari prisoners # Hotfix until new criminal doctrines
+		trigger_if = {
+			limit = { 
+				scope:actor = { is_ai = yes }
+				scope:actor.faith = faith:kaldorei_religion 
+				scope:actor = { has_trait = creature_night_elf }
+				scope:actor.culture = scope:recipient.culture 
+				scope:recipient.faith = faith:illidari 
+			}
+			NOR = {
+				scope:recipient = { 
+					has_trait = being_demon	
+				}
+				scope:recipient = { 
 					has_trait = creature_night_elf 
 				}
 			}
-			AND = { 
-				scope:recipient = {
-					has_faith = faith:illidari 
-					has_same_culture_as = scope:actor
-						OR = { 
-						has_trait = creature_night_elf 
-						has_trait = being_demon
-					}
-				}
-			}
 		}
-	}
+	}	
 	
 	on_accept = {
 		if = {
@@ -3788,6 +3783,25 @@ torture_interaction = {
 			custom_description = {
 				text = "currently_being_tortured"
 				NOT = { has_character_flag = is_being_tortured }
+			}
+		}
+		# Warcraft
+		# Elunic Kaldorei AI will not torture Kaldorei Illidari prisoners # Hotfix until new criminal doctrines
+		trigger_if = {
+			limit = { 
+				scope:actor = { is_ai = yes }
+				scope:actor.faith = faith:kaldorei_religion 
+				scope:actor = { has_trait = creature_night_elf }
+				scope:actor.culture = scope:recipient.culture 
+				scope:recipient.faith = faith:illidari 
+			}
+			NOR = {
+				scope:recipient = { 
+					has_trait = being_demon	
+				}
+				scope:recipient = { 
+					has_trait = creature_night_elf 
+				}
 			}
 		}
 	}

--- a/common/character_interactions/00_prison_interactions.txt
+++ b/common/character_interactions/00_prison_interactions.txt
@@ -3548,6 +3548,21 @@ execute_prisoner_interaction = {
 		}
 	}
 	
+	# Warcraft
+	is_valid = {
+		# Elunic Kaldorei will not execute Kaldorei Illidari prisoners
+		NOT = {
+			AND = { 
+				scope:actor = { has_faith = faith:kaldorei_religion }
+				scope:actor = { has_trait = creature_night_elf }
+			}
+			AND = { 
+				scope:recipient = { has_faith = faith:illidari }
+				scope:recipient = { has_trait = creature_night_elf }
+			}
+		}
+	}
+	
 	on_accept = {
 		if = {
 			limit = { scope:recipient = { is_imprisoned_by = scope:actor } }

--- a/common/character_interactions/00_prison_interactions.txt
+++ b/common/character_interactions/00_prison_interactions.txt
@@ -3548,17 +3548,26 @@ execute_prisoner_interaction = {
 		}
 	}
 	
-	# Warcraft
 	is_valid = {
-		# Elunic Kaldorei will not execute Kaldorei Illidari prisoners
+		# Warcraft
+		# Elunic Kaldorei AI will not execute Kaldorei Illidari prisoners, mortal or demon
 		NOT = {
 			AND = { 
-				scope:actor = { has_faith = faith:kaldorei_religion }
-				scope:actor = { has_trait = creature_night_elf }
+				scope:actor = { 
+					is_ai = yes 
+					has_faith = faith:kaldorei_religion 
+					has_trait = creature_night_elf 
+				}
 			}
 			AND = { 
-				scope:recipient = { has_faith = faith:illidari }
-				scope:recipient = { has_trait = creature_night_elf }
+				scope:recipient = {
+					has_faith = faith:illidari 
+					has_same_culture_as = scope:actor
+						OR = { 
+						has_trait = creature_night_elf 
+						has_trait = being_demon
+					}
+				}
 			}
 		}
 	}

--- a/history/characters/340000_night_elf.txt
+++ b/history/characters/340000_night_elf.txt
@@ -328,7 +328,7 @@
 				limit = { NOT = { current_date >= 604.1.1 } }
 				imprison = {
 					target = character:340009	#Illidan
-					type = dungeon
+					type = house_arrest			# Hotfix for poor health in dungeon
 				}
 			}
 		}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Maiev will no longer **execute or torture[^1]** Illidan while he is imprisoned by her. 
- Maiev will not release, ransom or move Illidan to the dungeon.
- Illidan is now confined to House Arrest.

Players should still be able to access all prison interactions as normal.

Closes #561 

~~This PR simulates the indefinite imprisonment of Illidan in the Barrow Deeps of Mount Hyjal and the same fate suffered by his Illidari Demon Hunters in the Vault of the Wardens, as opposed to capital punishment.~~
> Will be worked into the new Torture/Execution Crimes doctrine and/or prison type #860.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:

- Let the game run in observer mode and check to see if Maiev has executed Illidan.
- Check to see if the execute and torture interactions are available to you as Maiev towards Illidan. (They should) Technically, these restrictions mean that no AI Elunic Kaldorei characters should be able to harm imprisoned Illidari characters.

[^1]:  Repeated torture sessions were causing premature death even if execution was blocked.