### PR TITLE
Dwarven Clothing Tweaks

### DIFF
--- a/common/culture/cultures/demonic.txt
+++ b/common/culture/cultures/demonic.txt
@@ -4,7 +4,7 @@
 		western_building_gfx
 		western_unit_gfx
 
-		no_headgear_gfx
+		no_lowborn_headgear_gfx
 		demonic_clothing_gfx
 		draenei_hairstyles_gfx
 		draenei_beards_gfx

--- a/common/culture/cultures/dwarf.txt
+++ b/common/culture/cultures/dwarf.txt
@@ -406,7 +406,7 @@
 			wildhammer_clothing_gfx
 			northern_clothing_gfx
 			fp1_norse_clothing_gfx
-			no_crown_gfx 				#No war headgear
+			no_helmet_gfx
 		}
 		color = rgb { 36 59 3 }
 

--- a/common/culture/cultures/dwarf.txt
+++ b/common/culture/cultures/dwarf.txt
@@ -406,7 +406,6 @@
 			wildhammer_clothing_gfx
 			northern_clothing_gfx
 			fp1_norse_clothing_gfx
-			no_helmet_gfx
 		}
 		color = rgb { 36 59 3 }
 

--- a/common/culture/cultures/elf.txt
+++ b/common/culture/cultures/elf.txt
@@ -1,13 +1,11 @@
 ﻿elf_group = { 
 	graphical_cultures = {
-		no_headgear_gfx
-		
 		western_coa_gfx
 		western_building_gfx
 		western_unit_gfx
 		
 		high_elven_hairstyles_gfx
-		no_headgear_gfx
+		no_lowborn_headgear_gfx
 	}
 	
 	high_elf = {
@@ -605,7 +603,6 @@
 		graphical_cultures = {
 			night_elven_clothing_gfx
 			night_elven_beards_gfx
-			no_crown_gfx
 			
 			creature_night_elf_gfx
 		}

--- a/common/culture/cultures/ogre.txt
+++ b/common/culture/cultures/ogre.txt
@@ -5,7 +5,7 @@
 		mediterranean_building_gfx
 		eastern_unit_gfx
 		
-		no_headgear_gfx
+		no_lowborn_headgear_gfx
 		ogre_clothing_gfx
 		ogre_hairstyles_gfx
 		orcish_beards_gfx

--- a/common/culture/cultures/troll.txt
+++ b/common/culture/cultures/troll.txt
@@ -1,13 +1,11 @@
 ﻿troll_group = { 
 	graphical_cultures = {
-		no_headgear_gfx
-		
 		african_building_gfx
 		mena_building_gfx
 		sub_sahran_unit_gfx
 		central_african_group_coa_gfx
 
-		no_headgear_gfx
+		no_lowborn_headgear_gfx
 		creature_troll_gfx
 		no_beard_gfx
 	}

--- a/common/scripted_triggers/00_clothing_triggers.txt
+++ b/common/scripted_triggers/00_clothing_triggers.txt
@@ -77,9 +77,6 @@ portrait_wear_armor_trigger = {
 
 
 portrait_wear_helmet_trigger = { # Different from Armor, as Counts+ should show their crowns!
-	# Warcraft
-	culture = { NOT = { has_graphical_culture = no_helmet_gfx } }
-	
 	OR = {
 		AND = {
 			is_ruler = yes

--- a/common/scripted_triggers/00_clothing_triggers.txt
+++ b/common/scripted_triggers/00_clothing_triggers.txt
@@ -77,6 +77,9 @@ portrait_wear_armor_trigger = {
 
 
 portrait_wear_helmet_trigger = { # Different from Armor, as Counts+ should show their crowns!
+	# Warcraft
+	culture = { NOT = { has_graphical_culture = no_helmet_gfx } }
+	
 	OR = {
 		AND = {
 			is_ruler = yes

--- a/common/scripted_triggers/wc_clothing_triggers.txt
+++ b/common/scripted_triggers/wc_clothing_triggers.txt
@@ -82,6 +82,14 @@ portrait_dwarven_clothing_trigger = {
 portrait_dwarven_clothing_spouse_trigger = {
 	culture = { has_graphical_culture = dwarf_clothing_gfx }
 }
+portrait_fp1_dwarven_clothing_trigger = {
+	has_fp1_dlc_trigger = yes
+	portrait_dwarven_clothing_trigger = yes
+}
+portrait_fp1_dwarven_clothing_spouse_trigger = {
+	has_fp1_dlc_trigger = yes
+	portrait_dwarven_clothing_spouse_trigger = yes
+}
 portrait_dwarven_hairstyles_trigger = {
 	scope:culture = { has_graphical_culture = dwarf_hairstyles_gfx }
 }

--- a/common/scripted_triggers/wc_portrait_triggers.txt
+++ b/common/scripted_triggers/wc_portrait_triggers.txt
@@ -29,7 +29,7 @@ has_no_clothes_trigger = {
 prefer_no_lowborn_headgear = {
 	OR = {
 		# Ears get in the way
-		culture = { has_graphical_culture = no_headgear_gfx }
+		culture = { has_graphical_culture = no_lowborn_headgear_gfx }
 		has_trait_with_flag = elven_family
 		is_race_no_gene_trigger = { RACE = creature_troll }
 		is_race_no_gene_trigger = { RACE = creature_goblin }
@@ -37,19 +37,9 @@ prefer_no_lowborn_headgear = {
 		is_race_no_gene_trigger = { RACE = creature_draenei }
 		is_race_no_gene_trigger = { RACE = creature_sayaadi }
 	}
-	
-	# Affects only counts or lower
-	duke_or_highter_clothing_trigger = no
-	trigger_if = {
-		limit = {
-			exists = primary_spouse
-			takes_spouse_clothing_trigger = yes
-		}
-		primary_spouse = { duke_or_highter_clothing_trigger = no }
-	}
 }
-prefer_no_crown = {
-	culture = { has_graphical_culture = no_crown_gfx }
+prefer_no_helmet = {
+	culture = { has_graphical_culture = no_helmet_gfx }
 }
 no_bald_trigger = {
 	portrait_high_elven_hairstyles_trigger = yes

--- a/common/scripted_triggers/wc_portrait_triggers.txt
+++ b/common/scripted_triggers/wc_portrait_triggers.txt
@@ -38,9 +38,6 @@ prefer_no_lowborn_headgear = {
 		is_race_no_gene_trigger = { RACE = creature_sayaadi }
 	}
 }
-prefer_no_helmet = {
-	culture = { has_graphical_culture = no_helmet_gfx }
-}
 no_bald_trigger = {
 	portrait_high_elven_hairstyles_trigger = yes
 }

--- a/gfx/portraits/portrait_modifiers/01_cloaks.txt
+++ b/gfx/portraits/portrait_modifiers/01_cloaks.txt
@@ -24,21 +24,11 @@ cloaks = {
 					portrait_high_elven_clothing_trigger = yes
 					portrait_goblin_clothing_trigger = yes
 					portrait_dwarven_clothing_trigger = yes
-					portrait_wildhammer_clothing_trigger = yes
 
 					portrait_western_clothing_trigger = yes
 					AND = {
 						portrait_northern_clothing_trigger = yes
-						OR = {
-							portrait_fp1_norse_clothing_trigger = no
-							AND = {
-								portrait_fp1_norse_clothing_trigger = yes
-								NOR = {
-									has_government = tribal_government
-									like_germanic_religion_trigger = yes
-								}
-							}
-						}
+						portrait_fp1_norse_clothing_trigger = no
 					}
 					portrait_byzantine_clothing_trigger = yes
 				}

--- a/gfx/portraits/portrait_modifiers/01_headgear.txt
+++ b/gfx/portraits/portrait_modifiers/01_headgear.txt
@@ -29,12 +29,6 @@ headgear = {
 				}
 			}
 			
-			# Warcraft
-			modifier = {
-				add = 1000
-				prefer_no_lowborn_headgear = yes
-			}
-			
 			modifier = {
 				factor = 0
 				OR = {
@@ -45,29 +39,6 @@ headgear = {
 						faith.religious_head = this
 					}
 				}
-			}
-
-			# Warcraft
-			modifier = {
-				add = 1000
-				trigger_if = {
-					limit = {
-						portrait_wear_armor_trigger = yes
-						scope:culture = { has_graphical_culture = wildhammer_coa_gfx }
-					}
-					# No helmet during war
-					prefer_no_crown = yes
-				}
-				
-				trigger_else_if = {
-					limit = {
-						scope:culture = { has_graphical_culture = wildhammer_coa_gfx }	
-					}
-					# Headgear during peacetime
-					prefer_no_crown = no
-				}
-				# Above conditions only apply to Wildhammer
-				trigger_else = { prefer_no_crown = yes }
 			}
 
 			# Refuses to wear a crown due to HighGod.
@@ -188,6 +159,12 @@ headgear = {
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
 				portrait_dde_hre_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -504,6 +481,12 @@ headgear = {
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
 				portrait_western_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -1067,6 +1050,12 @@ headgear = {
 				}
 				portrait_byzantine_clothing_spouse_trigger = yes
 			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
+			}
 		}
 	}
 
@@ -1428,6 +1417,12 @@ headgear = {
 					# Warcraft
 					portrait_draenei_clothing_trigger = yes
 				}
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -1834,6 +1829,12 @@ headgear = {
 				}
 				portrait_mena_clothing_spouse_trigger = yes
 			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
+			}
 		}
 	}
 
@@ -2169,6 +2170,12 @@ headgear = {
 				}
 				portrait_dde_abbasid_clothing_spouse_trigger = yes
 			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
+			}
 		}
 	}
 
@@ -2448,12 +2455,7 @@ headgear = {
 						has_monarchy_government_trigger = yes
 					}
 				}
-				OR = {
-					# Warcraft
-					portrait_night_elven_clothing_trigger = yes
-					
-					portrait_steppe_clothing_trigger = yes
-				}
+				portrait_steppe_clothing_trigger = yes
 			}
 			modifier = {
 				add = 20
@@ -2471,12 +2473,13 @@ headgear = {
 					}
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
-				OR = {
-					# Warcraft
-					portrait_night_elven_clothing_trigger = yes
-
-					portrait_steppe_clothing_spouse_trigger = yes
-				}
+				portrait_steppe_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -2519,12 +2522,7 @@ headgear = {
 							AND = { is_ruler = yes has_government = theocracy_government }
 						}
 						NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
-						OR = {
-							# Warcraft
-							portrait_night_elven_clothing_trigger = yes
-							
-							portrait_steppe_clothing_trigger = yes
-						}
+						portrait_steppe_clothing_trigger = yes
 					}
 					AND = {
 						exists = primary_spouse
@@ -2541,12 +2539,7 @@ headgear = {
 								}
 								AND = { is_ruler = yes has_government = theocracy_government }
 							}
-							OR = {
-								# Warcraft
-								portrait_night_elven_clothing_spouse_trigger = yes
-								
-								portrait_steppe_clothing_trigger = yes
-							}
+							portrait_steppe_clothing_trigger = yes
 						}
 					}
 				}
@@ -2593,12 +2586,7 @@ headgear = {
 							AND = { is_ruler = yes has_government = theocracy_government }
 						}
 						NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
-						OR = {
-							# Warcraft
-							portrait_night_elven_clothing_trigger = yes
-							
-							portrait_steppe_clothing_trigger = yes
-						}
+						portrait_steppe_clothing_trigger = yes
 					}
 					AND = {
 						exists = primary_spouse
@@ -2615,12 +2603,7 @@ headgear = {
 								}
 								AND = { is_ruler = yes has_government = theocracy_government }
 							}
-							OR = {
-								# Warcraft
-								portrait_night_elven_clothing_spouse_trigger = yes
-
-								portrait_steppe_clothing_spouse_trigger = yes
-							}
+							portrait_steppe_clothing_spouse_trigger = yes
 						}
 					}
 				}
@@ -2664,12 +2647,7 @@ headgear = {
 						}
 						NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
 						NOT = { has_government = republic_government }
-						OR = {
-							# Warcraft
-							portrait_night_elven_clothing_trigger = yes
-							
-							portrait_steppe_clothing_trigger = yes
-						}
+						portrait_steppe_clothing_trigger = yes
 					}
 					AND = {
 						exists = primary_spouse
@@ -2684,12 +2662,7 @@ headgear = {
 							}
 							NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
 							NOT = { has_government = republic_government }
-							OR = {
-								# Warcraft
-								portrait_night_elven_clothing_spouse_trigger = yes
-								
-								portrait_steppe_clothing_spouse_trigger = yes
-							}
+							portrait_steppe_clothing_spouse_trigger = yes
 						}
 					}
 				}
@@ -2808,6 +2781,12 @@ headgear = {
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
 				portrait_northern_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -2960,6 +2939,12 @@ headgear = {
 				 	AND = { is_ruler = yes has_government = theocracy_government }
 				}
 				portrait_fp1_norse_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -3198,11 +3183,8 @@ headgear = {
 				OR = {
 					portrait_fp1_norse_clothing_trigger = yes
 					
-					AND = {
-						#Warcraft
-						duke_or_highter_clothing_trigger = yes
-						portrait_dwarven_clothing_trigger = yes
-					}
+					# Warcraft
+					portrait_dwarven_clothing_trigger = yes
 				}
 				NOR = {
 				    AND = {
@@ -3216,7 +3198,7 @@ headgear = {
 				        like_christianity_religion_trigger = yes
 
 				        is_landed = no
-				        portrait_wear_armor_trigger = yes
+				        portrait_wear_helmet_trigger = yes
 				        exists = liege
 				        liege = {
 				            has_government = holy_order_government
@@ -3226,7 +3208,7 @@ headgear = {
 						# Warcraft
 				        like_christianity_religion_trigger = yes
 
-				        portrait_wear_armor_trigger = yes
+				        portrait_wear_helmet_trigger = yes
 				        OR = {
 				            any_character_war = {
 				                OR = {
@@ -3385,6 +3367,12 @@ headgear = {
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
 				portrait_african_clothing_spouse_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}
@@ -3691,14 +3679,20 @@ headgear = {
 				OR = {
 					AND = {
 						duke_or_highter_clothing_trigger = yes
-						portrait_high_elven_clothing_trigger = yes
+						OR = {
+							portrait_high_elven_clothing_trigger = yes
+							portrait_night_elven_clothing_trigger = yes
+						}
 					}
 					AND = {
 						exists = primary_spouse
 						takes_spouse_clothing_trigger = yes
 						primary_spouse = {
 							duke_or_highter_clothing_trigger = yes
-							portrait_high_elven_clothing_spouse_trigger = yes
+							OR = {
+								portrait_high_elven_clothing_spouse_trigger = yes
+								portrait_night_elven_clothing_spouse_trigger = yes
+							}
 						}
 					}
 				}
@@ -3745,6 +3739,12 @@ headgear = {
 				add = 50
 				commoner_clothing_trigger = yes
 				portrait_scourge_clothing_trigger = yes
+			}
+			
+			# Warcraft
+			modifier = {
+				multiply = 0
+				prefer_no_lowborn_headgear = yes
 			}
 		}
 	}

--- a/gfx/portraits/portrait_modifiers/01_headgear.txt
+++ b/gfx/portraits/portrait_modifiers/01_headgear.txt
@@ -23,10 +23,8 @@ headgear = {
 			base = 0
 			modifier = {
 				add = 1000
-				AND = {
-					# Deliberately not the "fully naked" one since dropping your crown's intended even if nudity is disabled
-					should_be_naked_trigger = yes
-				}
+				# Deliberately not the "fully naked" one since dropping your crown's intended even if nudity is disabled
+				should_be_naked_trigger = yes
 			}
 			
 			modifier = {
@@ -45,6 +43,13 @@ headgear = {
 			modifier = {
 				add = 110
 				has_character_modifier = fp1_abased_before_highgod_modifier
+			}
+			
+			# Warcraft
+			modifier = {
+				add = 1000
+				portrait_wildhammer_clothing_trigger = yes
+				portrait_wear_helmet_trigger = yes
 			}
 		}
 	}
@@ -626,18 +631,7 @@ headgear = {
 							
 							AND = {
 								portrait_northern_clothing_trigger = yes
-								OR = {
-									portrait_fp1_norse_clothing_trigger = no
-									AND = {
-										portrait_fp1_norse_clothing_trigger = yes
-										NOR = {
-											has_government = tribal_government
-
-											# Warcraft
-											like_germanic_religion_trigger = yes
-										}
-									}
-								}
+								portrait_fp1_norse_clothing_trigger = no
 							}
 						}
 					}
@@ -663,21 +657,9 @@ headgear = {
 								portrait_dwarven_clothing_spouse_trigger = yes
 
 								# Warcraft
-								# Vanilla bug: allows females of any culture wear western crowns
 								AND = {
 									portrait_northern_clothing_trigger = yes
-									OR = {
-										portrait_fp1_norse_clothing_spouse_trigger = no
-										AND = {
-											portrait_fp1_norse_clothing_spouse_trigger = yes
-											NOR = {
-												has_government = tribal_government
-
-												# Warcraft
-												like_germanic_religion_trigger = yes
-											}
-										}
-									}
+									portrait_fp1_norse_clothing_spouse_trigger = no
 								}
 							}
 						}
@@ -737,13 +719,6 @@ headgear = {
 								portrait_northern_clothing_trigger = yes
 								portrait_fp1_norse_clothing_trigger = no
 							}
-							AND = {
-								portrait_fp1_norse_clothing_trigger = yes
-								NOR = {
-									has_government = tribal_government
-									like_germanic_religion_trigger = yes
-								}
-							}
 						}
 					}
 					AND = {
@@ -773,13 +748,6 @@ headgear = {
 								AND = {
 									portrait_northern_clothing_spouse_trigger = yes
 									portrait_fp1_norse_clothing_spouse_trigger = no
-								}
-								AND = {
-									portrait_fp1_norse_clothing_spouse_trigger = yes
-									NOR = {
-										has_government = tribal_government
-										like_germanic_religion_trigger = yes
-									}
 								}
 							}
 						}

--- a/gfx/portraits/portrait_modifiers/01_headgear.txt
+++ b/gfx/portraits/portrait_modifiers/01_headgear.txt
@@ -627,7 +627,10 @@ headgear = {
 							portrait_western_clothing_trigger = yes
 							
 							#Warcraft
-							portrait_dwarven_clothing_trigger = yes
+							AND = {
+								portrait_dwarven_clothing_trigger = yes
+								portrait_fp1_dwarven_clothing_trigger = no
+							}
 							
 							AND = {
 								portrait_northern_clothing_trigger = yes
@@ -654,7 +657,10 @@ headgear = {
 								portrait_western_clothing_trigger = yes
 								
 								#Warcraft
-								portrait_dwarven_clothing_spouse_trigger = yes
+								AND = {
+									portrait_dwarven_clothing_spouse_trigger = yes
+									portrait_fp1_dwarven_clothing_trigger = no
+								}
 
 								# Warcraft
 								AND = {
@@ -713,7 +719,10 @@ headgear = {
 							portrait_western_clothing_trigger = yes
 							
 							#Warcraft
-							portrait_dwarven_clothing_trigger = yes
+							AND = {
+								portrait_dwarven_clothing_trigger = yes
+								portrait_fp1_dwarven_clothing_trigger = no
+							}
 							
 							AND = {
 								portrait_northern_clothing_trigger = yes
@@ -743,7 +752,10 @@ headgear = {
 								portrait_western_clothing_spouse_trigger = yes
 								
 								#Warcraft
-								portrait_dwarven_clothing_spouse_trigger = yes
+								AND = {
+									portrait_dwarven_clothing_spouse_trigger = yes
+									portrait_fp1_dwarven_clothing_spouse_trigger = no
+								}
 								
 								AND = {
 									portrait_northern_clothing_spouse_trigger = yes
@@ -2996,7 +3008,10 @@ headgear = {
 							AND = { is_ruler = yes has_government = theocracy_government }
 						}
 						NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
-						portrait_fp1_norse_clothing_trigger = yes
+						OR = {
+							portrait_fp1_norse_clothing_trigger = yes
+							portrait_fp1_dwarven_clothing_trigger = yes
+						}
 					}
 					AND = {
 						exists = primary_spouse
@@ -3013,7 +3028,10 @@ headgear = {
 								}
 								AND = { is_ruler = yes has_government = theocracy_government }
 							}
-							portrait_fp1_norse_clothing_spouse_trigger = yes
+							OR = {
+								portrait_fp1_norse_clothing_spouse_trigger = yes
+								portrait_fp1_dwarven_clothing_spouse_trigger = yes
+							}
 						}
 					}
 				}
@@ -3057,7 +3075,10 @@ headgear = {
 						}
 						NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
 						NOT = { has_government = republic_government }
-						portrait_fp1_norse_clothing_trigger = yes
+						OR = {
+							portrait_fp1_norse_clothing_trigger = yes
+							portrait_fp1_dwarven_clothing_trigger = yes
+						}
 					}
 					AND = {
 						exists = primary_spouse
@@ -3072,7 +3093,10 @@ headgear = {
 							}
 							NOT = { AND = { is_ruler = yes has_government = mercenary_government  } } # Blocked for mercenaries
 							NOT = { has_government = republic_government }
-							portrait_fp1_norse_clothing_spouse_trigger = yes
+							OR = {
+								portrait_fp1_norse_clothing_spouse_trigger = yes
+								portrait_fp1_dwarven_clothing_spouse_trigger = yes
+							}
 						}
 					}
 				}
@@ -3114,7 +3138,10 @@ headgear = {
 					has_government = republic_government
 					AND = { is_ruler = yes has_government = theocracy_government }
 				}
-				portrait_fp1_norse_clothing_trigger = yes
+				OR = {
+					portrait_fp1_norse_clothing_trigger = yes
+					portrait_fp1_dwarven_clothing_trigger = yes
+				}
 			}
 		}
 	}

--- a/gfx/portraits/portrait_modifiers/01_headgear.txt
+++ b/gfx/portraits/portrait_modifiers/01_headgear.txt
@@ -168,7 +168,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -490,7 +490,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -1033,7 +1033,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -1401,7 +1401,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -1812,7 +1812,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -2153,7 +2153,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -2458,7 +2458,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -2765,7 +2765,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -2923,7 +2923,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -3366,7 +3366,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}
@@ -3738,7 +3738,7 @@ headgear = {
 			
 			# Warcraft
 			modifier = {
-				multiply = 0
+				factor = 0
 				prefer_no_lowborn_headgear = yes
 			}
 		}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Night elves wear high elven crowns.
- Made sure the Wildhammers wear Northern Lords crowns and cloaks.
- Bronzebeards wear Northern Lords crowns.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added `no_lowborn_headgear_gfx` instead of `no_headgear_gfx`.
- Removed `no_crown_gfx` because it was barely used.
- Reworked `prefer_no_lowborn_headgear`. It's used in modifiers of commoner headgears.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
