### PR TITLE
Undead Population and Scourge Invite Conversion

### DIFF
--- a/common/character_interactions/00_courtier_and_guest_interactions.txt
+++ b/common/character_interactions/00_courtier_and_guest_interactions.txt
@@ -534,6 +534,8 @@ invite_to_court_interaction = {
 	desc = {
 		desc = invite_to_court_interaction_desc
 
+		# Warcraft
+		# Warning for Scourge players
 		triggered_desc = { 
 			trigger = { 
 				scope:actor.culture = { has_cultural_pillar = heritage_undead }

--- a/common/character_interactions/00_courtier_and_guest_interactions.txt
+++ b/common/character_interactions/00_courtier_and_guest_interactions.txt
@@ -5,7 +5,19 @@
 
 	special_ai_interaction = recruit_courtier
 
-	desc = recruit_guest_interaction_desc
+	# Warcraft
+	# Warning for Scourge players
+	desc = {
+		desc = recruit_guest_interaction_desc
+		triggered_desc = { 
+			trigger = { 
+				scope:actor.culture = { has_cultural_pillar = heritage_undead }
+				scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+			}
+
+			desc = recruit_guest_may_turn_undead
+		}
+	}
 
 	should_use_extra_icon = {
 		NOT = { scope:recipient = { is_close_family_of = scope:actor } }
@@ -112,6 +124,21 @@
 				target = scope:actor
 				opinion = 50
 				modifier = grateful_opinion
+			}
+
+			# Warcraft
+			# Scourge convert those who join court
+			if = { 
+				limit = { 
+					AND = {
+						scope:actor.culture = { has_cultural_pillar = heritage_undead }
+						scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+					}
+				} 
+				random = { 
+					chance = 90 
+					add_trait = being_undead
+				}
 			}
 		}
 
@@ -504,8 +531,18 @@ kick_from_court_interaction = {
 invite_to_court_interaction = {
 	category = interaction_category_vassal
 	icon = guest
-	
-	desc = invite_to_court_interaction_desc
+	desc = {
+		desc = invite_to_court_interaction_desc
+
+		triggered_desc = { 
+			trigger = { 
+				scope:actor.culture = { has_cultural_pillar = heritage_undead }
+				scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+			}
+
+			desc = invite_to_court_may_turn_undead
+		}
+	}
 	
 	is_shown = {
 		scope:recipient = {
@@ -617,6 +654,25 @@ invite_to_court_interaction = {
 				stress_impact = {
 					greedy = minor_stress_impact_gain
 				}
+			}
+		}
+
+		# Warcraft
+		# Scourge convert invitees to undead by inviting to court
+		scope:recipient = { 
+			if = { 
+				limit = { 
+					AND = {
+						scope:actor.culture = { has_cultural_pillar = heritage_undead }
+						scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+					}
+				} 
+				every_traveling_family_member = { 
+					random = { 
+						chance = 90 
+						add_trait = being_undead
+					}
+				} 
 			}
 		}
 	}

--- a/common/character_interactions/00_courtier_and_guest_interactions.txt
+++ b/common/character_interactions/00_courtier_and_guest_interactions.txt
@@ -136,7 +136,7 @@
 					}
 				} 
 				random = { 
-					chance = 90 
+					chance = scourge_conversion_effectiveness
 					add_trait = being_undead
 				}
 			}
@@ -671,7 +671,7 @@ invite_to_court_interaction = {
 				} 
 				every_traveling_family_member = { 
 					random = { 
-						chance = 90 
+						chance = scourge_conversion_effectiveness 
 						add_trait = being_undead
 					}
 				} 

--- a/common/character_interactions/00_grant_titles_interaction.txt
+++ b/common/character_interactions/00_grant_titles_interaction.txt
@@ -1100,8 +1100,12 @@
 						scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
 					}
 				} 
-
-				random = { chance = 90 add_trait = being_undead }
+				every_traveling_family_member = { 
+					random = { 
+						chance = 90 
+						add_trait = being_undead
+					}
+				} 
 			}
 		}
 

--- a/common/character_interactions/00_grant_titles_interaction.txt
+++ b/common/character_interactions/00_grant_titles_interaction.txt
@@ -3,7 +3,19 @@
 	category = interaction_category_vassal
 	common_interaction = yes
 
-	desc = grant_titles_interaction_desc
+	# Warcraft
+	desc = { 
+		desc = grant_titles_interaction_desc 
+
+		triggered_desc = { 
+			trigger = { 
+				scope:actor.culture = { has_cultural_pillar = heritage_undead }
+				scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+			}
+
+			desc = grant_title_may_turn_undead
+		}
+	}
 
 	special_interaction = grant_titles_interaction
 	interface = grant_titles
@@ -27,7 +39,7 @@
 			}
 		}
 	}
-	
+
 	is_valid_showing_failures_only = {
 		scope:recipient = {
 			custom_tooltip = {
@@ -1075,6 +1087,21 @@
 						custom_tooltip = grant_titles_interaction_notification_effect
 					}
 				}
+			}
+		}
+
+		# Warcraft
+		# Evil Undead heritage characters will turn other characters when granting titles
+		scope:recipient = { 
+			if = { 
+				limit = { 
+					AND = {
+						scope:actor.culture = { has_cultural_pillar = heritage_undead }
+						scope:actor.faith = { has_doctrine = special_doctrine_end_justifies_means }
+					}
+				} 
+
+				random = { chance = 99 add_trait = being_undead }
 			}
 		}
 

--- a/common/character_interactions/00_grant_titles_interaction.txt
+++ b/common/character_interactions/00_grant_titles_interaction.txt
@@ -1101,7 +1101,7 @@
 					}
 				} 
 
-				random = { chance = 99 add_trait = being_undead }
+				random = { chance = 90 add_trait = being_undead }
 			}
 		}
 

--- a/common/character_interactions/00_grant_titles_interaction.txt
+++ b/common/character_interactions/00_grant_titles_interaction.txt
@@ -1103,7 +1103,7 @@
 				} 
 				every_traveling_family_member = { 
 					random = { 
-						chance = 90 
+						chance = scourge_conversion_effectiveness 
 						add_trait = being_undead
 					}
 				} 

--- a/common/character_interactions/00_grant_titles_interaction.txt
+++ b/common/character_interactions/00_grant_titles_interaction.txt
@@ -4,6 +4,7 @@
 	common_interaction = yes
 
 	# Warcraft
+	# Warning for Scourge players
 	desc = { 
 		desc = grant_titles_interaction_desc 
 
@@ -1091,7 +1092,7 @@
 		}
 
 		# Warcraft
-		# Evil Undead heritage characters will turn other characters when granting titles
+		# Evil Undead heritage characters may turn other characters when granting titles
 		scope:recipient = { 
 			if = { 
 				limit = { 

--- a/common/script_values/wc_plague_values.txt
+++ b/common/script_values/wc_plague_values.txt
@@ -54,3 +54,13 @@ plague_agent_sins = {
 
 	min = 0
 }
+
+# Scourge conversion values
+
+scourge_undead_population_percent = { 
+	value = 80 # this could be changed with a game rule in the future
+}
+
+scourge_conversion_effectiveness = { 
+	value = 90 # this could be changed with a game rule in the future
+}

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -26,7 +26,7 @@ try_to_set_race_effect = {
 			culture = { has_cultural_pillar = heritage_undead } 
 		} 
 		random = { 
-			chance = 80 
+			chance = scourge_undead_population_percent
 			add_trait = being_undead 
 		} 
 	}

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -19,8 +19,8 @@ try_to_set_race_effect = {
 		# limit = { exists = mother }
 		# mother = { trigger_event = WCRAC.5 }
 	# }
-	
-	# Add new races always at the end
+
+	#Add Undead trait if undead culture
 	if = { 
 		limit = { 
 			culture = { has_cultural_pillar = heritage_undead } 
@@ -30,7 +30,8 @@ try_to_set_race_effect = {
 			add_trait = being_undead 
 		} 
 	}
-
+	
+	# Add new races always at the end
 	if = {
 		limit = {
 			OR = {

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -21,7 +21,9 @@ try_to_set_race_effect = {
 	# }
 	
 	# Add new races always at the end
-	if = {
+	if = { limit = { culture = { has_cultural_pillar = heritage_undead } } random = { chance = 80 add_trait = being_undead } }
+
+	else_if = {
 		limit = {
 			OR = {
 				AND = {

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -21,9 +21,17 @@ try_to_set_race_effect = {
 	# }
 	
 	# Add new races always at the end
-	if = { limit = { culture = { has_cultural_pillar = heritage_undead } } random = { chance = 80 add_trait = being_undead } }
+	if = { 
+		limit = { 
+			culture = { has_cultural_pillar = heritage_undead } 
+		} 
+		random = { 
+			chance = 80 
+			add_trait = being_undead 
+		} 
+	}
 
-	else_if = {
+	if = {
 		limit = {
 			OR = {
 				AND = {

--- a/localization/english/wc_tooltip_l_english.yml
+++ b/localization/english/wc_tooltip_l_english.yml
@@ -46,3 +46,7 @@
 
  wc_members_choice_the_first_horde_tooltip:0 "Your [vassals|E] will face a choice — stay in the Horde or leave it and become [independent|E]."
  wc_save_the_first_horde_tooltip:0 "The Horde will stay united"
+
+ grant_title_may_turn_undead:0 "\n#warning Granting this character a Title may cause them to turn Undead.\n#"
+ recruit_guest_may_turn_undead:0 "\n#warning Recruiting this character to Court may cause them to turn Undead.\n#"
+ invite_to_court_may_turn_undead:0 "\n#warning This character may turn Undead when they arrive at your Court.\n#""


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Undead heritage cultures now will start the game with an 80% chance to have the Undead trait
- Inviting to court, recruiting guests, and granting titles now has a 90% chance to turn the recruit and their accompanying family Undead.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added encapsulated conversion and population constant(?) values to `common/script_values/wc_plague_values.txt`
- Added Undead population generation mechanic to `common/scripted_effects/wc_race_effects.txt`
- Added conversion for recruitment interactions to `common/character_interactions/00_courtier_and_guest_interactions.txt`
- Added conversion for title grants to `common/character_interactions/00_grant_titles_interaction.txt`
- Added localization to `localization/english/wc_tooltip_l_english.yml`

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test: 
- Begin a new game in the 603 or 605 bookmark as a Scourge character
- Inspect "Damned", "Forsaken", and other Undead heritage culture characters for a majority Undead population

# Known issues: 
- Children do not seem to get the Undead trait at game start.
- Player is not informed that character will get the Undead trait in the Character Generator.
