### PR TITLE
fix: missing localisation keys

### DIFF
--- a/localization/english/wc_portraits_l_english.yml
+++ b/localization/english/wc_portraits_l_english.yml
@@ -19,6 +19,8 @@
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0:0 "Thin Long Eyebrows"
  PORTRAIT_MODIFIER_custom_special_eyebrows_female_high_elven_eyebrows_0:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0$"
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_dwarven_eyebrows_0:0 "Bushy Eyebrows"
+ PORTRAIT_MODIFIER_custom_special_eyebrows_boy_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
+ PORTRAIT_MODIFIER_custom_special_eyebrows_girl_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
 
  #Dwarven Ethnicities
  dwarven_ethnicity:0 "Old Dwarven"
@@ -64,6 +66,9 @@
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_0:0 "Small Upward"
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_1:0 "Small Forward"
 
+ PORTRAIT_MODIFIER_custom_static_tusks_boy_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+ PORTRAIT_MODIFIER_custom_static_tusks_girl_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+
  special_eyes:0 "Eye Type"
  PORTRAIT_MODIFIER_custom_special_eyes:0 "$special_eyes$"
  RULER_DESIGNER_CATEGORY_special_eye:0 "$special_eyes$"
@@ -103,6 +108,9 @@
 
  PORTRAIT_MODIFIER_custom_horns_male_ogre_horns_2:0 "One Broken"
  PORTRAIT_MODIFIER_custom_horns_female_ogre_horns_2:0 "One Broken"
+
+ PORTRAIT_MODIFIER_custom_horns_boy_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
+ PORTRAIT_MODIFIER_custom_horns_girl_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
 
  ogre_ethnicity:0 "Ogre"
 

--- a/localization/french/wc_portraits_l_french.yml
+++ b/localization/french/wc_portraits_l_french.yml
@@ -19,7 +19,9 @@
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0:0 "Long Sourcils Fins"
  PORTRAIT_MODIFIER_custom_special_eyebrows_female_high_elven_eyebrows_0:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0$"
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_dwarven_eyebrows_0:0 "Sourcils Broussailleux"
- 
+ PORTRAIT_MODIFIER_custom_special_eyebrows_boy_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
+ PORTRAIT_MODIFIER_custom_special_eyebrows_girl_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
+
  #Dwarven Ethnicities
  dwarven_ethnicity:0 "Nain Ancestral"
  bronzebeard_ethnicity:0 "Nain Barbe-de-Bronze"
@@ -64,6 +66,9 @@
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_0:0 "Grosses Vers le Haut"
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_1:0 "Petites Vers le Haut"
  
+ PORTRAIT_MODIFIER_custom_static_tusks_boy_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+ PORTRAIT_MODIFIER_custom_static_tusks_girl_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+
  special_eyes:0 "Yeux Spéciaux"
  PORTRAIT_MODIFIER_custom_special_eyes:0 "$special_eyes$"
  RULER_DESIGNER_CATEGORY_special_eye:0 "$special_eyes$"
@@ -103,6 +108,9 @@
  
  PORTRAIT_MODIFIER_custom_horns_male_ogre_horns_2:0 "One Broken"
  PORTRAIT_MODIFIER_custom_horns_female_ogre_horns_2:0 "One Broken"
+
+ PORTRAIT_MODIFIER_custom_horns_boy_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
+ PORTRAIT_MODIFIER_custom_horns_girl_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
 
  ogre_ethnicity:0 "Ogre"
  

--- a/localization/german/wc_portraits_l_german.yml
+++ b/localization/german/wc_portraits_l_german.yml
@@ -19,6 +19,8 @@
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0:0 "Dünne, lange Augenbrauen"
  PORTRAIT_MODIFIER_custom_special_eyebrows_female_high_elven_eyebrows_0:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_high_elven_eyebrows_0$"
  PORTRAIT_MODIFIER_custom_special_eyebrows_male_dwarven_eyebrows_0:0 "Buschige Augenbrauen"
+ PORTRAIT_MODIFIER_custom_special_eyebrows_boy_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
+ PORTRAIT_MODIFIER_custom_special_eyebrows_girl_empty:0 "$PORTRAIT_MODIFIER_custom_special_eyebrows_male_empty$"
 
  #Dwarven Ethnicities
  dwarven_ethnicity:0 "Alte Zwerge"
@@ -64,6 +66,9 @@
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_0:0 "Klein - aufwärts"
  PORTRAIT_MODIFIER_custom_static_tusks_female_orcish_tusks_1:0 "Klein - vorwärts"
 
+ PORTRAIT_MODIFIER_custom_static_tusks_boy_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+ PORTRAIT_MODIFIER_custom_static_tusks_girl_empty:0 "$PORTRAIT_MODIFIER_custom_static_tusks_male_empty$"
+
  special_eyes:0 "Besondere Augen"
  PORTRAIT_MODIFIER_custom_special_eyes:0 "$special_eyes$"
  RULER_DESIGNER_CATEGORY_special_eye:0 "$special_eyes$"
@@ -103,6 +108,9 @@
 
  PORTRAIT_MODIFIER_custom_horns_male_ogre_horns_2:0 "Eins - abgebrochen"
  PORTRAIT_MODIFIER_custom_horns_female_ogre_horns_2:0 "Eins - abgebrochen"
+
+ PORTRAIT_MODIFIER_custom_horns_boy_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
+ PORTRAIT_MODIFIER_custom_horns_girl_empty:0 "$PORTRAIT_MODIFIER_custom_horns_male_empty$"
 
  ogre_ethnicity:0 "Oger"
 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added a few localisation keys for children in English/French/German

I had those errors in my error log so figured I'd add the keys:

```log
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_special_eyebrows_boy_empty
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_special_eyebrows_girl_empty
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_horns_boy_empty
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_horns_girl_empty
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_static_tusks_boy_empty
[13:58:52][pdx_locstring.cpp:93]: Key is missing localization: PORTRAIT_MODIFIER_custom_static_tusks_girl_empty
```
