### PR TITLE
Kultiras CoA color fix

### DIFF
--- a/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
+++ b/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
@@ -148,33 +148,33 @@ k_kul_tiras = {
 }
 d_drustwar = {
 	pattern = "pattern_solid.dds"
-	color1 = rgb "brown_drust" 
+	color1 = rgb { 89 58 42 } 
 	colored_emblem = {
 		texture = "ce_waycrest.dds"
-		color1 = rgb "cream_kultiras"
-		color2 = rgb "brown_drust" 
+		color1 = rgb { 165 171 176 }
+		color2 = rgb { 104 85 74 }
 		instance = { position = { 0.5 @single_charge_position } }
 	}
 }
 
 d_tidemother = {
 	pattern = "pattern_solid.dds"
-	color1 = rgb "blue_stormsong"
+	color1 = rgb "aqua_stormsong"
 	colored_emblem = {
 		texture = "ce_stormsong.dds"
-		color1 = rgb "cream_kultiras"
-		color2 = rgb "blue_stormsong"
+		color1 = rgb { 165 171 176 }
+		color2 = rgb "aqua_stormsong"
 		instance = { position = { 0.5 @single_charge_position } }
 	}
 }
 
 d_ashvane = {
 	pattern = "pattern_solid.dds"
-	color1 = rgb "orange_ashvane"
+	color1 = rgb { 173 54 41 }
 	colored_emblem = {
 		texture = "ce_ashvane.dds"
-		color1 = rgb "lightorange_ashvane"
-		color2 = rgb "orange_ashvane"
+		color1 = rgb { 216 161 131 }
+		color2 = rgb { 189 69 51 }
 		instance = { position = { 0.5 @single_charge_position } }
 	}
 }

--- a/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
+++ b/common/coat_of_arms/coat_of_arms/00_wc_landed_titles.txt
@@ -136,7 +136,15 @@ d_kirin_tor = {
 }
 
 ### Kul tiras
-
+e_kul_tiras = {
+	pattern = "pattern_solid.dds"
+	color1 = rgb { 37 78 51 } 
+	colored_emblem = {
+		texture = "ce_kul_tiras.dds"
+		color1 = rgb { 165 158 90 }
+		instance = { position = { 0.5 @single_charge_position } }
+	}
+}
 k_kul_tiras = {
 	pattern = "pattern_solid.dds"
 	color1 = rgb { 37 78 51 } 


### PR DESCRIPTION
Rewrote the Kul'Tiras duchies' CoA code.
In-game the CoAs look like this:
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/86983221/a6336465-d221-48ce-a9f3-f1543a683e88)

# How to test:
Launch game
Look at Kul'Tiras CoAs.
Make sure they have color&emblems.