### PR TITLE
Dark Crystal artifact

### DIFF
--- a/common/artifacts/templates/wc_historical_artifacts_templates.txt
+++ b/common/artifacts/templates/wc_historical_artifacts_templates.txt
@@ -27,3 +27,17 @@ gorehowl_template = {
 
 	unique = yes
 }
+dark_crystal_template = {
+	can_equip = {
+	}
+
+	# can this character benefit from the full modifiers of the artifact?
+	can_benefit = {
+	}
+
+	# if a given character does not pass the "can_benefit" trigger then this modifier will be applied instead.
+	fallback = {
+	}
+
+	unique = yes
+}

--- a/common/artifacts/visuals/wc_historical.txt
+++ b/common/artifacts/visuals/wc_historical.txt
@@ -12,3 +12,8 @@ gorehowl = {
 	#placeholder asset
 	asset = ep1_northern_axe_01_a_portrait_entity
 }
+dark_crystal = {
+	icon = "wc_dark_crystal.dds"
+	pedestal = "tall_pillow"
+	# asset = ep1_northern_axe_01_a_portrait_entity
+}

--- a/common/modifiers/wc_historical_artifact_modifiers.txt
+++ b/common/modifiers/wc_historical_artifact_modifiers.txt
@@ -21,3 +21,9 @@ gorehowl_modifier = {
 	min_combat_roll = -3
 	max_combat_roll = 3
 }
+dark_crystal_modifier = {
+	intrigue = 1
+	learning = 2
+	prowess = 8
+	monthly_prestige = 1
+}

--- a/common/scripted_effects/wc_historical_artifacts_creation_effect.txt
+++ b/common/scripted_effects/wc_historical_artifacts_creation_effect.txt
@@ -92,3 +92,30 @@ create_artifact_gorehowl_effect = {
 		set_variable = { name = gorehowl value = yes }
 	}
 }
+create_artifact_dark_crystal_effect = {
+	# Get the character the artifact is being made for.
+	$OWNER$ = { save_scope_as = owner }
+	set_artifact_rarity_illustrious = yes
+
+	# Create the artifact
+	create_artifact = {
+		name = dark_crystal_name
+		description = dark_crystal_desc
+		type = miscellaneous
+		template = dark_crystal_template
+		# visuals = dark_crystal
+		wealth = scope:wealth
+		quality = scope:quality
+		history = {
+			type = created_before_history
+		}
+		modifier = dark_crystal_modifier
+		save_scope_as = newly_created_artifact
+		decaying = no
+	}
+
+	scope:newly_created_artifact = {
+		set_variable = { name = historical_unique_artifact value = yes }
+		set_variable = { name = dark_crystal value = yes }
+	}
+}

--- a/events/artifacts/historical_artifacts_events.txt
+++ b/events/artifacts/historical_artifacts_events.txt
@@ -174,6 +174,13 @@ historical_artifacts.0023 = {
 			}
 			character:10200 = { create_artifact_gorehowl_effect = { OWNER = this } }
 		}
+		# Dark Crystal
+		if = {
+			limit = {
+				game_start_date >= 1.1.1
+			}
+			character:10200 = { create_artifact_dark_crystal_effect = { OWNER = this } }
+		}
 	}
 }
 

--- a/localization/english/artifacts/wc_artifacts_l_english.yml
+++ b/localization/english/artifacts/wc_artifacts_l_english.yml
@@ -5,3 +5,5 @@
  frostmourne_desc:1 "An [inventory_artifact|E], a cursed runeblade of the [GetTrait('lich_king').GetName( GetNullCharacter )]. The blade imprisons souls, increasing the blade's $MOD_PROWESS$ and $MOD_DREAD_BASELINE_ADD$ #weak (up to 17 $MOD_PROWESS$ and 30 $MOD_DREAD_BASELINE_ADD$)#!. $frostmourne_name$ doesn't lose [durability|E]. The wielder turns the killed [GetTrait('being_undead').GetName( GetNullCharacter )]. In such a case, the killed's soul is twisted: they get evil [traits|E] like [GetTrait('callous').GetName( GetNullCharacter )], [GetTrait('vengeful').GetName( GetNullCharacter )], etc."
  gorehowl_name:0 "Gorehowl"
  gorehowl_desc:0 "A massive axe wielded by Grommash Hellscream of the Warsong Clan. It is permanently stained with the blood of the warrior's fallen enemies. Small holes and notches that dot the blade make it "sing" when swung."
+ dark_crystal_name:0 "Dark Crystal"
+ dark_crystal_desc:0 "Void magic emanates from this strange crystal, but somewhere in the depths of it you feel the presence of the Light."

--- a/localization/german/artifacts/wc_artifacts_l_german.yml
+++ b/localization/german/artifacts/wc_artifacts_l_german.yml
@@ -5,3 +5,6 @@
  frostmourne_desc:0 "Ein [inventory_artifact|E], eine verfluchte Runenklinge des #TOOLTIP:GAME_TRAIT,lich_king,[GetNullCharacter.GetID] #L Lichkönigs#!#!. Die Klinge schließt Seelen ein und erhöht $MOD_PROWESS$ und $MOD_DREAD_BASELINE_ADD$ #weak (bis zu 17 $MOD_PROWESS$ und 30 $MOD_DREAD_BASELINE_ADD$)#!. $frostmourne_name$ verliert nicht an [durability|E]. Der Träger verwandelt die Gefallenen in #TOOLTIP:GAME_TRAIT,being_undead,[GetNullCharacter.GetID] #L Untote#!#!. In einem solchen Fall wird die Seele der Getöteten verdorben: sie erhalten böse [traits|E] wie [GetTrait('callous').GetName( GetNullCharacter )], [GetTrait('vengeful').GetName( GetNullCharacter )], etc."
  gorehowl_name:0 "Blutschrei"
  gorehowl_desc:0 "Eine riesige von Grommash Hellscream des Warsong-Clans benutzte Axt. Sie ist dauerhaft mit dem Blut gefallener Opfer des Kriegers besudelt. Kleine Löcher und Einkerbungen an der Klinge lassen die Axt „singen“ wenn sie geschwungen wird."
+ dark_crystal_name:0 "Dunkler Kristall"
+ dark_crystal_desc:0 "Aus diesem seltsamen Kristall entspringt die Magie der Leere, aber irgendwo in seinem Inneren spürt Ihr die Präsenz des Lichts."
+ 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- [x] Added the dark crystal with stats based on what we gave it in the ck2 mod.
- [ ] Icon added
- [ ] remove Grommash as receiver of the artifact

![grafik](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/47716948/b693c469-684c-49b0-b564-9d58c9459e68)

Balancing Spreadsheet:
<https://docs.google.com/spreadsheets/d/18zS-FAte6nsejx7rpzSmVuioRXps3iWSvSkx_xRJSWI/edit#gid=1165316868>