### PR TITLE
Portrait Error Fixes

### DIFF
--- a/common/bookmark_portraits/anasterian_character.txt
+++ b/common/bookmark_portraits/anasterian_character.txt
@@ -141,7 +141,6 @@ anasterian_character={
  		hairstyles={ "scripted_character_hairstyles_01" 68 "all_hairstyles" 0 }
  		headgear={ "high_elven_crowns" 74 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 146 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 3942081117 3942081117 }
 	tags={ {

--- a/common/bookmark_portraits/arthas_menethil_character.txt
+++ b/common/bookmark_portraits/arthas_menethil_character.txt
@@ -139,7 +139,6 @@ arthas_menethil_character={
  		clothes={ "western_low_nobility_clothes" 173 "most_clothes" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 158 "all_hairstyles" 0 }
  		legwear={ "western_common_legwear" 120 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 1863162561 1863162561 }
 }

--- a/common/bookmark_portraits/blackhand_character.txt
+++ b/common/bookmark_portraits/blackhand_character.txt
@@ -140,7 +140,6 @@ blackhand_character={
  		clothes={ "religious_northern_high_clothes" 207 "most_clothes" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 153 "all_hairstyles" 0 }
  		legwear={ "western_common_legwear" 183 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 2268070609 2268070609 }
 }

--- a/common/bookmark_portraits/daelin_character.txt
+++ b/common/bookmark_portraits/daelin_character.txt
@@ -141,7 +141,6 @@ daelin_character={
  		hairstyles={ "scripted_character_hairstyles_01" 68 "all_hairstyles" 0 }
  		headgear={ "western_royalty" 173 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 193 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 979141817 979141817 }
 }

--- a/common/bookmark_portraits/darkhan_character.txt
+++ b/common/bookmark_portraits/darkhan_character.txt
@@ -140,7 +140,6 @@ darkhan_character={
  		hairstyles={ "scripted_character_hairstyles_01" 221 "all_hairstyles" 0 }
  		headgear={ "high_elven_crowns" 207 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 152 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 2268070609 2720375217 }
 	tags={ {

--- a/common/bookmark_portraits/durotan_character.txt
+++ b/common/bookmark_portraits/durotan_character.txt
@@ -139,7 +139,6 @@ durotan_character={
  		clothes={ "northern_war_nobility_clothes" 24 "most_clothes" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 165 "all_hairstyles" 0 }
  		legwear={ "western_common_legwear" 134 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 979141817 979141817 }
 }

--- a/common/bookmark_portraits/guldan_character.txt
+++ b/common/bookmark_portraits/guldan_character.txt
@@ -140,7 +140,6 @@ guldan_character={
  		clothes={ "religious_northern_high_clothes" 177 "most_clothes" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 137 "all_hairstyles" 0 }
  		legwear={ "western_common_legwear" 145 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 616600735 616600735 }
 	tags={ {

--- a/common/bookmark_portraits/illidan_character.txt
+++ b/common/bookmark_portraits/illidan_character.txt
@@ -142,7 +142,6 @@ illidan_character={
  		headgear={ "high_elven_crowns" 2 "no_headgear" 0 }
  		legwear={ "fp1_common_legwear" 130 "all_legwear" 0 }
  		gene_body_markings={ "demon_hunter_01" 255 "no_body_markings" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 979141817 979141817 }
 	tags={ {

--- a/common/bookmark_portraits/kaelthas_character.txt
+++ b/common/bookmark_portraits/kaelthas_character.txt
@@ -140,7 +140,6 @@ kaelthas_character={
  		hairstyles={ "scripted_character_hairstyles_01" 158 "all_hairstyles" 0 }
  		headgear={ "high_elven_crowns" 233 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 17 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 3942081117 3942081117 }
 	tags={ {

--- a/common/bookmark_portraits/llane_wrynn_character.txt
+++ b/common/bookmark_portraits/llane_wrynn_character.txt
@@ -141,7 +141,6 @@ llane_wrynn_character={
  		hairstyles={ "scripted_character_hairstyles_01" 68 "all_hairstyles" 0 }
  		headgear={ "western_royalty" 210 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 44 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 979141817 979141817 }
 }

--- a/common/bookmark_portraits/malakk_character.txt
+++ b/common/bookmark_portraits/malakk_character.txt
@@ -140,7 +140,6 @@ malakk_character={
  		clothes={ "religious_northern_high_clothes" 5 "most_clothes" 0 }
  		legwear={ "western_common_legwear" 205 "all_legwear" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 165 "all_hairstyles" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 979141817 979141817 }
 }

--- a/common/bookmark_portraits/medivh_character.txt
+++ b/common/bookmark_portraits/medivh_character.txt
@@ -140,7 +140,6 @@ medivh_character={
  		hairstyles={ "scripted_character_hairstyles_01" 38 "all_hairstyles" 0 }
  		headgear={ "western_high_nobility" 1 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 229 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 3942081117 3942081117 }
 }

--- a/common/bookmark_portraits/nerzhul_character.txt
+++ b/common/bookmark_portraits/nerzhul_character.txt
@@ -143,7 +143,6 @@ nerzhul_character={
  		hairstyles={ "no_hairstyles" 43 "all_hairstyles" 0 }
  		headgear={ "no_headgear" 127 "no_headgear" 0 }
  		legwear={ "no_legwear" 0 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  		static_model={ "static_nerzhul" 230 "static_murloc" 0 }
  }
 	entity={ 2142141949 2142141949 }

--- a/common/bookmark_portraits/valonforth_character.txt
+++ b/common/bookmark_portraits/valonforth_character.txt
@@ -140,7 +140,6 @@ valonforth_character={
  		hairstyles={ "western_hairstyles_wavy" 245 "all_hairstyles" 0 }
  		headgear={ "western_high_nobility" 245 "no_headgear" 0 }
  		legwear={ "western_common_legwear" 225 "all_legwear" 0 }
- 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
  }
 	entity={ 3942081117 3942081117 }
 }

--- a/common/dna_data/wc_dragon_dna.txt
+++ b/common/dna_data/wc_dragon_dna.txt
@@ -139,6 +139,12 @@ ysera_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -278,6 +284,12 @@ alexstrasza_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_dwarf_dna.txt
+++ b/common/dna_data/wc_dwarf_dna.txt
@@ -131,6 +131,12 @@ magni_bronzebeard_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -269,6 +275,12 @@ muradin_bronzebeard_dna = { #by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -407,6 +419,12 @@ brann_bronzebeard_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -545,6 +563,12 @@ moira_bronzebeard_dna = { #by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -683,6 +707,12 @@ kurdran_dna = { #by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -821,6 +851,12 @@ falstad_dna = { #by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
  		}
 	}
@@ -959,6 +995,12 @@ dagran_thaurissan_dna = { #by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
  		}
 	}

--- a/common/dna_data/wc_easter_egg_dna.txt
+++ b/common/dna_data/wc_easter_egg_dna.txt
@@ -131,6 +131,12 @@
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -270,6 +276,12 @@ derthon_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -409,6 +421,12 @@ garith_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -548,6 +566,12 @@ evelyn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -687,6 +711,12 @@ fenarith_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -826,6 +856,12 @@ arren_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -965,6 +1001,12 @@ melyina_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1104,6 +1146,12 @@ ion_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1242,6 +1290,12 @@ squidward_dna = { #by Herbe
 			tail={ "draenei_tails" 171 "draenei_tails" 171 }
 			tendrils={ "draenei_tendrils" 21 "draenei_tendrils" 21 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_elf_dna.txt
+++ b/common/dna_data/wc_elf_dna.txt
@@ -143,6 +143,12 @@ lorthemar_theron_dna = { # by ercarp & TheDrPibb
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 255 "no_tusks" 0 }
 		}
 	}
@@ -284,6 +290,12 @@ kaelthas_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -423,6 +435,12 @@ anasterian_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -564,6 +582,12 @@ sylvanas_windrunner_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -703,6 +727,12 @@ alleria_windrunner_dna = { # by Herbe
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -843,6 +873,12 @@ vereesa_windrunner_dna = { # by Herbe (tweaks by ercarp)
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -984,6 +1020,12 @@ darkhan_drathir_dna = { # by Runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
  		}
 	}

--- a/common/dna_data/wc_gnome_dna.txt
+++ b/common/dna_data/wc_gnome_dna.txt
@@ -131,6 +131,12 @@ gelbin_mekkatorque_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_goblin_dna.txt
+++ b/common/dna_data/wc_goblin_dna.txt
@@ -139,6 +139,12 @@ jastor_gallywix_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_human_dna.txt
+++ b/common/dna_data/wc_human_dna.txt
@@ -157,6 +157,12 @@ daelin_proudmoore_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -296,6 +302,12 @@ katherine_proudmoore_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -435,6 +447,12 @@ tandred_proudmoore_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -574,6 +592,12 @@ jaina_proudmoore_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}		
 	}
@@ -713,6 +737,12 @@ derek_proudmoore_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -855,6 +885,12 @@ garithos_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -994,6 +1030,12 @@ robert_garithos_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1133,6 +1175,12 @@ aliberta_garithos_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1274,6 +1322,12 @@ thoras_trollbane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1413,6 +1467,12 @@ galen_trollbane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1552,6 +1612,12 @@ danath_trollbane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1694,6 +1760,12 @@ llane_wrynn_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1833,6 +1905,12 @@ anduin_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -1972,6 +2050,12 @@ varian_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2111,6 +2195,12 @@ tiffin_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2250,6 +2340,12 @@ barathen_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2389,6 +2485,12 @@ landan_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2528,6 +2630,12 @@ varia_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2667,6 +2775,12 @@ taria_wrynn_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2809,6 +2923,12 @@ anduin_lothar_movie_dna = { # based on Travis Fimmel's portrayal, by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -2951,6 +3071,12 @@ nathanos_marris_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3093,6 +3219,12 @@ terenas_menethil_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3232,6 +3364,12 @@ lianne_menethil_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3371,6 +3509,12 @@ arthas_menethil_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3510,6 +3654,12 @@ calia_menethil_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3652,6 +3802,12 @@ tirion_fordring_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3791,6 +3947,12 @@ karandra_fordring_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -3930,6 +4092,12 @@ taelan_fordring_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4072,6 +4240,12 @@ genn_greymane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4211,6 +4385,12 @@ tess_greymane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4350,6 +4530,12 @@ archibald_greymane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4489,6 +4675,12 @@ liam_greymane_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4628,6 +4820,12 @@ mia_greymane_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4770,6 +4968,12 @@ aiden_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -4909,6 +5113,12 @@ aliden_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5048,6 +5258,12 @@ beve_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5187,6 +5403,12 @@ isolde_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5326,6 +5548,12 @@ valerius_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5465,6 +5693,12 @@ malatar_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5604,6 +5838,12 @@ isiden_perenolde_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5746,6 +5986,12 @@ alexandros_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -5885,6 +6131,12 @@ elena_mograine_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6027,6 +6279,12 @@ alonsus_faol_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6169,6 +6427,12 @@ saidan_dathrohan_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6311,6 +6575,12 @@ aedelas_blackmoore_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6453,6 +6723,12 @@ mathias_shaw_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6595,6 +6871,12 @@ bolvar_fordragon_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6734,6 +7016,12 @@ taelia_fordragon_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -6876,6 +7164,12 @@ vanessa_vancleef_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7015,6 +7309,12 @@ edwin_vancleef_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7156,6 +7456,12 @@ ansirem_runeweaver_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7295,6 +7601,12 @@ catelyn_runeweaver_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7436,6 +7748,12 @@ alexei_barov_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7575,6 +7893,12 @@ illucia_barov_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7714,6 +8038,12 @@ jandice_barov_dna = { #by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7855,6 +8185,12 @@ uther_dna_2 = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -7994,6 +8330,12 @@ turalyon_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -8133,6 +8475,12 @@ antonidas_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -8272,6 +8620,12 @@ khadgar_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -8411,6 +8765,12 @@ medivh_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -8550,6 +8910,12 @@ kelthuzad_dna = { # by runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 255 "no_tusks" 0 }
 		}
 	}
@@ -8689,6 +9055,12 @@ rhonin_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -8828,6 +9200,12 @@ godfrey_dna = { # by runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 255 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_nightelf_dna.txt
+++ b/common/dna_data/wc_nightelf_dna.txt
@@ -141,6 +141,12 @@ illidan_stormrage_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -280,6 +286,12 @@ malfurion_stormrage_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -421,6 +433,12 @@ maiev_shadowsong_dna = { # by Runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -559,6 +577,12 @@ jarod_shadowsong_dna = { # by Runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 0 "no_tusks" 0 }
 		}
 	}
@@ -700,6 +724,12 @@ tortheldrin_dna = { # by Runtd
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "no_tusks" 255 "no_tusks" 0 }
 		}
 	}

--- a/common/dna_data/wc_orc_dna.txt
+++ b/common/dna_data/wc_orc_dna.txt
@@ -145,6 +145,12 @@ orgrim_doomhammer_dna_2 = { # base by Garthor13, adjusted by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 246 "orcish_tusks" 246 }
 		}
 	}
@@ -284,6 +290,12 @@ blackhand_dna_2 = { # base by Garthor13, adjusted by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "orcish_tusks" 193 }
 		}
 	}
@@ -423,6 +435,12 @@ urukal_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "orcish_tusks" 193 }
 		}
 	}
@@ -562,6 +580,12 @@ dalrend_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "orcish_tusks" 193 }
 		}
 	}
@@ -701,6 +725,12 @@ maim_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "orcish_tusks" 193 }
 		}
 	}
@@ -840,6 +870,12 @@ griselda_dna = { # by icelille999
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "orcish_tusks" 105 }
 		}
 	}
@@ -981,6 +1017,12 @@ guldan_dna_2 = { # base by Garthor13, adjusted by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 81 "orcish_tusks" 81 }
 		}
 	}
@@ -1122,6 +1164,12 @@ kilrogg_dna_2 = { # base by Garthor13, adjusted by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 145 "orcish_tusks" 193 }
 		}
 	}
@@ -1263,6 +1311,12 @@ durotan_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 27 "orcish_tusks" 27 }
 		}
 	}
@@ -1402,6 +1456,12 @@ thrall_dna_2 = { # base by Garthor13, adjusted by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 237 "orcish_tusks" 237 }
 		}
 	}
@@ -1541,6 +1601,12 @@ drekthar_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 52 "orcish_tusks" 52 }
 		}
 	}
@@ -1680,6 +1746,12 @@ draka_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 235 "orcish_tusks" 235 }
 		}
 	}
@@ -1819,6 +1891,12 @@ nazgrel_dna = { # by NovelConcept
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 4 "orcish_tusks" 4 }
 		}
 	}
@@ -1960,6 +2038,12 @@ grommash_dna = { # by Herbe
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 18 "orcish_tusks" 18 }
 		}
 	}
@@ -2099,6 +2183,12 @@ garrosh_dna = { # by Herbe (tweaks by ercarp)
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 127 "no_tusks" 0 }
 		}
 	}
@@ -2240,6 +2330,12 @@ rexxar_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 255 "orcish_tusks" 52 }
 		}
 	}
@@ -2381,6 +2477,12 @@ garona_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "orcish_tusks" 255 "orcish_tusks" 204 }
 		}
 	}

--- a/common/dna_data/wc_troll_dna.txt
+++ b/common/dna_data/wc_troll_dna.txt
@@ -131,6 +131,12 @@ ateena_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "troll_tusks" 115 "troll_tusks" 115 }
 		}
 	}
@@ -269,6 +275,12 @@ malakk_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "troll_tusks" 255 "no_tusks" 0 }
 		}
 	}
@@ -407,6 +419,12 @@ voljin_dna = { # by ercarp
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "troll_tusks" 255 "troll_tusks" 244 }
 		}
 	}
@@ -545,6 +563,12 @@ rastakhan_dna = { # by Herbe
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "troll_tusks" 91 "troll_tusks" 91 }
 		}
 	}
@@ -682,6 +706,12 @@ talanji_dna = { # by Herbe
 			tail={ "no_tail" 0 "no_tail" 0 }
 			tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
 			wings={ "no_wings" 0 "no_wings" 0 }
+			static_eyes={ "no_static_eyes" 0 "no_static_eyes" 0 }
+ 			static_hairstyles={ "no_static_hairstyles" 0 "no_static_hairstyles" 0 }
+ 			static_hairstyles2={ "no_static_hairstyles2" 0 "no_static_hairstyles2" 0 }
+ 			static_model={ "no_static_model" 0 "no_static_model" 0 }
+ 			static_mustaches={ "no_static_mustaches" 0 "no_static_mustaches" 0 }
+ 			static_beards={ "no_static_beards" 0 "no_static_beards" 0 }
 			tusks={ "troll_tusks" 124 "troll_tusks" 124 }
 		}
 	}

--- a/common/genes/wc_genes_static_hairstyles.txt
+++ b/common/genes/wc_genes_static_hairstyles.txt
@@ -1121,15 +1121,15 @@
 		tauren_foremanes_skin0 = { # Used by F Skins 0 & 1 / M Skins 0, 1, 2 & 31
 			index = 1
 			male = {
-				100 = maletauren_foremane1_skin0
-				100 = maletauren_foremane2_skin0
-				100 = maletauren_foremane3_skin0
-				33 = maletauren_foremane4_skin0
+				10 = maletauren_foremane1_skin0
+				10 = maletauren_foremane2_skin0
+				10 = maletauren_foremane3_skin0
+				3 = maletauren_foremane4_skin0
 			}
 			female = {
-				100 = femaletauren_foremane1_skin0
-				33 = femaletauren_foremane2_skin0
-				100 = femaletauren_foremane3_skin0
+				10 = femaletauren_foremane1_skin0
+				3 = femaletauren_foremane2_skin0
+				10 = femaletauren_foremane3_skin0
 			}
 			boy = male
 			girl = female
@@ -1137,15 +1137,15 @@
 		tauren_foremanes_skin2 = { # Used by F Skins 2 & 3 / M Skins 3, 4, & 5
 			index = 2
 			male = {
-				100 = maletauren_foremane1_skin3
-				100 = maletauren_foremane2_skin3
-				100 = maletauren_foremane3_skin3
-				33 = maletauren_foremane4_skin3
+				10 = maletauren_foremane1_skin3
+				10 = maletauren_foremane2_skin3
+				10 = maletauren_foremane3_skin3
+				3 = maletauren_foremane4_skin3
 			}
 			female = {
-				100 = femaletauren_foremane1_skin2
-				33 = femaletauren_foremane2_skin2
-				100 = femaletauren_foremane3_skin2
+				10 = femaletauren_foremane1_skin2
+				3 = femaletauren_foremane2_skin2
+				10 = femaletauren_foremane3_skin2
 			}
 			boy = male
 			girl = female
@@ -1153,15 +1153,15 @@
 		tauren_foremanes_skin4 = { # Used by F Skins 4 & 5 / M Skins 6, 7, & 8
 			index = 3
 			male = {
-				100 = maletauren_foremane1_skin6
-				100 = maletauren_foremane2_skin6
-				100 = maletauren_foremane3_skin6
-				33 = maletauren_foremane4_skin6
+				10 = maletauren_foremane1_skin6
+				10 = maletauren_foremane2_skin6
+				10 = maletauren_foremane3_skin6
+				3 = maletauren_foremane4_skin6
 			}
 			female = {
-				100 = femaletauren_foremane1_skin4
-				33 = femaletauren_foremane2_skin4
-				100 = femaletauren_foremane3_skin4
+				10 = femaletauren_foremane1_skin4
+				3 = femaletauren_foremane2_skin4
+				10 = femaletauren_foremane3_skin4
 			}
 			boy = male
 			girl = female
@@ -1169,15 +1169,15 @@
 		tauren_foremanes_skin6 = { # Used by F Skins 6 & 7 / M Skins 9, 10 & 11
 			index = 4
 			male = {
-				100 = maletauren_foremane1_skin9
-				100 = maletauren_foremane2_skin9
-				100 = maletauren_foremane3_skin9
-				33 = maletauren_foremane4_skin9
+				10 = maletauren_foremane1_skin9
+				10 = maletauren_foremane2_skin9
+				10 = maletauren_foremane3_skin9
+				3 = maletauren_foremane4_skin9
 			}
 			female = {
-				100 = femaletauren_foremane1_skin6
-				33 = femaletauren_foremane2_skin6
-				100 = femaletauren_foremane3_skin6
+				10 = femaletauren_foremane1_skin6
+				3 = femaletauren_foremane2_skin6
+				10 = femaletauren_foremane3_skin6
 			}
 			boy = male
 			girl = female
@@ -1185,15 +1185,15 @@
 		tauren_foremanes_skin8 = { # Used by F Skins 8 & 9 / M Skins 15, 16, & 17
 			index = 5
 			male = {
-				100 = maletauren_foremane1_skin15
-				100 = maletauren_foremane2_skin15
-				100 = maletauren_foremane3_skin15
-				33 = maletauren_foremane4_skin15
+				10 = maletauren_foremane1_skin15
+				10 = maletauren_foremane2_skin15
+				10 = maletauren_foremane3_skin15
+				3 = maletauren_foremane4_skin15
 			}
 			female = {
-				100 = femaletauren_foremane1_skin8
-				33 = femaletauren_foremane2_skin8
-				100 = femaletauren_foremane3_skin8
+				10 = femaletauren_foremane1_skin8
+				3 = femaletauren_foremane2_skin8
+				10 = femaletauren_foremane3_skin8
 			}
 			boy = male
 			girl = female
@@ -1201,15 +1201,15 @@
 		tauren_foremanes_skin10 = { # Used by F Skin 10 / M Skin 18
 			index = 6
 			male = {
-				100 = maletauren_foremane1_skin18
-				100 = maletauren_foremane2_skin18
-				100 = maletauren_foremane3_skin18
-				33 = maletauren_foremane4_skin18
+				10 = maletauren_foremane1_skin18
+				10 = maletauren_foremane2_skin18
+				10 = maletauren_foremane3_skin18
+				3 = maletauren_foremane4_skin18
 			}
 			female = {
-				100 = femaletauren_foremane1_skin10
-				33 = femaletauren_foremane2_skin10
-				100 = femaletauren_foremane3_skin10
+				10 = femaletauren_foremane1_skin10
+				3 = femaletauren_foremane2_skin10
+				10 = femaletauren_foremane3_skin10
 			}
 			boy = male
 			girl = female
@@ -1217,10 +1217,10 @@
 		tauren_foremanes_skin12 = { # Used by M Skins 12, 13, & 14
 			index = 7
 			male = {
-				100 = maletauren_foremane1_skin12
-				100 = maletauren_foremane2_skin12
-				100 = maletauren_foremane3_skin12
-				33 = maletauren_foremane4_skin12
+				10 = maletauren_foremane1_skin12
+				10 = maletauren_foremane2_skin12
+				10 = maletauren_foremane3_skin12
+				3 = maletauren_foremane4_skin12
 			}
 			female = {
 				1 = empty
@@ -1231,15 +1231,15 @@
 		tauren_foremanes_skin29 = { # Used by F Skin 21 / M Skin 29
 			index = 8
 			male = {
-				100 = maletauren_foremane1_skin29
-				100 = maletauren_foremane2_skin29
-				100 = maletauren_foremane3_skin29
-				33 = maletauren_foremane4_skin29
+				10 = maletauren_foremane1_skin29
+				10 = maletauren_foremane2_skin29
+				10 = maletauren_foremane3_skin29
+				3 = maletauren_foremane4_skin29
 			}
 			female = {
-				100 = femaletauren_foremane1_skin21
-				33 = femaletauren_foremane2_skin21
-				100 = femaletauren_foremane3_skin21
+				10 = femaletauren_foremane1_skin21
+				3 = femaletauren_foremane2_skin21
+				10 = femaletauren_foremane3_skin21
 			}
 			boy = male
 			girl = female
@@ -1247,15 +1247,15 @@
 		tauren_foremanes_skin30 = { # Used by F Skin 22 / M Skin 30
 			index = 9
 			male = {
-				100 = maletauren_foremane1_skin30
-				100 = maletauren_foremane2_skin30
-				100 = maletauren_foremane3_skin30
-				33 = maletauren_foremane4_skin30
+				10 = maletauren_foremane1_skin30
+				10 = maletauren_foremane2_skin30
+				10 = maletauren_foremane3_skin30
+				3 = maletauren_foremane4_skin30
 			}
 			female = {
-				100 = femaletauren_foremane1_skin22
-				33 = femaletauren_foremane2_skin22
-				100 = femaletauren_foremane3_skin22
+				10 = femaletauren_foremane1_skin22
+				3 = femaletauren_foremane2_skin22
+				10 = femaletauren_foremane3_skin22
 			}
 			boy = male
 			girl = female

--- a/gfx/portraits/portrait_modifiers/wc_race_portrait_modifiers.txt
+++ b/gfx/portraits/portrait_modifiers/wc_race_portrait_modifiers.txt
@@ -730,17 +730,17 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 100
+				add = 50
 				has_culture = culture:frozen_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 200
+				add = 100
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:290000 # King Jokkum
 			}
 			modifier = {
-				add = 200
+				add = 100
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:toravon # Toravon the Ice Watcher
 			}
@@ -765,12 +765,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 100
+				add = 50
 				has_culture = culture:frozen_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 2001
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:koralon # Koralon the Flame Watcher
 			}
@@ -795,12 +795,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 100
+				add = 50
 				has_culture = culture:storm_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 2001
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:emalon # Emalon the Storm Watcher
 			}
@@ -825,12 +825,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 100
+				add = 50
 				has_culture = culture:storm_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 2001
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:440001 # Gymer
 			}
@@ -879,7 +879,7 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 100
+				add = 50
 				is_race_no_gene_trigger = { RACE = creature_watcher }
 			}
 			modifier = {
@@ -1135,7 +1135,7 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 2000
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_mechagnome }
 				this = character:400505 # Mimiron
 			}

--- a/gfx/portraits/portrait_modifiers/wc_race_portrait_modifiers.txt
+++ b/gfx/portraits/portrait_modifiers/wc_race_portrait_modifiers.txt
@@ -730,17 +730,17 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 50
+				add = 100
 				has_culture = culture:frozen_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 100
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:290000 # King Jokkum
 			}
 			modifier = {
-				add = 100
+				add = 200
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:toravon # Toravon the Ice Watcher
 			}
@@ -765,12 +765,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 50
+				add = 100
 				has_culture = culture:frozen_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 200
+				add = 2001
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:koralon # Koralon the Flame Watcher
 			}
@@ -795,12 +795,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 50
+				add = 100
 				has_culture = culture:storm_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 200
+				add = 2001
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:emalon # Emalon the Storm Watcher
 			}
@@ -825,12 +825,12 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 50
+				add = 100
 				has_culture = culture:storm_giant
 				is_race_no_gene_trigger = { RACE = creature_giant }
 			}
 			modifier = {
-				add = 200
+				add = 2001
 				is_race_no_gene_trigger = { RACE = creature_giant }
 				this = character:440001 # Gymer
 			}
@@ -879,7 +879,7 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 50
+				add = 100
 				is_race_no_gene_trigger = { RACE = creature_watcher }
 			}
 			modifier = {
@@ -1135,7 +1135,7 @@
 		weight = {
 			base = 0
 			modifier = {
-				add = 200
+				add = 2000
 				is_race_no_gene_trigger = { RACE = creature_mechagnome }
 				this = character:400505 # Mimiron
 			}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed the issues causing the error log to be spammed with 'weight sum' and 'persistent portrait' error messages.
  - _(Note: Hopefully this will help increase game stability now that the game isn't constantly generating error messages.)_

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)