### PR TITLE
Sylvanas' Possessed Vassals

### DIFF
--- a/common/dynasties/12000_gnoll.txt
+++ b/common/dynasties/12000_gnoll.txt
@@ -25,7 +25,7 @@
 12022 = {name = "dynn_Zesthands" culture=gnoll}
 12023 = {name = "dynn_Scuztoe" culture=gnoll}
 12024 = {name = "dynn_Claywatch" culture=gnoll}
-12025 = {name = "dynn_Loosedeath" culture=gnoll}
+12025 = {name = "dynn_Loosedeath" culture=gnoll} #Rothide by 608
 12026 = {name = "dynn_Dreckhand" culture=gnoll}
 12027 = {name = "dynn_Zesttooth" culture=gnoll}
 12028 = {name = "dynn_Woefrown" culture=gnoll} #Generated

--- a/common/nicknames/wc_nicknames.txt
+++ b/common/nicknames/wc_nicknames.txt
@@ -53,6 +53,7 @@ nick_the_twisted = {}
 nick_the_patriarch = {}
 nick_the_flagellant = {}
 nick_the_bloodcursed = {}
+nick_the_puddlelord = {}
 
 ### From Lifestyle
 nick_the_ice_hearted = {}

--- a/common/scripted_triggers/wc_maa_triggers.txt
+++ b/common/scripted_triggers/wc_maa_triggers.txt
@@ -150,7 +150,6 @@ is_giant_culture_trigger = {
 		culture_group = culture_group:ancient_group
 		culture_group = culture_group:shathyar_group
 		culture_group = culture_group:magnataur_group
-		culture_group = culture_group:ogre_group
 		scope:culture = culture:storm_giant
 		scope:culture = culture:titan
 		scope:culture = culture:frozen_giant

--- a/common/scripted_triggers/wc_maa_triggers.txt
+++ b/common/scripted_triggers/wc_maa_triggers.txt
@@ -150,6 +150,7 @@ is_giant_culture_trigger = {
 		culture_group = culture_group:ancient_group
 		culture_group = culture_group:shathyar_group
 		culture_group = culture_group:magnataur_group
+		culture_group = culture_group:ogre_group
 		scope:culture = culture:storm_giant
 		scope:culture = culture:titan
 		scope:culture = culture:frozen_giant

--- a/history/characters/29000_gnoll.txt
+++ b/history/characters/29000_gnoll.txt
@@ -275,7 +275,7 @@
 
 #dynasty=12008
 29025={
-	name=Snarlmane
+	name=Ripsnarl
 	dynasty=12008
 	culture=gnoll religion=primitive_shamanism
 	martial=7 diplomacy=4 stewardship=7 intrigue=6 learning=6
@@ -1602,12 +1602,12 @@
 	584.10.25={ death=yes }
 }
 29220={
-	name=Gorp
+	name=Snarlmane
 	dynasty=12025
 	culture=gnoll religion=primitive_shamanism
 	martial=8 diplomacy=2 stewardship=6 intrigue=6 learning=6
-	trait=education_martial_2 trait=physique_good_3 trait=sadistic trait=just
-	trait=content
+	trait=sadistic trait=just trait=wrathful
+	trait=education_martial_2 trait=physique_good_3 trait=overseer
 	disallow_random_traits = yes
 	father=29219
 	584.6.9={ birth=yes trait=creature_gnoll employer=29038 add_pressed_claim=c_dawning_isles }
@@ -1620,8 +1620,17 @@
 		# trait=physical_lifestyle_endurance_3
 		# trait=physical_lifestyle_strength_3
 	}
-	603.7.1={
+	605.5.5={ #Possessed by banshee of Sylvanas
+		employer=42076
+		trait=possessed_1
+	}
+	608.1.7={ #Scourged and joins Rothide at Fenris Isle
 		trait=being_undead
+		remove_trait=possessed_1
+		remove_hook={
+			target = character:29220
+			type = loyalty_hook
+		}
 		employer=59171
 		religion=death_god
 		effect={

--- a/history/characters/34000_murloc.txt
+++ b/history/characters/34000_murloc.txt
@@ -499,6 +499,29 @@
 	552.1.12={ birth=yes trait=creature_murloc }
 	606.11.3={ death=yes }
 }
+34051={
+	name=Mrrmgrhl
+	dynasty=6013
+	culture=murloc religion=water_deities
+	martial=4 diplomacy=5 stewardship=5 intrigue=5 learning=6
+	trait=education_learning_2 trait=arrogant trait=patient trait=ambitious
+	trait=giant
+	disallow_random_traits = yes
+	579.10.1={ 
+		birth=yes 
+		trait=creature_murloc 
+		employer=34050 
+	}
+	602.4.17={ 
+		give_nickname=nick_the_puddlelord
+		trait=forder
+	}
+	605.5.5={ #Possessed by banshee of Sylvanas
+		employer=42076
+		trait=possessed_1
+	}
+	608.11.18={ death=yes }
+}
 #dynasty=6014 WoTTH ( War of the Three Hammers & Gnoll War )
 34100={
 	name=Hmlmrl

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1132,6 +1132,24 @@
 			set_relation_rival = character:60003 #Arthas
 			#spawn_colonial_troops_effect = yes
 			#spawn_small_colonial_troops_effect = yes
+			
+			#Possessed Snarlhide, Mug'thol, Mrrmgrhl and Zul'rogg - Prevents hostile schemes
+			add_hook_no_toast = {
+				target = character:29220
+				type = loyalty_hook
+			}
+			add_hook_no_toast = {
+				target = character:52057
+				type = loyalty_hook
+			}
+			add_hook_no_toast = {
+				target = character:56008
+				type = loyalty_hook
+			}
+			add_hook_no_toast = {
+				target = character:34051
+				type = loyalty_hook
+			}
 		}
 	}
 	620.4.5={ death=yes }

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1143,7 +1143,7 @@
 				type = loyalty_hook
 			}
 			add_hook_no_toast = {
-				target = character:56008	#Zul'rogg
+				target = character:zulrogg	#Zul'rogg
 				type = loyalty_hook
 			}
 			add_hook_no_toast = {

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1133,21 +1133,25 @@
 			#spawn_colonial_troops_effect = yes
 			#spawn_small_colonial_troops_effect = yes
 			
-			#Possessed Snarlhide, Mug'thol, Mrrmgrhl and Zul'rogg - Prevents hostile schemes
+			#Prevents hostile schemes by possessed vassals
 			add_hook_no_toast = {
-				target = character:29220
+				target = character:29220	#Snarlhide
 				type = loyalty_hook
 			}
 			add_hook_no_toast = {
-				target = character:52057
+				target = character:52057	#Mug'thol
 				type = loyalty_hook
 			}
 			add_hook_no_toast = {
-				target = character:56008
+				target = character:56008	#Zul'rogg
 				type = loyalty_hook
 			}
 			add_hook_no_toast = {
-				target = character:34051
+				target = character:34051	#Mrrmgrhl
+				type = loyalty_hook
+			}
+			add_hook_no_toast = {
+				target = character:60675	#Blackthorn
 				type = loyalty_hook
 			}
 		}

--- a/history/characters/52000_ogre.txt
+++ b/history/characters/52000_ogre.txt
@@ -119,12 +119,16 @@
 	dynasty=42000
 	culture=ogre religion=gorgog_worship
 	martial=6 diplomacy=8 stewardship=5 intrigue=4 learning=6
-	trait=education_martial_3 trait=trusting trait=brave trait=wrathful
+	trait=education_martial_3 trait=stubborn trait=brave trait=arbitrary
+	trait=adventurer
 	disallow_random_traits = yes
 	father=52051	#Bo'kar
 	572.4.4={ 
 		birth=yes trait=creature_ogre 
 		effect = { make_important_lore_character_effect = yes }
+	}
+	604.3.10={
+		trait=possessed_1
 	}
 	665.2.18={ death=yes }
 }

--- a/history/characters/52000_ogre.txt
+++ b/history/characters/52000_ogre.txt
@@ -127,8 +127,15 @@
 		birth=yes trait=creature_ogre 
 		effect = { make_important_lore_character_effect = yes }
 	}
-	604.3.10={
+	604.3.10={ #Possessed by banshee of Sylvanas
 		trait=possessed_1
+	}
+	608.12.22={ #Crown of Will breaks possession
+		remove_trait=possessed_1
+		remove_hook={
+			target = character:52057 
+			type = loyalty_hook
+		}
 	}
 	665.2.18={ death=yes }
 }

--- a/history/characters/56000_mossflayer.txt
+++ b/history/characters/56000_mossflayer.txt
@@ -68,3 +68,20 @@
 	561.6.12={ birth=yes trait=creature_troll }
 	612.1.24={ death=yes }
 }
+56008={
+	name=Zul'rogg
+	culture=amani religion=amism
+	martial=7 diplomacy=6 stewardship=5 intrigue=6 learning=4
+	trait=education_martial_2 trait=just trait=zealous trait=vengeful
+	trait=hunter_2 trait=viking
+	disallow_random_traits = yes
+	577.8.24={ 
+		birth=yes trait=creature_troll
+		employer=57150
+	}
+	605.5.5={ #Possessed by banshee of Sylvanas
+		employer=42076
+		trait=possessed_1
+	}
+	608.7.13={ death=yes }
+}

--- a/history/characters/56000_mossflayer.txt
+++ b/history/characters/56000_mossflayer.txt
@@ -68,7 +68,7 @@
 	561.6.12={ birth=yes trait=creature_troll }
 	612.1.24={ death=yes }
 }
-56008={
+zulrogg={
 	name=Zul'rogg
 	culture=amani religion=amism
 	martial=7 diplomacy=6 stewardship=5 intrigue=6 learning=4

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -4256,7 +4256,7 @@
 	605.4.21={ 
 		religion = forsaken_cult
 		trait = heresiarch
-		trait=lunatic_1
+		trait=possessed_1
 		effect = { 
 			add_opinion = { modifier = loyal_servant target = character:42076 } 
 		}

--- a/history/cultures/ogre_group.txt
+++ b/history/cultures/ogre_group.txt
@@ -5,7 +5,7 @@
 	#
 	discover_innovation = innovation_casus_belli 
 	#
-	discover_innovation = innovation_taming_the_skies
+	discover_innovation = innovation_large_soldiers
 }
 270.1.1 = {
  	discover_innovation = innovation_barracks 

--- a/history/titles/00_k_alterac.txt
+++ b/history/titles/00_k_alterac.txt
@@ -203,7 +203,14 @@ c_dandred = {
 	603.1.1={
 		holder=52057
 	}
+	# Possessed by one of Sylvanas' banshees
 	605.3.10={
+		liege=d_brill
 		# set_tribute_suzerain = { who = d_brill type = permanent }
+	}
+	#Obtains the Crown of Will
+	608.12.22={
+		liege=0
+		# Add Crown of Will artifact (Also removes possessed trait)
 	}
 }

--- a/history/titles/00_k_lordaeron.txt
+++ b/history/titles/00_k_lordaeron.txt
@@ -325,15 +325,18 @@ c_riverborn = {
 	}
 	#Barovs take place
 	554.3.25={holder=60009}
-	#Barovs lose place
+	#Barovs lose place and gnolls move in
 	603.6.1={
-		holder = 60037
+		holder = 29220	#Snarlmane[12025]
 		liege = 0
 	}
 	#Joins Sylvanas' forces
 	605.5.5={
 		liege=d_brill
-		holder=42076 #Sylvanas[20016]
+	}
+	#Snarlmane scourged, forces defeated and flees to Fenris Isle
+	608.1.7={
+		holder=0
 	}
 }
 c_nightmare_vale = {

--- a/history/titles/00_k_lordaeron.txt
+++ b/history/titles/00_k_lordaeron.txt
@@ -336,7 +336,7 @@ c_riverborn = {
 	}
 	#Snarlmane scourged, forces defeated and flees to Fenris Isle
 	608.1.7={
-		holder=0
+		holder=42076 #Sylvanas[20016]
 	}
 }
 c_nightmare_vale = {

--- a/localization/english/names/wc_character_names_l_english.yml
+++ b/localization/english/names/wc_character_names_l_english.yml
@@ -18359,3 +18359,6 @@
 
  Lyra:0 "Lyra"
  Flynn:0 "Flynn"
+ Zul'rogg:0 "Zul'rogg"
+ Mrrmgrhl:0 "Mrrmgrhl"
+ Ripsnarl:0 "Ripsnarl"

--- a/localization/english/wc_nicknames_l_english.yml
+++ b/localization/english/wc_nicknames_l_english.yml
@@ -97,3 +97,5 @@
  nick_the_patriarch:0 "the Patriarch"
  nick_the_flagellant:0 "the Flagellant"
  nick_the_bloodcursed:0 "the Bloodcursed"
+ 
+ nick_the_puddlelord:0 "the Puddle Lord"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Mug'thol vassalised by Sylvanas.
- Snarlmane now holds c_riverborn by 605 bookmark as Sylvanas' vassal.
- Added Zul'rogg and Puddle Lord Mrrmgrhl to Sylvanas' court for 605 bookmark.
- Updated aforementioned characters with possessed trait.
- Added strong loyalty hooks on WC3 possessed characters to Sylvanas, simulating possession and blocking hostile schemes.

### Misc
- Ogre culture group now has `large soldiers` innovation researched by all bookmarks.
- Ogre culture group blocked from researching `taming the skies` (Aerial MaA)

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
Closes #649 

- Added remove_hook command to Snarlmane and Mug'thol character histories at future dates to reflect Snarlmane's later scourging and Mug'thol obtaining the Crown of Will, thus breaking free.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Hooked characters should not be able to initiate hostile schemes against Sylvanas.
- Is Sylvanas' consistently stronger due to having extra vassal? Feudal contract can be tweaked for balance.