### PR TITLE
Character sexualities

### DIFF
--- a/common/culture/cultures/wc_highborne.txt
+++ b/common/culture/cultures/wc_highborne.txt
@@ -94,7 +94,7 @@ blood_elf = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		10 = high_elven
+		1 = high_elven
 	}
 }
 
@@ -125,6 +125,6 @@ nightborne = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		10 = high_elven
+		1 = high_elven
 	}
 }

--- a/common/dynasty_legacies/96_fp2_legacies.txt
+++ b/common/dynasty_legacies/96_fp2_legacies.txt
@@ -3,7 +3,7 @@ fp2_urbanism_legacy_track = {
 	is_shown = {
 		has_dlc_feature = the_fate_of_iberia
 		dynasty = {
-			#OR = {
+			OR = {
 				dynast = {
 			#		OR = {
 			#			any_character_struggle = {
@@ -24,8 +24,8 @@ fp2_urbanism_legacy_track = {
 			#			}
 			#		}
 				}
-			#	has_dynasty_perk = fp2_urbanism_legacy_1
-			#}
+				has_dynasty_perk = fp2_urbanism_legacy_1
+			}
 		}
 
 	}
@@ -36,7 +36,7 @@ fp2_coterie_legacy_track = {
 	is_shown = {
 		has_dlc_feature = the_fate_of_iberia
 		dynasty = {
-			#OR = {
+			OR = {
 				dynast = {
 			#		OR = {
 			#			any_character_struggle = {
@@ -53,8 +53,8 @@ fp2_coterie_legacy_track = {
 			#			}
 			#		}
 				}
-			#	has_dynasty_perk = fp2_coterie_legacy_1
-			#}
+				has_dynasty_perk = fp2_coterie_legacy_1
+			}
 		}
 	}
 }

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -225,6 +225,7 @@ try_to_set_race_effect = {
 	else_if = {
 		limit = { is_race_no_gene_trigger = { RACE = creature_sayaadi } }
 		set_race_effect = { RACE = creature_sayaadi }
+		set_sexuality = { bisexual }
 		# add_trait_demon_effect = yes
 		# if = {
 			# limit = { culture = nathrezim }

--- a/events/education_and_childhood/child_personality_events.txt
+++ b/events/education_and_childhood/child_personality_events.txt
@@ -3875,6 +3875,10 @@ child_personality.0021 = {
 			add = -0.5
 			has_sexuality = asexual
 		}
+		modifier = {
+			add = 10
+			has_trait = creature_sayaadi
+		}
 	}
 
 	immediate = {
@@ -3905,6 +3909,10 @@ child_personality.0021 = {
 					0 = { #Bisexual
 						modifier = {
 							add = bisexuality_chance
+						}
+						modifier = {
+							has_trait = creature_sayaadi
+							factor = 100
 						}
 						save_scope_value_as = {
 							name = bisexual
@@ -9153,6 +9161,10 @@ child_personality.4000 = {
 						modifier = {
 							add = bisexuality_chance
 						}
+						modifier = {
+							has_trait = creature_sayaadi
+							factor = 100
+						}
 						trigger_event = {
 							id = child_personality.4013
 							days = { 3 730 }
@@ -9306,6 +9318,7 @@ child_personality.4011 = {
 		ai_chance = {
 			base = 0
 			modifier = { add = bisexuality_chance }
+			modifier = { has_trait = creature_sayaadi factor = 100 }
 		}
 	}
 
@@ -9457,6 +9470,10 @@ child_personality.4015 = {
 						0 = { #Bisexual
 							modifier = {
 								add = bisexuality_chance
+							}
+							modifier = {
+								has_trait = creature_sayaadi
+								factor = 100
 							}
 							set_sexuality = bisexual
 						}

--- a/events/education_and_childhood/child_personality_events_2.txt
+++ b/events/education_and_childhood/child_personality_events_2.txt
@@ -2609,6 +2609,10 @@ child_personality.7040 = {
 					has_trait = chaste
 				}
 			}
+			modifier = {
+				add = 10
+				has_trait = creature_sayaadi
+			}
 		}
 	}
 
@@ -2647,6 +2651,10 @@ child_personality.7040 = {
 					has_trait = chaste
 				}
 			}
+			modifier = {
+				add = 10
+				has_trait = creature_sayaadi
+			}
 		}
 	}
 
@@ -2678,6 +2686,10 @@ child_personality.7040 = {
 					type = guardian
 					has_trait = lustful
 				}
+			}
+			modifier = {
+				add = -10
+				has_trait = creature_sayaadi
 			}
 		}
 	}

--- a/history/characters/100000_vrykul.txt
+++ b/history/characters/100000_vrykul.txt
@@ -4,6 +4,7 @@
 	# name=Ymiron
 	# dynasty=70000
 	# culture=vrykul religion=odyn
+	# sexuality = heterosexual
 	# martial=6 diplomacy=6 stewardship=4 intrigue=7 learning=7
 	# trait=education_martial_3
 	# trait=wrathful trait=arrogant trait=ambitious trait=arbitrary 
@@ -34,6 +35,7 @@
 	dynasty=70008
 	female=yes
 	culture=vrykul religion=odyn
+	sexuality = heterosexual
 	trait=arbitrary trait=content trait=arrogant trait=chaste
 	2.1.1={ birth=yes trait=creature_vrykul effect = { add_character_modifier = hibernated_modifier } }
 	20.1.1={
@@ -5772,6 +5774,7 @@ astrid_bjornrittar={
 	name=Sif
 	female=yes
 	culture=hyldnir religion=mystery_of_the_makers
+	sexuality = heterosexual
 	martial=4 diplomacy=8 stewardship=7 intrigue=6 learning=5
 	trait=education_intrigue_2 trait=greedy trait=compassionate trait=patient trait=lustful
 	100.1.1={ birth=yes trait=creature_vrykul }

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -5,6 +5,7 @@
 	dynasty_house = house_blackhand
 	give_nickname=nick_the_destroyer
 	culture=blackrock religion=orcish_fel
+	sexuality = heterosexual
 	martial=6 diplomacy=5 stewardship=4 intrigue=3 learning=4
 	trait=education_martial_4 
 	trait=wrathful trait=greedy trait=arrogant trait=arbitrary
@@ -49,6 +50,7 @@
 	dna = urukal_dna
 	female = yes
 	culture=blackrock religion=orcish_fel
+	sexuality = heterosexual
 	martial=7 diplomacy=4 stewardship=7 intrigue=2 learning=3
 	trait=education_martial_2
 	trait=arrogant trait=temperate
@@ -818,6 +820,7 @@ bleedinghollow1={
 	dna = grommash_dna
 	dynasty_house=house_hellscream
 	culture=warsong religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=5 diplomacy=8 stewardship=7 intrigue=5 learning=6
 	trait=education_martial_4
 	trait = physique_good_3
@@ -1202,6 +1205,7 @@ golmash = {
 	female=yes	
 	#dynasty=2300
 	culture=maghar religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=7 intrigue=6 learning=6
 	trait=education_martial_2
 	trait=brave trait=gregarious trait=compassionate trait=diligent

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -164,6 +164,7 @@
     dna=kilrogg_dna_2
 	dynasty=2150
 	culture=bleeding_hollow religion=orcish_fel
+	sexuality = heterosexual
 	martial=8 diplomacy=6 stewardship=7 intrigue=5 learning=7
 	trait=education_martial_3
 	trait=brave trait=patient trait=temperate trait=just 

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -126,6 +126,7 @@
 	### dynasty=2000
 	dynasty_house = house_blackhand
 	culture=blackrock religion=orcish_fel
+	sexuality = heterosexual
 	martial=3 diplomacy=5 stewardship=3 intrigue=4 learning=2
 	trait=education_intrigue_2
 	trait=chaste trait=humble trait=brave trait=content
@@ -360,6 +361,7 @@ bleedinghollow1={
 	name=Ner'zhul
 	dynasty_house = house_shadowmoon
 	culture=shadowmoon religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=5 intrigue=5 learning=7
 	trait = education_learning_4
 	trait = shrewd trait = patient trait = ambitious trait = callous
@@ -504,8 +506,9 @@ bleedinghollow1={
 	name=Fel'dan
 	dynasty=2354
 	culture=stormreaver religion=orcish_fel
+	sexuality = heterosexual
 	martial=3 diplomacy=6 stewardship=4 intrigue=7 learning=3
-	trait=education_learning_3 trait=sadistic trait=arrogant
+	trait=education_learning_3 trait=sadistic trait=arrogant trait = lustful
 	541.1.1={ birth=yes trait=creature_orc }
 	557.1.1={
 		effect={ set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
@@ -521,7 +524,6 @@ bleedinghollow1={
 	592.1.19={
 		trait = being_demon
 		religion = burning_legion_religion
-		trait = lustful
 	}
 	603.1.1={
 		employer = 10550 #Jubei'thos
@@ -539,6 +541,7 @@ bleedinghollow1={
 	dynasty=2200
 	dna=durotan_dna
 	culture=frostwolf religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=6 intrigue=3 learning=3
 	trait=education_martial_3 
 	trait=honest trait=patient trait=just trait=brave 
@@ -581,6 +584,7 @@ bleedinghollow1={
 	female = yes
 	dna=draka_dna
 	culture=frostwolf religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=3 diplomacy=6 stewardship=3 intrigue=5 learning=6
 	trait=education_martial_2 trait=honest trait=brave trait=compassionate trait=patient
 	558.8.6={ birth=yes trait=creature_orc }
@@ -604,6 +608,7 @@ bleedinghollow1={
 	dynasty=2200
     dna = thrall_dna_2
 	culture=frostwolf religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=5 intrigue=2 learning=6
 	father=10019	#Durotan
 	mother = 10020	#Draka
@@ -715,7 +720,7 @@ bleedinghollow1={
 	dynasty=2001
 	culture=blackrock religion=orcish_shamanism
 	martial=7 diplomacy=4 stewardship=5 intrigue=4 learning=2
-	trait=education_martial_4 trait=physique_good_3 trait=honest trait=wrathful trait=brave trait=ambitious 
+	trait=education_martial_4 trait=physique_good_3 trait=honest trait=wrathful trait=brave trait=ambitious trait=shrewd
 	disallow_random_traits = yes
 	558.1.1={ 
 		birth=yes trait=creature_orc 
@@ -1250,6 +1255,7 @@ golmash = {
 	dna=garona_dna
 	female=yes
 	culture=shadowmoon religion=orcish_fel
+	sexuality = heterosexual
 	martial=6 diplomacy=4 stewardship=8 intrigue=5 learning=8
 	trait=education_intrigue_4
 	trait=content trait=humble trait=patient trait=chaste trait = legitimized_bastard
@@ -1286,6 +1292,7 @@ golmash = {
 	name=Drum	
 	dynasty=2301
 	culture=frostwolf religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=7 diplomacy=5 stewardship=6 intrigue=6 learning=7
 	trait=education_martial_2
 	trait=brave trait=physique_good_1 trait=just trait=diligent trait=wrathful
@@ -1508,6 +1515,7 @@ golmash = {
 	name=Korin
 	female=yes
 	culture=frostwolf religion=orcish_shamanism
+	sexuality = heterosexual
 	martial=7 diplomacy=8 stewardship=7 intrigue=5 learning=4
 	trait=education_diplomacy_2
 	trait=chaste trait=compassionate	

--- a/history/characters/11000_dark_iron.txt
+++ b/history/characters/11000_dark_iron.txt
@@ -1102,6 +1102,7 @@
 	dna=dagran_thaurissan_dna
 	dynasty=4010
 	culture=dark_iron religion=khazism
+	sexuality = heterosexual
 	martial=8 diplomacy=5 stewardship=6 intrigue=4 learning=6
 	father = 12052
 	trait=education_learning_3 trait=trusting trait=patient trait=content trait=honest
@@ -1112,6 +1113,12 @@
 	}
 	369.5.7={
 		effect={ set_variable = { name = wc_elemental_fire_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
+	}
+	608.1.1={
+		add_spouse=17029
+		effect = {
+			set_relation_soulmate = character:17029
+		}
 	}
 	640.2.6={ death=yes }
 }

--- a/history/characters/17000_28000_bronzebeard.txt
+++ b/history/characters/17000_28000_bronzebeard.txt
@@ -26,6 +26,7 @@
 	dynasty=4200
 	dna=magni_bronzebeard_dna
 	culture=bronzebeard religion=khazism
+	sexuality = heterosexual
 	martial=8 diplomacy=8 stewardship=6 intrigue=4 learning=6
 	trait=education_martial_4 trait=patient trait=generous trait=compassionate trait=honest
 	father=17042	#Horhunn
@@ -395,12 +396,13 @@
 	dna=moira_bronzebeard_dna
 	female=yes
 	culture=bronzebeard religion=khazism
+	sexuality = heterosexual
 	trait=education_learning_3 trait=compassionate trait=patient trait=content
 	father=17001	#Magni
 	mother = eimear
 	disallow_random_traits = yes
-	533.1.1={ 
-		birth=yes trait=creature_dwarf 
+	533.1.1={
+		birth=yes trait=creature_dwarf
 		effect = { make_important_lore_character_effect = yes }
 	}
 	551.1.1={
@@ -410,6 +412,7 @@
 	608.1.1={
 		employer = 12002
 		culture=dark_iron
+		add_spouse=12002
 		effect = {
 			set_relation_soulmate = character:12002
 		}
@@ -2543,6 +2546,7 @@ eimear={
 	name=Eimear
 	female=yes
 	culture=bronzebeard religion=khazism
+	sexuality = heterosexual
 	trait = education_diplomacy_2
 	trait = content
 	365.5.25={ birth=yes trait=creature_dwarf }

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -102,7 +102,7 @@
 	mother=6	#Taria
 	573.4.1={ 
 		birth=yes trait=creature_human 
-		effect = { make_important_lore_character_effect = yes } 
+		effect = { make_important_lore_character_effect = yes }
 	}
 	575.1.1={
 		effect = {
@@ -2183,6 +2183,7 @@
 	name=Bolten
 	dynasty=3
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=5 stewardship=4 intrigue=4 learning=7
 	trait=education_martial_2
 	trait=arbitrary trait=ambitious trait=arrogant trait=brave 
@@ -7406,6 +7407,7 @@
 	name=Patricia
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=5 stewardship=6 intrigue=4 learning=6
 	trait=education_intrigue_2 trait=arbitrary trait=deceitful trait=arrogant trait=stubborn
 	555.2.9={ birth=yes }
@@ -12891,12 +12893,19 @@
 	name=Nielas
 	dynasty=31
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=7 intrigue=6 learning=8
 	trait=education_learning_4
 	trait=magic_good_3
 	501.1.1={
 		birth=yes trait=creature_human
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_4_magic_trait_value } }
+	}
+	537.1.1={
+		add_spouse = 60578
+		effect = {
+			set_relation_soulmate = character:60578 # Aegwynn
+		}
 	}
 	552.1.16={death=yes}
 }
@@ -15325,6 +15334,7 @@
 	name=Abercrombie
 	dynasty=404
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=8 stewardship=8 intrigue=7 learning=5
 	trait=education_learning_2 trait=generous trait=chaste trait=compassionate trait=diligent 
 	disallow_random_traits = yes
@@ -15350,6 +15360,7 @@
 	female=yes
 	dynasty=403
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=8 stewardship=8 intrigue=4 learning=5
 	trait=education_stewardship_4 trait=compassionate trait=gregarious trait=generous trait=chaste 
 	disallow_random_traits = yes
@@ -15606,6 +15617,7 @@
 	name=Isiah			#Reginald's greatgrandfather
 	dynasty=413
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=6 stewardship=3 intrigue=4 learning=4
 	495.10.8 = { birth=yes }
 	522.7.13 = {
@@ -15620,6 +15632,7 @@
 	name=Landen			#Reginald's grandfather
 	dynasty=413
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=6 stewardship=3 intrigue=4 learning=4
 	father=5820		# Isiah
 	mother=5830		# Dalia
@@ -15638,6 +15651,7 @@
 	name=Scot			#Reginald's father
 	dynasty=413
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=4 stewardship=5 intrigue=3 learning=4
 	father=5821		# Landen
 	mother=5835		# Ysabel
@@ -15662,6 +15676,7 @@
 	name=Reginald
 	dynasty=413
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=4 intrigue=4 learning=4
 	trait=education_martial_2 trait=strong trait=stubborn trait=honest trait=brave
 	father=5822		# Scot
@@ -15689,6 +15704,7 @@
 	name=Dalia				#Reginald's greatgrandmother
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=1 diplomacy=6 stewardship=6 intrigue=5 learning=3
 	498.3.26 = { birth=yes }
 	551.10.8={ death=yes }
@@ -15697,6 +15713,7 @@
 	name=Ysabel				#Reginald's grandmother
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=2 diplomacy=4 stewardship=6 intrigue=4 learning=4
 	524.1.16 = { birth=yes }
 	576.11.12={ death=yes }
@@ -15705,6 +15722,7 @@
 	name=Jane				#Reginald's mother
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=2 diplomacy=4 stewardship=6 intrigue=4 learning=4
 	550.1.16 = { birth=yes }
 	565.1.1={

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -21,6 +21,7 @@
 	dynasty=1
 	dna = llane_wrynn_dna_2
 	religion=holy_light culture=azerothian
+	sexuality = heterosexual
 	martial=8 diplomacy=6 intrigue=4 stewardship=7 learning=5
 	trait=education_martial_4 trait=brave trait=gregarious trait=honest trait=trusting
 	disallow_random_traits = yes
@@ -68,6 +69,7 @@
 	dna = taria_wrynn_dna
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=7 intrigue=5 stewardship=7 learning=4
 	trait=education_diplomacy_3 trait=chaste trait=patient trait=cynical
 	disallow_random_traits = yes
@@ -93,6 +95,7 @@
 	dynasty=1
 	dna=varian_wrynn_dna
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=6 stewardship=5 intrigue=3 learning=3
 	trait=education_martial_4 trait=diligent trait=compassionate trait=generous trait=stubborn
 	father=2	#Llane
@@ -123,7 +126,7 @@
 		}
 	}
 	601.5.3={
-				# Because of Tiffin's death
+			# Because of Tiffin's death
 	}
 	640.1.1={ death=yes }
 }
@@ -132,6 +135,7 @@
 	dynasty=1
 	dna=anduin_wrynn_dna
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=5 intrigue=3 learning=7
 	trait=education_diplomacy_4 trait=gregarious trait=trusting trait=honest trait=generous
 	father=8		# Varian
@@ -2237,6 +2241,7 @@
 	name=Morelan
 	dynasty=3
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=8 stewardship=6 intrigue=4 learning=5
 	trait=education_martial_3
 	trait=brave trait=humble trait=honest trait=diligent
@@ -3905,6 +3910,7 @@
 	female=yes
 	dynasty=5
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=3 diplomacy=6 stewardship=7 intrigue=3 learning=5
 	trait=education_stewardship_3
 	trait=temperate trait=generous trait=patient trait=compassionate
@@ -7387,6 +7393,7 @@
 	name=Mary
 	female=yes
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=7 intrigue=8 learning=7
 	trait=education_diplomacy_3 trait=humble trait=content trait=compassionate
 	581.5.3={ birth=yes }
@@ -12627,6 +12634,7 @@
 	female=yes
 	dynasty=15
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=5 intrigue=7 learning=5
 	trait=education_intrigue_4
 	trait=content trait=just
@@ -12755,6 +12763,7 @@
 	name=Waltion
 	dynasty=16
 	culture=azerothian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=4 stewardship=5 intrigue=7 learning=4
 	trait=education_intrigue_3
 	trait=honest trait=content
@@ -12835,6 +12844,7 @@
 	mother=60578
 	culture=azerothian religion=kirin_tor
 	# secret_religion=burning_legion_religion
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=7 intrigue=6 learning=8
 	trait=education_learning_4
 	trait=magic_good_3

--- a/history/characters/210000_tauren.txt
+++ b/history/characters/210000_tauren.txt
@@ -330,6 +330,7 @@
 	female=yes
 	dynasty=1160016
 	culture=tauren religion=earth_mother_worship
+	sexuality = heterosexual
 	martial=4 diplomacy=4 stewardship=4 intrigue=4 learning=4
 	trait=education_intrigue_4 trait=intellect_good_2 trait=diligent trait=shrewd
 	disallow_random_traits = yes
@@ -8506,6 +8507,7 @@
 	name=Yodol't
 	dynasty=1160015
 	culture=tauren religion=earth_mother_worship
+	sexuality = heterosexual
 	martial=4 diplomacy=8 stewardship=8 intrigue=6 learning=4
 	trait=education_martial_3 trait=brave trait=diligent trait=lustful 
 	disallow_random_traits = yes

--- a/history/characters/210000_tauren.txt
+++ b/history/characters/210000_tauren.txt
@@ -4,6 +4,7 @@
 	name=Cairne
 	dynasty=116000
 	culture=tauren religion=earth_mother_worship
+	sexuality = heterosexual
 	martial=8 diplomacy=7 stewardship=7 intrigue=3 learning=6
 	trait=diligent trait=brave trait=just
 	trait=education_martial_3 trait=strong trait=physique_good_3
@@ -63,6 +64,7 @@
 	name=Tamaala
 	female=yes
 	culture=tauren religion=earth_mother_worship
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=compassionate trait=gregarious trait=chaste
 	disallow_random_traits = yes

--- a/history/characters/22000_wildhammer.txt
+++ b/history/characters/22000_wildhammer.txt
@@ -161,6 +161,7 @@
 	name=Thoryl
 	dynasty=4400
 	culture=wildhammer religion=shamanism
+	sexuality = heterosexual
 	martial=7 diplomacy=7 stewardship=5 intrigue=8 learning=4
 	trait=education_martial_3 trait=compassionate trait=brave trait=trusting
 	father=22051	#Bramrigg

--- a/history/characters/340000_night_elf.txt
+++ b/history/characters/340000_night_elf.txt
@@ -4,6 +4,7 @@
 	name=Pas'draen
 	dynasty=128000
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=7 intrigue=3 learning=8
 	trait=education_martial_3 trait=diligent trait=brave trait=patient trait=strategist
 	2.12.21={ birth=yes trait=creature_night_elf }
@@ -28,6 +29,7 @@
 	name=Natalia
 	female=yes
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=4 diplomacy=5 stewardship=6 intrigue=5 learning=8
 	trait=education_learning_3 trait=honest trait=shrewd trait=diligent trait=chaste
 	2.9.23={ birth=yes trait=creature_night_elf }
@@ -77,6 +79,7 @@
 	female=yes
 	dynasty=128002
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=5 diplomacy=8 stewardship=8 intrigue=3 learning=8
 	trait=education_learning_4 trait=diligent trait=chaste trait=brave trait=temperate
 	trait=beauty_good_lore  
@@ -114,6 +117,7 @@
 	dna = malfurion_stormrage_dna
 	dynasty=128003
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=6 diplomacy=7 stewardship=6 intrigue=4 learning=6
 	trait=education_learning_4
 	trait=twin
@@ -156,6 +160,7 @@
 	dynasty=128003
 	dna=illidan_stormrage_dna
 	culture=night_elf religion=illidari
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=8 learning=6
 	trait=education_intrigue_4
 	trait=twin trait=magic_good_3
@@ -369,6 +374,7 @@
 	dna = jarod_shadowsong_dna
 	dynasty=128008
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=5 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	trait=education_martial_4
 	trait=patient trait=diligent trait=brave trait=humble
@@ -398,6 +404,7 @@
 	name=Shalasyr
 	female=yes
 	culture=night_elf religion=kaldorei_religion
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=8 intrigue=4 learning=4
 	trait=education_learning_2
 	trait=content trait=shy trait=humble

--- a/history/characters/400000_titan.txt
+++ b/history/characters/400000_titan.txt
@@ -91,6 +91,7 @@
 	name = Thorim
 	dynasty=150005
 	culture=titanforged religion=mystery_of_the_makers
+	sexuality = heterosexual
 	martial=18 diplomacy=11 stewardship=10 intrigue=6 learning=10
 	trait=education_martial_4 trait=brave trait=compassionate trait=wrathful
 	trait=physique_good_2

--- a/history/characters/400000_titan.txt
+++ b/history/characters/400000_titan.txt
@@ -23,6 +23,7 @@
 	name = Loken
 	dynasty=150004
 	culture=titanforged religion=mystery_of_the_makers
+	sexuality = heterosexual
 	martial=12 diplomacy=8 stewardship=9 intrigue=13 learning=13
 	trait=education_learning_4 trait=lustful trait=deceitful trait=callous
 	trait = intellect_good_2

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1073,6 +1073,7 @@
 	dynasty=20016
 	dna=sylvanas_windrunner_dna
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=6 diplomacy=4 stewardship=6 intrigue=5 learning=5
 	trait=education_martial_4
 	trait=unyielding_defender
@@ -1329,6 +1330,7 @@
 	dynasty=20016
 	dna=alleria_windrunner_dna
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=5 diplomacy=5 stewardship=5 intrigue=6 learning=5
 	trait=education_martial_4 trait=beauty_good_lore trait=brave trait=diligent trait=stubborn trait=patient trait=rough_terrain_expert
 	disallow_random_traits = yes
@@ -1361,6 +1363,7 @@
 	dynasty=20016
 	dna=vereesa_windrunner_dna
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=4 intrigue=5 learning=5
 	trait=education_martial_4 trait=beauty_good_lore trait=brave trait=compassionate trait=trusting
 	disallow_random_traits = yes
@@ -1811,6 +1814,7 @@
 	name=Qaeyas
 	dynasty=20020
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_martial_2
 	trait=intellect_good_2 trait=lustful trait=ambitious trait=lazy trait=deceitful
@@ -1842,6 +1846,7 @@
 	name=Nelea
 	female=yes
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_intrigue_3
 	trait=intellect_good_2 trait=humble trait=chaste trait=strategist
@@ -1896,6 +1901,7 @@
 	name=Vynaen
 	dynasty=20022
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	martial=7 diplomacy=6 stewardship=5 intrigue=8 learning=8
 	trait=education_diplomacy_3 trait=wrathful trait=generous trait=compassionate trait=lustful 
 	500.10.7={ birth=yes trait=creature_high_elf }
@@ -1945,6 +1951,7 @@
 	name=Beledine
 	female=yes
 	culture=high_elf religion=cult_of_sunwell
+	sexuality = heterosexual
 	549.7.18={ birth=yes trait=creature_high_elf }
 	# Killed by bandits before the Scourge
 	603.1.1={

--- a/history/characters/450000_sayaadi.txt
+++ b/history/characters/450000_sayaadi.txt
@@ -3,6 +3,7 @@
 	name=Moora
 	female=yes
 	culture=sayaadi religion=burning_legion_religion
+	sexuality = bisexual
 	martial=6 diplomacy=5 stewardship=6 intrigue=6 learning=8
 	trait=education_intrigue_2
 	trait=beauty_good_3
@@ -15,6 +16,7 @@
 	name=Salia
 	female=yes
 	culture=sayaadi religion=burning_legion_religion
+	sexuality = bisexual
 	martial=4 diplomacy=6 stewardship=6 intrigue=7 learning=7
 	trait=education_intrigue_2
 	trait=beauty_good_3
@@ -31,6 +33,7 @@
 	female=yes
 	dynasty=147000
 	culture=sayaadi religion=burning_legion_religion
+	sexuality = bisexual
 	martial=6 diplomacy=5 stewardship=5 intrigue=7 learning=5
 	trait=education_intrigue_3
 	trait=beauty_good_3

--- a/history/characters/46000_gilnean.txt
+++ b/history/characters/46000_gilnean.txt
@@ -12,6 +12,7 @@
 }
 46001={
 	name=Genn
+	sexuality = heterosexual
 	dynasty=24000
 	dna=genn_greymane_dna
 	culture=gilnean religion=holy_light
@@ -42,6 +43,7 @@
 	dna = mia_greymane_dna
 	female=yes
 	culture=gilnean religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=5 stewardship=4 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=chaste trait=gregarious trait=humble 
 	trait=trusting 

--- a/history/characters/46000_gilnean.txt
+++ b/history/characters/46000_gilnean.txt
@@ -12,10 +12,10 @@
 }
 46001={
 	name=Genn
-	sexuality = heterosexual
 	dynasty=24000
 	dna=genn_greymane_dna
 	culture=gilnean religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=1 stewardship=6 intrigue=3 learning=7
 	trait=education_martial_3
 	trait=strong
@@ -29,6 +29,7 @@
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
 			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
+			set_relation_soulmate = character:46002
 		}
 		# trait=physical_lifestyle_endurance_2
 		# trait=physical_lifestyle_strength_2
@@ -46,7 +47,7 @@
 	sexuality = heterosexual
 	martial=6 diplomacy=5 stewardship=4 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=chaste trait=gregarious trait=humble 
-	trait=trusting 
+	trait=trusting
 	disallow_random_traits=yes
 	558.4.12={ birth=yes trait=creature_human effect = { make_important_lore_character_effect = yes } }
 	620.3.30={ death=yes }

--- a/history/characters/48000_tirassian.txt
+++ b/history/characters/48000_tirassian.txt
@@ -782,6 +782,7 @@
 	dna=daelin_proudmoore_dna
 	dynasty=26000
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=8 diplomacy=5 stewardship=8 intrigue=3 learning=6
 	trait=education_martial_4 trait=strong trait=strategist
 	trait=temperate trait=diligent trait=wrathful trait=brave  
@@ -817,6 +818,7 @@
 	female=yes
 	dynasty=26000
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=8 diplomacy=6 stewardship=6 intrigue=2 learning=7
 	trait=education_learning_4
 	trait=magic_good_3
@@ -912,6 +914,7 @@
 	dna=katherine_proudmoore_dna
 	female=yes
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=6 diplomacy=8 stewardship=6 intrigue=4 learning=5
 	trait=education_diplomacy_3 trait=just trait=honest trait=patient trait=trusting 
 	549.11.19={ 

--- a/history/characters/48000_tirassian.txt
+++ b/history/characters/48000_tirassian.txt
@@ -1719,6 +1719,7 @@
 	name=Arthur
 	dynasty=26001
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=7 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_3
 	trait=honest trait=arrogant trait=trusting trait=chaste
@@ -1751,6 +1752,7 @@
 	# dynasty=26001
 	female=yes
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=7
 	trait=education_learning_4
 	trait=beauty_good_3 trait=sadistic trait=deceitful trait=chaste
@@ -10577,6 +10579,7 @@
 	name=Aldrius
 	dynasty=26004
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=8 diplomacy=5 stewardship=8 intrigue=3 learning=6
 	trait=education_diplomacy_3
 	trait=generous trait=temperate trait=patient trait=content
@@ -12517,6 +12520,7 @@
 	name=Wallace
 	dynasty=26116
 	culture=tirassian religion=tidemother
+	sexuality = heterosexual
 	martial=4 diplomacy=5 stewardship=6 intrigue=5 learning=7
 	trait=education_diplomacy_4
 	564.4.25={ birth=yes trait=creature_human }

--- a/history/characters/500000_pandaren.txt
+++ b/history/characters/500000_pandaren.txt
@@ -6945,6 +6945,7 @@
 	name=Zhang
 	dynasty=170011
 	culture=mainland_pandaren religion=august_celestials
+	sexuality = heterosexual
 	martial=6 diplomacy=5 stewardship=4 intrigue=7 learning=7
 	trait=education_martial_1 trait=celibate trait=diligent trait=lustful 
 	father=500716	#Tong
@@ -7090,6 +7091,7 @@
 	name=Lang
 	dynasty=170015
 	culture=mainland_pandaren religion=august_celestials
+	sexuality = heterosexual
 	martial=6 diplomacy=5 stewardship=6 intrigue=5 learning=6
 	trait=education_intrigue_2 trait=lazy trait=compassionate trait=humble trait=cynical 
 	father=500728	#Ji
@@ -37608,6 +37610,7 @@
 	name=Mia
 	female=yes
 	culture=mainland_pandaren religion=august_celestials
+	sexuality = heterosexual
 	560.4.2={ birth=yes trait=creature_pandaren }
 	639.5.19={ death=yes }
 }
@@ -37615,6 +37618,7 @@
 	name=Rin
 	female=yes
 	culture=mainland_pandaren religion=august_celestials
+	sexuality = heterosexual
 	573.4.18={ birth=yes trait=creature_pandaren }
 	612.6.23={ death=yes }
 }

--- a/history/characters/52000_ogre.txt
+++ b/history/characters/52000_ogre.txt
@@ -940,6 +940,7 @@
 52450={
 	name=Turok
 	culture=ogre religion=gorgog_worship
+	sexuality = heterosexual
 	martial=8 diplomacy=7 stewardship=6 intrigue=7 learning=7
 	trait=education_martial_2
 	trait=beauty_good_3 #WHY NOT?!
@@ -947,6 +948,9 @@
 	561.6.6={ birth=yes }
 	583.1.1={
 		employer=10000 #Blackhand[2000]
+		effect={
+			set_relation_soulmate = character:10004 #Griselda
+		}
 	}
 	#Executed by Blackhand
 	584.1.1={

--- a/history/characters/53000_hillsbrad.txt
+++ b/history/characters/53000_hillsbrad.txt
@@ -74,6 +74,7 @@
 	name=Tammis
 	dynasty=32002
 	culture=hillsbrad religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=content trait=patient trait=generous
 	trait=humble
@@ -101,6 +102,7 @@
 	name=Clannia
 	female=yes
 	culture=hillsbrad religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=7 stewardship=5 intrigue=5 learning=8
 	trait=education_learning_2 trait=gregarious trait=compassionate trait=humble
 	disallow_random_traits = yes
@@ -397,6 +399,7 @@
 	name=Vorrel
 	dynasty=32008
 	culture=hillsbrad religion=holy_light
+	sexuality = heterosexual
 	martial=7 diplomacy=5 stewardship=6 intrigue=6 learning=5
 	trait=education_martial_3 trait=compassionate trait=cynical trait=humble trait=shy 
 	trait=shrewd
@@ -414,6 +417,7 @@
 	name=Monika
 	female=yes
 	culture=hillsbrad religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=7 stewardship=5 intrigue=6 learning=6
 	trait=education_diplomacy_4 trait=compassionate trait=deceitful trait=diligent
 	trait=intellect_good_2

--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -4,9 +4,10 @@
 	dna=aiden_perenolde_dna
 	dynasty=34000
 	culture=alteraci religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=4 stewardship=6 intrigue=6 learning=5
 	trait=education_diplomacy_2
-	trait=deceitful trait=shy trait=temperate trait=greedy 
+	trait=deceitful trait=shy trait=temperate trait=greedy
 	disallow_random_traits = yes
 	father=58006	#Hrolfr
 	550.7.21={ 
@@ -45,6 +46,7 @@
 	dna = isolde_perenolde_dna
 	female=yes
 	culture=alteraci religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=7 stewardship=7 intrigue=4 learning=6
 	trait=education_diplomacy_2 trait=patient trait=zealous
 	551.9.17={ birth=yes trait=creature_human }

--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -568,6 +568,7 @@
 	name=Zoltan
 	dynasty=34071
 	culture=alteraci religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=5 stewardship=6 intrigue=3 learning=4
 	trait=education_stewardship_2
 	trait=gregarious trait=honest trait=patient trait=generous
@@ -584,6 +585,7 @@
 	name=Lucina
 	female=yes
 	culture=alteraci religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=4 stewardship=5 intrigue=4 learning=5
 	552.7.5={ birth=yes trait=creature_human }
 	598.1.18={ death=yes }

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -355,6 +355,7 @@
 	name=Rhonin
 	dna = rhonin_dna
 	culture=dalaranian religion=kirin_tor
+	sexuality = heterosexual
 	martial=7 diplomacy=7 stewardship=8 intrigue=5 learning=6
 	trait=education_learning_4 trait=magic_good_3
 	trait=temperate trait=brave trait=compassionate trait=wrathful trait=shrewd

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -280,6 +280,7 @@
 	dna = alexei_barov_dna
 	dynasty=30002
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=7 diplomacy=6 stewardship=8 intrigue=6 learning=5
 	trait=education_martial_3
 	trait=greedy trait=callous trait=arrogant
@@ -322,6 +323,7 @@
 	dna = illucia_barov_dna
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=4 stewardship=4 intrigue=8 learning=8
 	trait=education_learning_3
 	trait=callous trait=arrogant trait=chaste
@@ -573,11 +575,11 @@
 }
 60018={
 	name=Elena
-	sexuality = heterosexual
 	dna=elena_mograine_dna
 	female=yes
 	# dynasty=30004
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=5 intrigue=4 learning=8
 	trait=education_diplomacy_3 trait=compassionate trait=patient trait=generous trait=humble
 	disallow_random_traits=yes
@@ -986,6 +988,7 @@
 	name=Jorum
 	dynasty=30010
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=6 stewardship=7 intrigue=4 learning=4
 	trait=education_stewardship_3 trait=patient trait=diligent trait=humble trait=temperate
 	disallow_random_traits=yes
@@ -999,6 +1002,7 @@
 	name=Vara
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=3 diplomacy=6 stewardship=6 intrigue=4 learning=6
 	trait=education_stewardship_2 trait=shy trait=humble trait=chaste
 	disallow_random_traits=yes
@@ -3142,6 +3146,7 @@
 	name=Darric
 	dynasty=30035
 	culture=northern religion=staroverstvo
+	sexuality = heterosexual
 	martial=6 diplomacy=7 stewardship=4 intrigue=8 learning=6
 	trait=education_martial_2 trait=zealous trait=shy trait=lazy
 	trait=content
@@ -3219,6 +3224,7 @@
 	female=yes
 	culture=northern
 	religion=staroverstvo
+	sexuality = heterosexual
 	525.2.11={ birth=yes trait=creature_human }
 	594.1.1={
 		religion = death_god
@@ -4101,6 +4107,7 @@
 	name=Aegwynn
 	female=yes
 	culture=lordaeronian religion=kirin_tor
+	sexuality = heterosexual
 	martial=4 diplomacy=4 stewardship=4 intrigue=3 learning=3
 	trait=education_learning_4
 	trait=magic_good_3
@@ -4119,6 +4126,9 @@
 	}
 	537.1.1={
 		add_spouse = 5001
+		effect = {
+			set_relation_soulmate = character:5001 # Nielas
+		}
 	}
 	583.1.1={
 		employer=2
@@ -9304,6 +9314,7 @@ arthur_fordragon={
 	name=Vivian
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	trait=education_stewardship_2 trait=compassionate
 	555.6.10={ birth=yes trait=creature_human}
 	# Killed on orders of Arthas by undead/subdued Thassarian	

--- a/history/characters/60000_63000_lordaeronian.txt
+++ b/history/characters/60000_63000_lordaeronian.txt
@@ -16,6 +16,7 @@
 	dynasty=30000
 	dna=terenas_menethil_dna
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=7 stewardship=8 intrigue=8 learning=5
 	trait=education_diplomacy_4
 	trait=compassionate trait=humble trait=just trait=temperate
@@ -50,6 +51,7 @@
 	dna = lianne_menethil_dna
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=compassionate trait=gregarious trait=chaste
 	disallow_random_traits = yes
@@ -67,6 +69,7 @@
 	dna=arthas_menethil_dna_2
 	dynasty=30000
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=4 stewardship=5 intrigue=5 learning=6
 	trait=education_martial_4
 	trait=vengeful trait=stubborn trait=arrogant
@@ -144,6 +147,7 @@
 	female=yes
 	dynasty=30000
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	trait=education_learning_3 trait=chaste trait=compassionate trait = honest
 	father=60001	#Terenas
 	mother=60002	#Lianne
@@ -181,6 +185,7 @@
 #Agamand
 60005={
 	name=Gregor
+	sexuality = heterosexual
 	dynasty=30001
 	culture=lordaeronian religion=holy_light
 	martial=8 diplomacy=5 stewardship=5 intrigue=6 learning=7
@@ -203,6 +208,7 @@
 }
 60006={
 	name=Nissa
+	sexuality = heterosexual
 	female=yes
 	culture=lordaeronian religion=holy_light
 	trait=education_stewardship_2 trait=compassionate trait=chaste trait=gregarious
@@ -445,6 +451,7 @@
     dna=tirion_fordring_dna_2
 	dynasty=30003
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=7 diplomacy=7 stewardship=6 intrigue=3 learning=6
 	trait=education_martial_4 trait=generous trait=compassionate trait=diligent trait=brave
 	disallow_random_traits = yes
@@ -480,6 +487,7 @@
 }
 60015={
 	name=Karandra
+	sexuality = heterosexual
 	dna = karandra_fordring_dna
 	female=yes
 	culture=lordaeronian religion=holy_light
@@ -524,6 +532,7 @@
 	dna=alexandros_dna
 	dynasty=30004
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=10 diplomacy=7 stewardship=7 intrigue=4 learning=6
 	trait=education_martial_4 trait=compassionate trait=patient trait=generous trait=brave trait=physique_good_3
 	disallow_random_traits=yes
@@ -564,6 +573,7 @@
 }
 60018={
 	name=Elena
+	sexuality = heterosexual
 	dna=elena_mograine_dna
 	female=yes
 	# dynasty=30004
@@ -759,6 +769,7 @@
 	name=Ramnulf
 	dynasty=30007
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=7 diplomacy=6 stewardship=7 intrigue=6 learning=6
 	trait=education_martial_3 trait=compassionate trait=just trait=humble trait=trusting
 	disallow_random_traits=yes
@@ -798,6 +809,7 @@
 	name=Carolaine
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=6 diplomacy=8 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_4 trait=compassionate trait=honest trait=trusting trait=gregarious
 	disallow_random_traits=yes
@@ -853,6 +865,7 @@
 	dna = robert_garithos_dna
 	dynasty=30008
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=5 stewardship=6 intrigue=7 learning=7
 	trait=education_stewardship_3 trait=patient trait=diligent trait=shrewd
 	disallow_random_traits=yes
@@ -875,6 +888,7 @@
 	dna = aliberta_garithos_dna
 	female=yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=7 intrigue=6 learning=7
 	trait=education_stewardship_3 trait=patient trait=humble trait=trusting trait=honest
 	disallow_random_traits=yes
@@ -899,7 +913,7 @@
 	disallow_random_traits=yes
 	father=60028	#Robert
 	mother=60029	#Aliberta
-	566.2.23={ 
+	566.2.23={
 		birth=yes trait=creature_human 
 		effect = { make_important_lore_character_effect = yes }
 	}
@@ -1431,6 +1445,7 @@
 	name=Arthur
 	dynasty=30020
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=4 intrigue=8 learning=7
 	trait=education_stewardship_3 trait=greedy trait=just trait=gluttonous
 	father=60310 #Robert
@@ -1449,6 +1464,7 @@
 	female=yes
 	# dynasty=30020
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=5 intrigue=6 learning=6
 	trait=education_diplomacy_3 trait=ambitious trait=humble trait=arbitrary
 	540.8.12={ birth=yes trait=creature_human }
@@ -1463,6 +1479,7 @@
 	dynasty=30020
 	dna=nathanos_marris_dna
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=6 stewardship=6 intrigue=6 learning=4
 	trait=education_martial_4
 	trait=unyielding_defender
@@ -1895,6 +1912,7 @@
 	name=Del
 	dynasty=30024
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=5 stewardship=7 intrigue=5 learning=4
 	trait=education_martial_2 trait=brave trait=diligent trait=gregarious trait=chaste
 	disallow_random_traits=yes
@@ -1913,6 +1931,7 @@
 	female=yes
 	# dynasty=30024
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	trait=education_learning_2 trait=zealous trait=compassionate trait=chaste trait=generous
 	disallow_random_traits=yes
 	540.4.22={ birth=yes trait=creature_human }
@@ -3071,6 +3090,7 @@
 	name=Turalyon
 	dna=turalyon_dna
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=8 diplomacy=7 stewardship=5 intrigue=6 learning=6
 	trait=education_martial_4 trait=brave trait=humble trait=compassionate trait=generous
 	565.1.2={ 
@@ -4261,6 +4281,7 @@
 60676={
 	name=Kiril
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=7 diplomacy=5 stewardship=5 intrigue=5 learning=6
 	trait=education_martial_3
 	trait=physique_good_1 trait=patient trait=humble trait=compassionate trait=zealous
@@ -4277,6 +4298,9 @@
 		employer=53053 # Southshore
 	}
 	598.4.24={
+		effect={
+			set_relation_soulmate = character:60004 # Calia Menethil
+		}
 		add_matrilineal_spouse=60004 # Calia Menethil (unaware of her royal status)
 	}
 	611.2.28={ death=yes }
@@ -4652,6 +4676,7 @@ arthur_fordragon={
 	dynasty=30132
 	father=60688
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=7 stewardship=6 intrigue=4 learning=4
 	571.3.11={ birth=yes trait=creature_human }
 	587.3.11={
@@ -4677,6 +4702,7 @@ arthur_fordragon={
 	name=Lynn
 	female = yes
 	culture=lordaeronian religion=holy_light
+	sexuality = heterosexual
 	martial=4 diplomacy=6 stewardship=4 intrigue=3 learning=5
 	573.2.11={ birth=yes trait=creature_human }
 	589.2.11={
@@ -9253,6 +9279,7 @@ arthur_fordragon={
 #Father of Thassarian and Leryssa
 61195={
 	name=Killoren
+	sexuality = heterosexual
 	culture=lordaeronian religion=holy_light
 	martial=6 diplomacy=4 stewardship=5 intrigue=5 learning=4
 	trait=education_martial_3 trait=brave trait=generous trait=compassionate

--- a/history/characters/62000_dragon.txt
+++ b/history/characters/62000_dragon.txt
@@ -16,6 +16,7 @@
 	female = yes
 	give_nickname=nick_the_dreamer
 	culture=green_dragon religion=yserism
+	sexuality = heterosexual
 	martial=6 diplomacy=8 stewardship=7 intrigue=7 learning=8
 	trait=education_diplomacy_4
 	trait = aspect_of_nature
@@ -76,6 +77,7 @@
 62005={
 	name=Eranikus
 	culture=green_dragon religion=yserism
+	sexuality = heterosexual
 	martial=7 diplomacy=8 stewardship=7 intrigue=8 learning=8
 	trait=education_diplomacy_4
 	trait=chaste trait=content trait=brave trait=gregarious
@@ -94,6 +96,7 @@
 	dynasty=38050
 	give_nickname=nick_the_destroyer
 	culture=black_dragon religion=nzoth_worship
+	sexuality = heterosexual
 	martial=10 diplomacy=5 stewardship=5 intrigue=10 learning=6
 	trait=education_martial_4
 	trait = aspect_of_death
@@ -120,6 +123,7 @@
 	dna=sintharia_dna
 	female = yes
 	culture=black_dragon religion=nzoth_worship
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=5 intrigue=7 learning=6
 	trait=education_intrigue_4
 	trait=deceitful trait=chaste trait=temperate trait=arrogant
@@ -159,6 +163,7 @@
 	female=yes
 	dynasty=38050
 	culture=black_dragon religion=nzoth_worship
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=4 intrigue=4 learning=7
 	trait=education_intrigue_4
 	trait=deceitful trait=ambitious trait=gregarious trait=arrogant
@@ -207,6 +212,7 @@
 	female = yes
 	give_nickname=nick_the_life_binder
 	culture=red_dragon religion=alexstraszism
+	sexuality = heterosexual
 	martial=6 diplomacy=10 stewardship=6 intrigue=5 learning=9
 	trait=education_diplomacy_4
 	trait = aspect_of_life
@@ -243,6 +249,7 @@
 62401={
 	name=Korialstrasz
 	culture=red_dragon religion=alexstraszism
+	sexuality = heterosexual
 	martial=7 diplomacy=5 stewardship=8 intrigue=4 learning=7
 	trait=education_learning_3
 	trait=diligent trait=brave trait=patient trait=humble
@@ -302,6 +309,7 @@
 	dynasty=38150
 	give_nickname=nick_the_spellweaver
 	culture=blue_dragon religion=malygosism
+	sexuality = heterosexual
 	martial=8 diplomacy=6 stewardship=6 intrigue=4 learning=12
 	trait=education_learning_4
 	trait = aspect_of_magic
@@ -332,6 +340,7 @@
 	name=Saragosa
 	female=yes
 	culture=blue_dragon religion=malygosism
+	sexuality = heterosexual
 	martial=7 diplomacy=4 stewardship=8 intrigue=7 learning=7
 	trait=education_learning_2
 	trait=paranoid trait=content trait=brave trait=arbitrary
@@ -477,6 +486,7 @@ colbatann={
 	dynasty=38200
 	give_nickname=nick_the_timeless
 	culture=bronze_dragon religion=nozdormism
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=10 intrigue=7 learning=8
 	trait=education_stewardship_4
 	trait = aspect_of_time
@@ -512,6 +522,7 @@ colbatann={
 	name=Soridormi
 	female=yes
 	culture=bronze_dragon religion=nozdormism
+	sexuality = heterosexual
 	martial=4 diplomacy=8 stewardship=8 intrigue=7 learning=6
 	trait=education_stewardship_4
 	trait=beauty_good_3 trait=chaste trait=humble trait=diligent trait=honest

--- a/history/characters/62000_dragon.txt
+++ b/history/characters/62000_dragon.txt
@@ -443,6 +443,7 @@ haleh={
 	name=Haleh
 	female = yes
 	culture=blue_dragon religion=malygosism
+	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=5 intrigue=6 learning=8
 	trait=education_learning_4
 	trait=shy trait=calm trait=diligent

--- a/history/characters/64000_goblin.txt
+++ b/history/characters/64000_goblin.txt
@@ -146,6 +146,7 @@
 	name=Luzik
 	dynasty=28030
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	martial=6 diplomacy=4 stewardship=6 intrigue=7 learning=4
 	trait=education_stewardship_2 trait=cynical trait=lazy trait=paranoid
 	trait=chaste 
@@ -166,6 +167,7 @@
 	name=Lisa
 	female=yes
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	536.6.2={ birth=yes trait=creature_goblin }
 	578.1.2={ death=yes }
 }

--- a/history/characters/64000_goblin.txt
+++ b/history/characters/64000_goblin.txt
@@ -22,6 +22,7 @@
 	name=Zeaz
 	dynasty=28106
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	martial=4 diplomacy=6 stewardship=8 intrigue=6 learning=6
 	trait=education_learning_1 trait=diligent trait=wrathful trait=chaste 
 	trait=arbitrary trait=lunatic_1
@@ -33,6 +34,7 @@
 	name=Greexdilex
 	dynasty=28106
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	martial=5 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_diplomacy_4 trait=paranoid trait=content trait=brave trait=arrogant
 	father=64005	#Zeaz
@@ -130,6 +132,7 @@
 	name=Nallyx
 	female=yes
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	527.1.1={ birth=yes trait=creature_goblin }
 	573.1.1={ death=yes }
 }
@@ -137,6 +140,7 @@
 	name=Moizlope
 	female=yes
 	culture=goblin religion=cult_of_wealth
+	sexuality = heterosexual
 	548.1.1={ birth=yes trait=creature_goblin }
 	611.1.1={ death=yes }
 }

--- a/history/characters/66000_zandalari.txt
+++ b/history/characters/66000_zandalari.txt
@@ -35,6 +35,7 @@ timalji = {
 	dynasty = 8330
 	religion = zandism
 	culture = zandalari
+	sexuality = heterosexual
 	trait = ambitious # Said to have a love o power
 	father = zandalari45
 	226.3.22 = { birth = yes trait = creature_troll }
@@ -2287,6 +2288,7 @@ wasi = {
 	dynasty = zandalari1
 	religion = zandism
 	culture = zandalari
+	sexuality = heterosexual
 	trait = ambitious # Said to have a love o power
 	mother = zandalari4
 	229.3.22 = { birth = yes trait = creature_troll }

--- a/history/characters/76000_nerubian.txt
+++ b/history/characters/76000_nerubian.txt
@@ -4,8 +4,9 @@
 	# dynasty = 47000
 	# culture=nerubian religion=spider_philosophy
 	# female = no
+	# sexuality = heterosexual
 	# martial=7 diplomacy=2 stewardship=5 intrigue=5 learning=7
-	# trait=education_martial_4 
+	# trait=education_martial_4
 	# trait=creature_nerubian 
 	# disallow_random_traits = yes
 	# trait=intellect_good_3 trait=wrathful trait=diligent trait=sadistic trait=brave


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
Many characters who have stated lovers and soulmates now have set sexualities.
Dagran and Moira get married when they become soulmates
The couples Genn and Mia, alongside Nielas and Aegwynn become soulmates when they get married

All Sayaads are now automatically bisexual
Sayaads are more likely to grow up to be lustful

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)


<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Check if Sayaadi children grow up to be bisexual and most likely lustful