### PR TITLE
Union gui member list fix

### DIFF
--- a/gui/hud.gui
+++ b/gui/hud.gui
@@ -492,19 +492,40 @@ widget = {
 										datamodel = "[GetPlayer.MakeScope.GetList('gui_pol_faction_members')]"
 									}
 									
-									blockoverride "grid_item" {
-										item = {
-											container = {
-												datacontext = "[Scope.GetCharacter]"
-												
-												portrait_head_small = {
-													blockoverride "portrait_button"
-													{
-														using = tooltip_ne
-													}
-													blockoverride "glow_visible"
-													{
-														visible = no
+									blockoverride "gridbox" {
+										fixedgridbox = {
+											flipdirection = yes
+											addcolumn = 85
+											addrow = 90
+											
+											# Warcraft
+											block "horizontal_slots"
+											{
+												datamodel_wrap = 7
+											}
+
+											block "gridbox_slots"
+											{
+												maxverticalslots = 1
+											}
+
+											block "portrait_datamodel" {
+												datamodel = "[CharacterWindow.GetParents]"
+											}
+
+											item = {
+												container = {
+													datacontext = "[Scope.GetCharacter]"
+													
+													portrait_head_small = {
+														blockoverride "portrait_button"
+														{
+															using = tooltip_ne
+														}
+														blockoverride "glow_visible"
+														{
+															visible = no
+														}
 													}
 												}
 											}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed member list in union window hud.gui

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- made blockoverride "gridbox" instead of grid_item, which didnt exist

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)
# How to test:
