### PR TITLE
1.5 cultural gfx adaptation

### DIFF
--- a/common/coat_of_arms/template_lists/color_lists.txt
+++ b/common/coat_of_arms/template_lists/color_lists.txt
@@ -262,6 +262,76 @@ color_lists = {
 			125 = "black"
 			250 = "black_empire_dark_red"
 		}
+		
+		###### Warcraft Culture Specific CoAs ######
+		### Humans ###
+		special_selection = { 
+			trigger = { azerothian_coa_trigger = yes }
+			25  = "cyan_silverhand"
+			250 = "blue"
+		}
+		special_selection = {
+			trigger = { lordaeronian_coa_trigger = yes }
+			15  = "purple"
+			25  = "cyan_silverhand"	
+			125 = "grey_dark"
+			250 = "blue"
+		}	
+		special_selection = {
+			trigger = { arathorian_coa_trigger = yes }
+			10  = "purple"
+			25  = "black"
+			25  = "brown_waycrest"
+			250 = "red"	
+		}
+		special_selection = {
+			trigger = { alteraci_coa_trigger = yes }
+			15   = "purple"			
+			250  = "black"
+			250  = "brown_dark"
+		}
+		special_selection = {
+			trigger = { gilnean_coa_trigger = yes }
+			25  = "brown"	
+			200 = "blue_gilneas"
+			250 = "black_gilneas"
+		}
+		special_selection = {
+			trigger = { tirassian_coa_trigger = yes }
+			15  = "blue_gilneas"
+			25  = "purple_tidesage"
+			25  = "brown_waycrest"
+			25  = "aqua_stormsong"
+			25	= "orange_ashvane"
+			250 = "green_kultiras"
+		}
+		special_selection = {
+			trigger = { theramoric_coa_trigger = yes }
+			10  = "brown_waycrest"
+			10  = "aqua_stormsong"
+			10	= "orange_ashvane"
+			10  = "purple"
+			30  = "green_kultiras"
+			250 = "blue"
+		}
+		special_selection = {
+			trigger = { dalaranian_coa_trigger = yes }
+			75  = "blue_light"			
+			250 = "purple"
+		}
+		special_selection = { 
+			trigger = { hillsbradian_coa_trigger = yes }
+			15  = "purple"
+			25  = "brown"
+			25  = "red"
+			25  = "green"
+			250 = "blue_light"
+		}
+		special_selection = {
+			trigger = { wastewander_coa_trigger = yes }
+			25  = "black"
+			250 = "yellow_wastewander"
+		}
 	}
 	metal_colors = {
 		24 = "yellow"
@@ -437,6 +507,61 @@ color_lists = {
 			trigger = { shadow_coa_trigger = yes }
 			125 = "white"
 			125 = "yellow"
+			250 = "red_light"
+		}
+		
+		###### Warcraft Culture Specific CoAs ######
+		### Humans ###
+		special_selection = {
+			trigger = { azerothian_coa_trigger = yes }
+			30  = "white"
+			250 = "yellow"
+		}
+		special_selection = {
+			trigger = { lordaeronian_coa_trigger = yes }
+			100  = "yellow"
+			250  = "white"
+		}	
+		special_selection = {
+			trigger = { arathorian_coa_trigger = yes }
+			50  = "yellow"
+			250 = "white"
+		}
+		special_selection = {
+			trigger = { alteraci_coa_trigger = yes }
+			50  = "yellow_alterac"
+			250 = "orange_light"
+		}
+		special_selection = {
+			trigger = { gilnean_coa_trigger = yes }	
+			75	  = "orange_light"
+			150   = "yellow"
+			250   = "red_gilneas"
+		}
+		special_selection = {
+			trigger = { tirassian_coa_trigger = yes }
+			50  = "yellow"
+			125	= "silver"
+			250 = "yellow_kultiras"
+		}
+		special_selection = {
+			trigger = { theramoric_coa_trigger = yes }
+			50  = "silver"
+			200 = "yellow_kultiras"
+			250 = "white"		
+		}
+		special_selection = {
+			trigger = { dalaranian_coa_trigger = yes }
+			125 = "silver"
+			250 = "white"
+		}
+		special_selection = { 
+			trigger = { hillsbradian_coa_trigger = yes }
+			250 = "white" #Lordaeron base culture
+		}
+		special_selection = {
+			trigger = { wastewander_coa_trigger = yes }
+			250 = "orange_light"
 			250 = "red_light"
 		}
 	}

--- a/common/coat_of_arms/template_lists/colored_emblem_lists.txt
+++ b/common/coat_of_arms/template_lists/colored_emblem_lists.txt
@@ -812,7 +812,7 @@ colored_emblem_texture_lists = {
 		### Arcane
 		special_selection = {
 			trigger = {
-				scope:faith.religion = religion:arcane_group
+				scope:faith = faith:kirin_tor
 			}
 			100 	= "ce_kirintor_eye.dds"
 		}

--- a/common/coat_of_arms/template_lists/colored_emblem_lists.txt
+++ b/common/coat_of_arms/template_lists/colored_emblem_lists.txt
@@ -192,26 +192,30 @@ colored_emblem_texture_lists = {
 			50 = "ce_african_habe.dds"
 			50 = "ce_antelope.dds"
 			
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = troll_coa_gfx } }
+			
 			# Warcraft
 			# Trollish
-			100 = "ce_troll_eagle_loa.dds"
-			100 = "ce_troll_mask_zuljin.dds"
-			100 = "ce_draktharon.dds"
-			100 = "ce_sandscalp.dds"
-			100 = "ce_senjin.dds"
-			100 = "ce_troll1.dds"
-			100 = "ce_troll2.dds"
-			100 = "ce_troll3.dds"
-			100 = "ce_troll4.dds"
-			100 = "ce_troll5.dds"
-			100 = "ce_troll6.dds"
-			100 = "ce_troll7.dds"
-			100 = "ce_troll8.dds"
-			100 = "ce_troll9.dds"
-			100 = "ce_troll10.dds"
-			100 = "ce_troll11.dds"
-			100 = "ce_troll12.dds"
-			100 = "ce_troll13.dds"
+			1000 = "ce_troll_eagle_loa.dds"
+			1000 = "ce_troll_mask_zuljin.dds"
+			1000 = "ce_draktharon.dds"
+			1000 = "ce_sandscalp.dds"
+			1000 = "ce_senjin.dds"
+			1000 = "ce_troll1.dds"
+			1000 = "ce_troll2.dds"
+			1000 = "ce_troll3.dds"
+			1000 = "ce_troll4.dds"
+			1000 = "ce_troll5.dds"
+			1000 = "ce_troll6.dds"
+			1000 = "ce_troll7.dds"
+			1000 = "ce_troll8.dds"
+			1000 = "ce_troll9.dds"
+			1000 = "ce_troll10.dds"
+			1000 = "ce_troll11.dds"
+			1000 = "ce_troll12.dds"
+			1000 = "ce_troll13.dds"
+			}
 		}
 		
 		# Christian
@@ -791,7 +795,19 @@ colored_emblem_texture_lists = {
 			100 	= "ce_ogre11.dds"
 			100 	= "ce_ogre12.dds"
 		}
-		
+		### Harpy
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = harpy_coa_gfx } }
+			1000    = "ce_wings.dds"
+			1000    = "ce_vol.dds"
+			1000    = "ce_demi_vol.dds"
+			1000    = "ce_owl.dds"
+			1000    = "ce_norse_bird_alstad.dds"
+			1000    = "ce_martlet.dds"
+			1000    = "ce_falcon.dds"
+			1000    = "ce_eagle_claw.dds"
+			1000    = "ce_eagle_head.dds"
+		}
 		
 		### Arcane
 		special_selection = {
@@ -2139,28 +2155,44 @@ colored_emblem_texture_lists = {
 			1000 = "ce_african_kara.dds"	
 			1000 = "ce_african_kile.dds"
 			1000 = "ce_african_karaka.dds"
-		}		
+		}
 		
-		# Warcraft
-		# Trollish
-		1000 = "ce_troll_eagle_loa.dds"
-		1000 = "ce_troll_mask_zuljin.dds"
-		1000 = "ce_draktharon.dds"
-		1000 = "ce_sandscalp.dds"
-		1000 = "ce_senjin.dds"
-		1000 = "ce_troll1.dds"
-		1000 = "ce_troll2.dds"
-		1000 = "ce_troll3.dds"
-		1000 = "ce_troll4.dds"
-		1000 = "ce_troll5.dds"
-		1000 = "ce_troll6.dds"
-		1000 = "ce_troll7.dds"
-		1000 = "ce_troll8.dds"
-		1000 = "ce_troll9.dds"
-		1000 = "ce_troll10.dds"
-		1000 = "ce_troll11.dds"
-		1000 = "ce_troll12.dds"
-		1000 = "ce_troll13.dds"
+		### Warcraft ###
+		### Harpy
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = harpy_coa_gfx } }
+			1000    = "ce_wings.dds"
+			1000    = "ce_vol.dds"
+			1000    = "ce_demi_vol.dds"
+			1000    = "ce_owl.dds"
+			1000    = "ce_norse_bird_alstad.dds"
+			1000    = "ce_martlet.dds"
+			1000    = "ce_falcon.dds"
+			1000    = "ce_eagle_claw.dds"
+			1000    = "ce_eagle_head.dds"
+		}
+		### Trollish
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = troll_coa_gfx } }
+			1000 = "ce_troll_eagle_loa.dds"
+			1000 = "ce_troll_mask_zuljin.dds"
+			1000 = "ce_draktharon.dds"
+			1000 = "ce_sandscalp.dds"
+			1000 = "ce_senjin.dds"
+			1000 = "ce_troll1.dds"
+			1000 = "ce_troll2.dds"
+			1000 = "ce_troll3.dds"
+			1000 = "ce_troll4.dds"
+			1000 = "ce_troll5.dds"
+			1000 = "ce_troll6.dds"
+			1000 = "ce_troll7.dds"
+			1000 = "ce_troll8.dds"
+			1000 = "ce_troll9.dds"
+			1000 = "ce_troll10.dds"
+			1000 = "ce_troll11.dds"
+			1000 = "ce_troll12.dds"
+			1000 = "ce_troll13.dds"
+		}
 	}	
 	african_geometrical_charge_list = {			
 		1000 = "ce_african_pattern_dancetty.dds"			

--- a/common/coat_of_arms/template_lists/colored_emblem_lists.txt
+++ b/common/coat_of_arms/template_lists/colored_emblem_lists.txt
@@ -628,8 +628,27 @@ colored_emblem_texture_lists = {
 			100 	= "ce_lordaeron.dds"
 		}
 		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = hillsbrad_coa_gfx } }	 #hillsbrad melting pot of migrant human cultures
+			100 	= "ce_lordaeron.dds"
+			100     = "wc_stormwind_lion.dds"
+			100     = "ce_gilneas_moon.dds"
+			100     = "ce_stromgarde_fist.dds"
+			100     = "ce_alteran_eagle.dds"
+			100     = "ce_kul_tiras.dds"
+			100     = "ce_kirintor_eye.dds"
+		}
+		special_selection = {
 			trigger = { scope:culture = { has_coa_gfx = tirassian_coa_gfx } }	
 			100 	= "ce_kul_tiras.dds"
+		}
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = theramoric_coa_gfx } }	
+			100 	= "ce_kul_tiras.dds"
+			100     = "ce_kirintor_eye.dds"
+		}
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = dalaranian_coa_gfx } }
+			100     = "ce_kirintor_eye.dds"
 		}
 		# Dwarven
 		special_selection = {
@@ -1471,6 +1490,11 @@ colored_emblem_texture_lists = {
 		special_selection = {
 			trigger = { scope:culture = { has_coa_gfx = tirassian_coa_gfx } }	
 			2000 	= "ce_kul_tiras.dds"
+		}
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = gilnean_coa_gfx } }	
+			2000 	= "ce_greymane.dds"
+			2000 	= "ce_gilneas_moon.dds"
 		}
 		# Dwarven
 		special_selection = {
@@ -2342,6 +2366,25 @@ colored_emblem_texture_lists = {
 		special_selection = {
 			trigger = { scope:culture = { has_coa_gfx = arathorian_coa_gfx } }	
 			300 	= "ce_stromgarde_fist.dds"
+		}
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = theramoric_coa_gfx } }	
+			300 	= "ce_kul_tiras.dds"
+			300     = "ce_kirintor_eye.dds"
+		}
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = dalaranian_coa_gfx } }
+			300     = "ce_kirintor_eye.dds"
+		}		
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = hillsbrad_coa_gfx } }	 #hillsbrad melting pot of migrant human cultures
+			300 	= "ce_lordaeron.dds"
+			300     = "wc_stormwind_lion.dds"
+			300     = "ce_gilneas_moon.dds"
+			300     = "ce_stromgarde_fist.dds"
+			300     = "ce_alteran_eagle.dds"
+			300     = "ce_kul_tiras.dds"
+			300     = "ce_kirintor_eye.dds"
 		}
 		# Dwarven
 		special_selection = {

--- a/common/coat_of_arms/template_lists/colored_emblem_lists.txt
+++ b/common/coat_of_arms/template_lists/colored_emblem_lists.txt
@@ -808,15 +808,133 @@ colored_emblem_texture_lists = {
 			1000    = "ce_eagle_claw.dds"
 			1000    = "ce_eagle_head.dds"
 		}
-		
-		### Arcane
+		### Druidic Group
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = druidic_coa_gfx } }
+			100    = "ce_antelope.dds"
+			100    = "ce_antler.dds"
+			100    = "ce_antler_pale.dds"
+			100    = "ce_antlers_attire.dds"
+			100    = "ce_attire.dds"
+			100    = "ce_bear_claw.dds"
+			100    = "ce_bear_head.dds"
+			100    = "ce_bear_passant.dds"		
+			100    = "ce_bear_rampant.dds"	
+			100    = "ce_boar_head.dds"
+			100    = "ce_boar_passant.dds"		
+			100    = "ce_boar_passant_02.dds"
+			100    = "ce_bull_head.dds"	
+			100    = "ce_bull_passant.dds"	
+			100    = "ce_bugle_horn_random.dds"
+			100    = "ce_chicots_saltire.dds"
+			100    = "ce_demi_vol.dds"
+			100    = "ce_eagle_claw.dds"
+			100    = "ce_eagle_head.dds"
+			100    = "ce_goat.dds"
+			100    = "ce_grape_tree.dds"
+			100    = "ce_griffin_head.dds"
+			100    = "ce_griffin_rampant.dds"	
+			100    = "ce_horn.dds"
+			100    = "ce_horse_rampant.dds"
+			100    = "ce_horse_statant.dds"
+			100    = "ce_owl.dds"
+			100    = "ce_panther.dds"
+			100    = "ce_peacock_01.dds"
+			100    = "ce_religion_custom_faith_6.dds"
+			100    = "ce_religion_magyar.dds"
+			100    = "ce_religion_waaqism.dds"
+			100    = "ce_religion_pagan_suomenusko.dds"
+			100    = "ce_squirrel.dds"
+			100    = "ce_stag.dds"
+			100    = "ce_swan.dds"
+			100    = "ce_tree.dds"
+			100    = "ce_wolf.dds"
+			100    = "ce_wolf_head.dds"
+			100    = "ce_wings.dds"
+			100    = "ce_vol.dds"
+			100    = "ce_wyvern.dds"	
+			100    = "ce_unicorn.dds"		
+
+				### Ancient
+				special_selection = {
+				trigger = { scope:culture = { has_coa_gfx = protector_coa_gfx } }
+				500    = "ce_yggdrasil.dds"
+				500    = "ce_yggdrasil_ockelbo.dds"
+				500    = "ce_tree.dds"
+				500    = "ce_religion_waaqism.dds"
+				500    = "ce_religion_custom_faith_6.dds"
+				500    = "ce_oak_leaf.dds"
+				500    = "ce_laurels.dds"
+				500    = "ce_religion_pagan_romuva.dds"
+				500    = "ce_rosetta_06.dds"
+				500    = "ce_rosetta_04.dds"
+				500    = "ce_rosetta_08.dds"
+			}
+		}
+		### Warcraft Religious CoAs ###
+		### Elunic # (Dryad and Night Elf) Lunar and Weaponry Motifs
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = elunic_coa_gfx } }
+			200    = "ce_arrow.dds"
+			200    = "ce_arrows_saltire.dds"
+			200    = "ce_bow.dds"		
+			200    = "ce_caltrop.dds"
+			200    = "ce_chalice.dds"
+			200    = "ce_chakratrisula.dds"
+			200    = "ce_circle.dds"
+			200    = "ce_crescent.dds"
+			200    = "ce_crescent_bone.dds"
+			200    = "ce_crescent_bone_checkered.dds"
+			200    = "ce_crescent_knot.dds"
+			200    = "ce_crescent_mask.dds"
+			200    = "ce_crescent_mask_02.dds"
+			200    = "ce_crescent_random.dds"
+			200    = "ce_cross_gringoly.dds"
+			200    = "ce_double_bow_islamic.dds"
+			200    = "ce_flaming_jewel.dds"
+			200    = "ce_india_small_crescent.dds"
+			200    = "ce_india_small_gammate_cross.dds"
+			200    = "ce_india_small_nandipada.dds"
+			200    = "ce_india_small_trisula.dds"
+			200    = "ce_mena_crescent.dds"
+			200    = "ce_mena_double_bow.dds"
+			200    = "ce_moon_flame.dds"
+			200    = "ce_moon_sun.dds"
+			200    = "ce_pagan_circle_frame.dds"
+			200    = "ce_norse_triquetra.dds"
+			200    = "ce_norse_triquetra_funbo.dds"
+			200    = "ce_pagan_circle_frame_02.dds"
+			200    = "ce_pagan_cross_yarovik.dds"
+			200    = "ce_pagan_jumis.dds"
+			200    = "ce_pagan_kolovrat_02.dds"
+			200    = "ce_pagan_star_04.dds"
+			200    = "ce_pagan_wolf_triskel.dds"
+			200    = "ce_polish_leliwa.dds"
+			200    = "ce_polish_odrovons.dds"
+			200    = "ce_polish_ogonczyk.dds"
+			200    = "ce_polish_orda.dds"
+			200    = "ce_religion_islam_asharism.dds"
+			200    = "ce_religion_islam_generic.dds"
+			200    = "ce_religion_islam_ismailism.dds"
+			200    = "ce_religion_pagan_zunist.dds"
+			200    = "ce_religion_pagan_tengri.dds"
+			200    = "ce_religion_sedism.dds"
+			200    = "ce_runic_circle_frame.dds"
+			200    = "ce_star_ishtar.dds"
+			200    = "ce_star_07.dds"			
+			200    = "ce_star_08.dds"	
+			200    = "ce_three_jewels.dds"
+			200    = "ce_trefoil_eretnid.dds"
+			200    = "ce_triskel_sassanian.dds"
+			200    = "ce_winged_arrow.dds"
+		}	
+		### Kirin Tor
 		special_selection = {
 			trigger = {
 				scope:faith = faith:kirin_tor
 			}
 			100 	= "ce_kirintor_eye.dds"
 		}
-		
 		### Death
 		special_selection = {
 			trigger = {
@@ -1268,7 +1386,7 @@ colored_emblem_texture_lists = {
 	# Generic symbolism (crescents, stars, crosses, knots, axes/hammers, runes & tamgha-like symbols)
 	# Here are still needed more : Wings, Winged Claws, Paws/Gambs, boats, bull head variants, norse designs (hugin & munin, fenrir, etc)
 	
-	pagan_single_charge_list = {
+	pagan_single_charge_list = {		#These weights effectively overwrite emblems in `charge`
 		1000 	= "ce_bull_head.dds"	
 		1000 	= "ce_bull_passant.dds"		
 		1000 	= "ce_bear_head.dds"
@@ -1754,6 +1872,22 @@ colored_emblem_texture_lists = {
 			10000 = "ce_rune_futhark_sol.dds"
 			10000 = "ce_rune_futhark_tyr.dds"
 			10000 = "ce_rune_futhark_bjarkan.dds"	
+		}
+		### Warcraft ###
+		### Ancient
+		special_selection = {
+			trigger = { scope:culture = { has_coa_gfx = protector_coa_gfx } }
+			2000    = "ce_yggdrasil.dds"
+			2000    = "ce_yggdrasil_ockelbo.dds"
+			2000    = "ce_tree.dds"
+			2000    = "ce_religion_waaqism.dds"
+			2000    = "ce_religion_custom_faith_6.dds"
+			2000    = "ce_oak_leaf.dds"
+			2000    = "ce_laurels.dds"
+			2000    = "ce_religion_pagan_romuva.dds"
+			2000    = "ce_rosetta_06.dds"
+			2000    = "ce_rosetta_04.dds"
+			2000    = "ce_rosetta_08.dds"
 		}
 	}
 	pagan_circle_frame_list = {	

--- a/common/culture/cultures/wc_agamagganic.txt
+++ b/common/culture/cultures/wc_agamagganic.txt
@@ -10,7 +10,7 @@
 
 	name_list = name_list_quilboar
 	
-	coa_gfx = { western_coa_gfx }
+	coa_gfx = { druidic_coa_gfx }
 	building_gfx = { western_building_gfx }
 	clothing_gfx = { creature_quilboar_gfx western_clothing_gfx }
 	unit_gfx = { western_unit_gfx }

--- a/common/culture/cultures/wc_arathi.txt
+++ b/common/culture/cultures/wc_arathi.txt
@@ -155,7 +155,7 @@ dalaranian = {
 	
 	name_list = name_list_dalaranian
 
-	coa_gfx = { western_coa_gfx } 
+	coa_gfx = { western_coa_gfx dalaranian_coa_gfx } 
 	building_gfx = { western_building_gfx } 
 	clothing_gfx = { creature_human_gfx western_clothing_gfx }  
 	unit_gfx = { western_unit_gfx } 		
@@ -197,7 +197,6 @@ baradin = {
 	}
 }
 
-
 hillsbrad = {
 	color = rgb { 255 240 204 }
 	
@@ -214,7 +213,7 @@ hillsbrad = {
 	
 	name_list = name_list_hillsbradian
 
-	coa_gfx = { western_coa_gfx } 
+	coa_gfx = { western_coa_gfx hillsbrad_coa_gfx } 
 	building_gfx = { western_building_gfx } 
 	clothing_gfx = { creature_human_gfx western_clothing_gfx }  
 	unit_gfx = { western_unit_gfx }  		

--- a/common/culture/cultures/wc_avianic.txt
+++ b/common/culture/cultures/wc_avianic.txt
@@ -10,8 +10,8 @@
 
 	name_list = name_list_harpy
 	
-	coa_gfx = { western_coa_gfx }
-	building_gfx = { western_building_gfx }
+	coa_gfx = { harpy_coa_gfx }
+	building_gfx = { indian_building_gfx }
 	clothing_gfx = { creature_harpy_gfx western_clothing_gfx }
 	unit_gfx = { western_unit_gfx }
 	

--- a/common/culture/cultures/wc_cenaric.txt
+++ b/common/culture/cultures/wc_cenaric.txt
@@ -10,10 +10,10 @@
 
 	name_list = name_list_dryad
 	
-	coa_gfx = { western_coa_gfx }
-	building_gfx = { western_building_gfx }
+	coa_gfx = { druidic_coa_gfx elunic_coa_gfx }
+	building_gfx = { indian_building_gfx }
 	clothing_gfx = { creature_dryad_gfx western_clothing_gfx }
-	unit_gfx = { western_unit_gfx }
+	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
 		10 = night_elven
@@ -32,10 +32,10 @@ frostnymph = {
 
 	name_list = name_list_frostnymph
 	
-	coa_gfx = { western_coa_gfx }
-	building_gfx = { western_building_gfx }
+	coa_gfx = { druidic_coa_gfx elunic_coa_gfx }
+	building_gfx = { indian_building_gfx }
 	clothing_gfx = { creature_frostnymph_gfx western_clothing_gfx }
-	unit_gfx = { western_unit_gfx }
+	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
 		10 = night_elven

--- a/common/culture/cultures/wc_darnassian.txt
+++ b/common/culture/cultures/wc_darnassian.txt
@@ -10,8 +10,8 @@
 
 	name_list = name_list_kal_dorei
 	
-	coa_gfx = { western_coa_gfx }
-	building_gfx = { western_building_gfx }
+	coa_gfx = { druidic_coa_gfx elunic_coa_gfx  }
+	building_gfx = { mediterranean_building_gfx }
 	clothing_gfx = { creature_night_elf_gfx night_elven_clothing_gfx no_headgear_gfx night_elven_beards_gfx no_crown_gfx high_elven_hairstyles_gfx }
 	unit_gfx = { western_unit_gfx }
 	
@@ -32,8 +32,8 @@ protector = {
 
 	name_list = name_list_protector
 	
-	coa_gfx = { western_coa_gfx }
-	building_gfx = { western_building_gfx }
+	coa_gfx = { protector_coa_gfx }
+	building_gfx = { indian_building_gfx }
 	clothing_gfx = { creature_protector_gfx night_elven_clothing_gfx }
 	unit_gfx = { western_unit_gfx }
 	

--- a/common/culture/cultures/wc_gilnean.txt
+++ b/common/culture/cultures/wc_gilnean.txt
@@ -72,7 +72,7 @@ theramore = {
 	
 	name_list = name_list_theramorian
 
-	coa_gfx = { tirassian_coa_gfx western_coa_gfx } 
+	coa_gfx = { theramoric_coa_gfx western_coa_gfx } 
 	building_gfx = { western_building_gfx } 
 	clothing_gfx = { creature_human_gfx western_clothing_gfx }  
 	unit_gfx = { western_unit_gfx } 		

--- a/common/culture/cultures/wc_highborne.txt
+++ b/common/culture/cultures/wc_highborne.txt
@@ -10,7 +10,7 @@
 
 	name_list = name_list_highborne
 	
-	coa_gfx = { western_coa_gfx }
+	coa_gfx = { elunic_coa_gfx }
 	building_gfx = { western_building_gfx }
 	clothing_gfx = { creature_highborne_gfx high_elven_clothing_gfx high_elven_hairstyles_gfx no_headgear_gfx high_elven_beards_gfx }
 	unit_gfx = { western_unit_gfx }
@@ -76,7 +76,7 @@ nightborne = {
 
 	name_list = name_list_sin_dorei
 	
-	coa_gfx = { western_coa_gfx high_elven_coa_gfx }
+	coa_gfx = { elunic_coa_gfx high_elven_coa_gfx }
 	building_gfx = { western_building_gfx }
 	clothing_gfx = { creature_nightborne_gfx high_elven_clothing_gfx high_elven_beards_gfx high_elven_hairstyles_gfx no_headgear_gfx }
 	unit_gfx = { western_unit_gfx }

--- a/common/culture/cultures/wc_jalgaric.txt
+++ b/common/culture/cultures/wc_jalgaric.txt
@@ -10,8 +10,8 @@
 	
 	name_list = name_list_furbolg
 	
-	coa_gfx = { western_coa_gfx } 
-	building_gfx = { western_building_gfx } 
+	coa_gfx = { druidic_coa_gfx } 
+	building_gfx = { steppe_building_gfx indian_building_gfx } 
 	clothing_gfx = { creature_furbolg_gfx western_clothing_gfx }  
 	unit_gfx = { western_unit_gfx }
 	

--- a/common/culture/cultures/wc_southern.txt
+++ b/common/culture/cultures/wc_southern.txt
@@ -33,7 +33,7 @@ wastewander = {
 	
 	name_list = name_list_wastewander
 
-	coa_gfx = { arabic_group_coa_gfx } 
+	coa_gfx = { arabic_group_coa_gfx wastewander_coa_gfx } 
 	building_gfx = { arabic_group_building_gfx mena_building_gfx } 
 	clothing_gfx = { creature_human_gfx dde_abbasid_clothing_gfx mena_clothing_gfx } 
 	unit_gfx = { mena_unit_gfx } 		

--- a/common/culture/cultures/wc_tauren.txt
+++ b/common/culture/cultures/wc_tauren.txt
@@ -10,7 +10,7 @@
 
 	name_list = name_list_tauren
 	
-	coa_gfx = { steppe_coa_gfx balto_finnic_group_coa_gfx western_coa_gfx }
+	coa_gfx = { druidic_coa_gfx }
 	building_gfx = { western_building_gfx }
 	clothing_gfx = { creature_tauren_gfx northern_clothing_gfx }
 	unit_gfx = { northern_unit_gfx }
@@ -35,7 +35,7 @@ highmountain = {
 
 	name_list = name_list_highmountain
 	
-	coa_gfx = { steppe_coa_gfx balto_finnic_group_coa_gfx western_coa_gfx }
+	coa_gfx = { druidic_coa_gfx }
 	building_gfx = { western_building_gfx }
 	clothing_gfx = { creature_highmountain_tauren_gfx northern_clothing_gfx }
 	unit_gfx = { northern_unit_gfx }

--- a/common/culture/cultures/wc_zulite.txt
+++ b/common/culture/cultures/wc_zulite.txt
@@ -10,7 +10,7 @@
 
 	name_list = name_list_zandalari
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -32,7 +32,7 @@ gurubashi = {
 
 	name_list = name_list_gurubashi
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -54,7 +54,7 @@ amani = {
 
 	name_list = name_list_amani
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -76,7 +76,7 @@ drakkari = {
 
 	name_list = name_list_drakkari
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx orcish_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -98,7 +98,7 @@ farraki = {
 
 	name_list = name_list_farraki
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -120,7 +120,7 @@ dark_troll = {
 
 	name_list = name_list_dark_troll
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }
@@ -142,7 +142,7 @@ blood_troll = {
 
 	name_list = name_list_nazmani
 	
-	coa_gfx = { central_african_group_coa_gfx }
+	coa_gfx = { central_african_group_coa_gfx troll_coa_gfx }
 	building_gfx = { african_building_gfx mena_building_gfx }
 	clothing_gfx = { creature_troll_gfx troll_clothing_gfx blood_troll_clothing_gfx no_headgear_gfx no_beard_gfx }
 	unit_gfx = { sub_sahran_unit_gfx }

--- a/common/named_colors/default_colors.txt
+++ b/common/named_colors/default_colors.txt
@@ -7,7 +7,7 @@ colors = {
 	black		= hsv {		0.1 	0.25 	0.10 	}
 	white		= hsv {		0.08 	0.02 	0.8 	}
 	purple 		= hsv {		0.9 	0.7 	0.35 	}
-	orange 		= hsv {		0.064 	1 	0.6 	}
+	orange 		= hsv {		0.064 	1 		0.6 	}
 	
 	grey 		= hsv {		0.0 	0.0 	0.50 	}
 	brown 		= hsv360 {	021 	074 	045		}
@@ -18,7 +18,11 @@ colors = {
 	
 	# Warcraft
 	red_light 		= hsv {		0.02 	0.8 	0.75 	}
-	purple_light 		= hsv {		0.9 	0.7 	0.65 	}
+	purple_light 	= hsv {		0.9 	0.7 	0.65 	}
+	grey_dark   	= hsv {     0.0     0.0     0.25    }
+	orange_light	= hsv {		0.064 	1		0.65 	}
+	silver 			= hsv {		0.00 	0.00 	0.65 	}
+	brown_dark 		= hsv360 {	021 	074 	025		}
 }
 
 	

--- a/common/named_colors/wc_colors.txt
+++ b/common/named_colors/wc_colors.txt
@@ -1,10 +1,23 @@
 colors = {
 	# used by coat of arms
 	brown_darkiron = rgb { 59 44 49 }
-	green_kultiras = rgb { 42 91 69 }
-	light_green_kultiras = rgb { 138 151 108 }
-	grey_gilneas = rgb { 50 50 50 }
+	
+	#Human Group
+	green_kultiras = rgb { 37 78 51 }		#k_kul_tiras
+	yellow_kultiras = rgb { 165 158 90 }	#k_kul_tiras
+	grey_gilneas = rgb { 33 40 56 }			#k_gilneas
+	red_gilneas = rgb { 129 19 19 }			#k_gilneas
+	black_gilneas = rgb { 50 50 50 }
+	blue_gilneas = rgb { 31 43 77 }
+	cyan_silverhand = rgb { 53 121 154 }
+	aqua_stormsong = rgb { 45 126 112 }
+	orange_ashvane = rgb { 141 58 43 }
+	brown_waycrest = rgb { 115 84 51 }
+	yellow_wastewander = rgb { 128 102 51 } 
+	yellow_alterac = rgb { 165 165 98 } 
+	purple_tidesage = rgb { 61 46 114 }
 
+	#Orc Group
 	brown_warsong = rgb { 69 18 22 }
 	purple_shadowmoon = rgb { 50 27 67 }
 	
@@ -13,8 +26,6 @@ colors = {
 	legion_dark_red = hsv { 0.95 0.75 0.25 }
 	legion_bright_green = hsv { 0.35 0.7 0.9 }
 	illidari_green = hsv { 0.4 0.35 0.3 }
-	black_harvest_dark_purple = hsv { 0.75 0.6 0.3 }
-	
 	black_harvest_dark_purple = hsv { 0.75 0.6 0.3 }
 	
 	forsaken_blue = hsv { 0.65 0.5 0.35 }

--- a/common/scripted_triggers/00_clothing_triggers.txt
+++ b/common/scripted_triggers/00_clothing_triggers.txt
@@ -43,6 +43,15 @@ should_be_topless_portrait_trigger = {
 		is_garrosh_trigger = yes
 
 		has_character_flag = single_combat_stripped_to_waist
+		
+		AND = {
+			OR = {
+				has_culture = culture:dryad
+				has_culture = culture:frostnymph
+				has_culture = culture:centaur
+			}
+			is_male = yes
+		}
 	}
 	should_show_nudity = yes
 }

--- a/common/scripted_triggers/wc_coa_triggers.txt
+++ b/common/scripted_triggers/wc_coa_triggers.txt
@@ -112,3 +112,37 @@ shadow_coa_trigger = {
 	}
 	scope:religion = { is_in_family = rf_shadow }
 }
+
+### Cultural CoA Colour Triggers ###
+# Human Group
+azerothian_coa_trigger = {
+	scope:culture = { has_coa_gfx = azerothian_coa_gfx }
+}
+lordaeronian_coa_trigger = { 
+	scope:culture = { has_coa_gfx = lordaeronian_coa_gfx }
+}
+arathorian_coa_trigger = { 
+	scope:culture = { has_coa_gfx = arathorian_coa_gfx }
+}
+alteraci_coa_trigger = {
+	scope:culture = { has_coa_gfx = alteraci_coa_gfx }
+}
+gilnean_coa_trigger = {
+	scope:culture = { has_coa_gfx = gilnean_coa_gfx }
+}
+
+tirassian_coa_trigger = {
+	scope:culture = { has_coa_gfx = tirassian_coa_gfx }
+}
+theramoric_coa_trigger = {
+	scope:culture = { has_coa_gfx = theramoric_coa_gfx }
+}
+dalaranian_coa_trigger = { 
+	scope:culture = { has_coa_gfx = dalaranian_coa_gfx }
+}
+hillsbradian_coa_trigger = { 
+	scope:culture = { has_coa_gfx = hillsbrad_coa_gfx }
+}
+wastewander_coa_trigger = {
+	scope:culture = { has_coa_gfx = wastewander_coa_gfx }
+}

--- a/common/scripted_triggers/wc_coa_triggers.txt
+++ b/common/scripted_triggers/wc_coa_triggers.txt
@@ -22,6 +22,13 @@ european_pagan_coa_trigger = {
 		like_baltic_religion_trigger = yes
 		like_finno_ugric_religion_trigger = yes
 		like_magyar_religion_trigger = yes
+		
+		#Warcraft
+		scope:culture = {
+			OR = {
+				has_coa_gfx = protector_coa_gfx
+			}
+		}
 	}
 	
 	disorder_coa_trigger = no
@@ -61,8 +68,8 @@ african_pagan_coa_trigger = {
 		#Warcraft
 		scope:culture = {
 			OR = {
-				has_graphical_culture = harpy_coa_gfx
-				has_graphical_culture = troll_coa_gfx
+				has_coa_gfx = harpy_coa_gfx
+				has_coa_gfx = troll_coa_gfx
 			}
 		}
 	}

--- a/common/scripted_triggers/wc_coa_triggers.txt
+++ b/common/scripted_triggers/wc_coa_triggers.txt
@@ -55,7 +55,17 @@ tamgha_coa_trigger = {
 	}
 }
 african_pagan_coa_trigger = {
-	coa_african_religion_trigger = yes
+	OR = {
+		coa_african_religion_trigger = yes
+		
+		#Warcraft
+		scope:culture = {
+			OR = {
+				has_graphical_culture = harpy_coa_gfx
+				has_graphical_culture = troll_coa_gfx
+			}
+		}
+	}
 }
 feudal_europe_coa_trigger = {
 	# Warcraft

--- a/localization/english/culture/wc_culture_gfx_l_english.yml
+++ b/localization/english/culture/wc_culture_gfx_l_english.yml
@@ -75,10 +75,6 @@
  tirassian_coa_gfx:0 "$tirassian$"
  azerothian_coa_gfx:0 "$azerothian$"
  gilnean_coa_gfx:0 "$gilnean$"
- dalaranian_coa_gfx:0 "$dalaranian$"
- hillsbrad_coa_gfx:0 "$hillsbradian$"
- theramoric_coa_gfx:0 "$theramoric$"
- wastewander_coa_gfx:0 "$wastewandrian$"
 
  orcish_coa_gfx:0 "$heritage_orcish_name$"
  orcish_clothing_gfx:0 "$heritage_orcish_name$"
@@ -155,3 +151,13 @@
  kvaldir_coa_gfx:0 "$kvaldir$"
  
  error_suppression_name:0 "Error Suppression"
+ 
+ dalaranian_coa_gfx:0 "$dalaran$"
+ hillsbrad_coa_gfx:0 "$hillsbrad$"
+ theramoric_coa_gfx:0 "$theramore$"
+ wastewander_coa_gfx:0 "$wastewander$"
+ harpy_coa_gfx:0 "$harpy$"
+ troll_coa_gfx:0 "$troll$"
+ druidic_coa_gfx:0 "$druidic$"
+ elunic_coa_gfx:0 "$elunic$"
+ protector_coa_gfx:0 "$protector$"

--- a/localization/english/culture/wc_culture_gfx_l_english.yml
+++ b/localization/english/culture/wc_culture_gfx_l_english.yml
@@ -75,6 +75,10 @@
  tirassian_coa_gfx:0 "$tirassian$"
  azerothian_coa_gfx:0 "$azerothian$"
  gilnean_coa_gfx:0 "$gilnean$"
+ dalaranian_coa_gfx:0 "$dalaranian$"
+ hillsbrad_coa_gfx:0 "$hillsbradian$"
+ theramoric_coa_gfx:0 "$theramoric$"
+ wastewander_coa_gfx:0 "$wastewandrian$"
 
  orcish_coa_gfx:0 "$heritage_orcish_name$"
  orcish_clothing_gfx:0 "$heritage_orcish_name$"

--- a/localization/english/names/wc_character_names_l_english.yml
+++ b/localization/english/names/wc_character_names_l_english.yml
@@ -16867,4 +16867,4 @@
  Thrall:0 "Thrall"
  Golmash:0 "Golmash"
  Li_Li:0 "Li Li"
- Malganis:0 "Mal'ganis"
+ Mal'ganis:0 "Mal'ganis"

--- a/localization/english/names/wc_character_names_l_english.yml
+++ b/localization/english/names/wc_character_names_l_english.yml
@@ -16867,3 +16867,4 @@
  Thrall:0 "Thrall"
  Golmash:0 "Golmash"
  Li_Li:0 "Li Li"
+ Malganis:0 "Mal'ganis"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:

**Supercedes #851 and #868.**

### CoA GFX Colours

Added colour weights to human culture CoAs. A higher weight number corresponds to a higher probability of selection.
Below are the custom weights. These do not include include the base templates for normal and metal colours.

<details>
<summary> Click to show details </summary>

- **Stormwind**
  - Main Colours
    - Cyan Silverhand
    - Blue
  - Emblem Colours
    - White
    - Yellow
- **Lordaeron**
  - Main Colours
    - Purple
    - Cyan Silverhand
    - Grey Dark
    - Blue
  - Emblem Colours
    - Yellow
	- White
- **Arathor**
  - Main Colours
    - Purple
	- Black
	- Brown Waycrest
	- Red
  - Emblem Colours
    - Yellow 
	- White
- **Alterac**
  - Main Colours
    - Purple
	- Black
	- Brown Dark
  - Emblem Colours
    - Yellow Alterac
	- Orange Light
- **Gilneas**
  - Main Colours
	- Brown
	- Blue Gilneas
	- Black Gilneas
  - Emblem Colours
    - Orange Light
	- Yellow
	- Red Gilneas
- **Kul Tiras**
  - Main Colours
	- Blue Gilneas
	- Purple Tidesage
	- Brown Waycrest
	- Aqua Stormsong
	- Orange Ashvane
	- Green Kultiras
  - Emblem Colours
	- Yellow
	- Silver
	- Yellow Kultiras
- **Theramore**
  - Main Colours
    - Brown Waycrest
	- Aqua Stormsong
	- Orange Ashvane
	- Purple
	- Green Kultiras
	- Blue
  - Emblem Colours
    - Silver
	- Yellow Kultiras
	- White
- **Dalaran/Kirin Tor**
 - Main Colours
	- Blue Light
	- Purple
  - Emblem Colours
	- Silver
	- White
- **Hillsbrad**
  - Main Colours
    - Purple
	- Red
	- Brown
	- Green
	- Blue Light	
  - Emblem Colours
	- White
- **Wastewander**
  - Main Colours
      - Black
	  - Yellow Wastewander
  - Emblem Colours
      - Orange Light
	  - Red Light

</details>

### Cultural GFX

Comprehensive CoA and Building cultural graphics overhaul for almost every culture group (Orcs notable exception). 
  - Clothing should be addressed in a separate PR.
  - New CoA gfx assembled using vanilla emblems; further additions of custom wc emblem .dds is optimal.
  
<details>
<summary> Click to Show: Added custom CoA gfx:</summary>

  - Ancient (Pagan symbols/Tree/Animal motifs)
  - Dryad (Lunar and animal motifs)
  - Night Elf (Lunar and animal motifs)
  - Highborne and Nightborne (Lunar motifs)
  - Harpy (African pagan and avian motifs)
  - Arakkoa (African pagan and avian motifs)
  - Furbolg (Animal motifs)
  - Gnoll (Pagan symbols and feudal Animal heraldry)
  - Kobold (Pagan symbols and feudal Animal heraldry)
  - Quilboar (Pagan african and animal motifs)
  - Tauren (Pagan symbols and animal motifs)
  - Trogg (Pagan symbols and feudal Animal heraldry)
  - Tuskar (Scandanavian (Not Viking) lists, Pagan symbols and feudal Animal heraldry)
 Note[^3]

</details>

<details>
<summary> Click to Show: New vanilla CoA additions: </summary> 

  - Centaur (Steppe)
  - Draenei (Zoroastrianism)
  - Dragon (Byzantine and Welsh)
  - Murloc (African Pagan)
  - Quilboar (African Pagan)
  - Titanforged (Byzantine)
  - Titan (Byzantine)
Note[^4]

</details>
  
<details>
<summary> Click to Show: Added building gfx: </summary>
 
- Indian[^1]
    - Ancient
    - Dryad
    - Harpy 
    - Arakkoa
    - Draenei
    - Satyr
    - Furbolg
    - Murloc
    - Tauren
    - Highmountain
- Steppe[^2]
    - Centaur
    - Furbolg
    - Tauren
    - Highmountain
    - Grummle
- African[^2]
    - Naga
    - Gnoll
    - Kobold 
    - Quilboar
    - Tauren
    - Highmountain
    - Trogg
    - Vulpera
- MENA
    - Centaur
    - Aqir 
    - Arakkoa
    - Gnoll
    - Goblin
    - Murloc
    - Quilboar
    - Shathyar
    - Tolvir
    - Tortollan
    - Trogg
    - Vulpera
- Mediterranean
    - Aqir
    - Dragon
    - Elves
    - Naga
    - Shathyar
    - Tolvir
    - Titan
- Norse
    - Taunka
    - Tuskar
Note:[^5]

</details>

<details>
<summary> Click to Show: Updated unit gfx </summary>

  - Centaur -> mongol 
  - Tuskar -> northern

</details>

<details>
<summary>Click to Show: Updated clothing gfx:</summary>

  - Tuskar -> northern 

</details>

### Misc
- Moved Kirin Tor emblem from Arcane Group to Kirin Tor faith
- Males of the Centaur Group and Dryad Group are now topless.
- Added localisation for Mal'ganis name.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:

### Cultural GFX
Closes #710.

### CoA GFX Colours
**Testing human changes; will extend to other culture groups once reviewed.**

Added cultural specific colours to wc_colors.txt and default_colors.txt.
Added coa gfx for dalaran, hillsbrad, theramore and wastewander.
  - Added Dalaran, Hillsbrad and Thereamore to 'charges' and 'hr_charges'
  - Added Gilneas to 'pagan_single_charge_list'
Added associated coa gfx triggers  

- Dalaran emblem graphics: 
"ce_kirintor_eye.dds"

- Hillsbrad emblem graphics: 
"ce_lordaeron.dds"
"wc_stormwind_lion.dds"
"ce_gilneas_moon.dds"
"ce_stromgarde_fist.dds"
"ce_alteran_eagle.dds"
"ce_kul_tiras.dds"
"ce_kirintor_eye.dds"

- Theramore emblem graphics: 
"ce_kul_tiras.dds"
"ce_kirintor_eye.dds"

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:

### Cultural GFX
Check for correct graphical assignments for each affected culture in the changelog. 

### CoA GFX Colours
Look for generated minor nobles and/or run the game long enough that ahistorical human CoAs begin cropping up. Check for increased frequency of colours as specified below. Colour codes can be found within the `default_colours.txt` and `wc_colors.txt`.

<details>
<summary> Click for example </summary>

![image](https://user-images.githubusercontent.com/77478662/149676381-3ec82286-3ccf-4871-b4c3-77b937396051.png)

</details>

[^1]: Indian Tribal buildings are stilted, wooden constructions that are relatively exposed. ,making them suited to airborne, aquatic and more primitive tribal cultures.
[^2]: African and Steppe gfx only apply in the Tribal Era, hence why cultures with them also have another gfx for when/if they feudalise.
[^3]: Some of these cultures share custom gfx.
[^4]: Some of these use repurposed emblem lists.
[^5]: Requires Northern Lords DLC