### PR TITLE
Infirm issue 1241 fix

### DIFF
--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -29,27 +29,28 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		has_trait = infirm
 		# Otherwise, we check health crossed against age.
 		## Characters that are this old are vulnerable regardless of health.
-		age >= 90
+		# Warcraft - we need to check racial age in relation to humans because different races have longer lifespans
+		age_in_relation_to_humans_greater_than_trigger = { age = 90 } #wc - note that characters might get an extra year out of this!
 		## Else, the higher your health is, the older you need to be to suffer age-related health problems.
 		AND = {
 			health <= good_health
-			age >= 80
+			age_in_relation_to_humans_greater_than_trigger = {age = 80}
 		}
 		AND = {
 			health <= medium_health
-			age >= 70
+			age_in_relation_to_humans_greater_than_trigger = {age = 70}
 		}
 		AND = {
 			health <= fine_health
-			age >= 60
+			age_in_relation_to_humans_greater_than_trigger = {age = 60}
 		}
 		AND = {
 			health <= poor_health
-			age >= 50
+			age_in_relation_to_humans_greater_than_trigger = {age = 50}
 		}
 		AND = {
 			health <= dying_health
-			age >= 40
+			age_in_relation_to_humans_greater_than_trigger = {age = 40}
 		}
 	}
 }

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -26,7 +26,7 @@ can_get_non_epidemic_disease_trigger = { #Diseases shouldn't stack. Don't add a 
 age_ranked_health_vulnerability_threshold_trigger = {
 	# Warcraft - add flags here that should prevent characters from getting "infirm"
 	NOT = { 
-		has_flag = can_not_get_sick
+		has_trait_with_flag = can_not_get_sick
 	}
 	OR = {
 		# If you're already having problems...

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -33,28 +33,35 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		has_trait = infirm
 		# Otherwise, we check health crossed against age.
 		# Warcraft - we have to divide by the age multiplier to get effective age for paradox purposes
+		save_temporary_scope_value_as = {
+			name = temp_age
+			value = {
+				value = age
+				divide = racial_age_multiplier_value
+			}
+		}
 		## Characters that are this old are vulnerable regardless of health.
-		age_in_relation_to_humans_more_than_trigger =  { age = 90 }
+		scope:temp_age >= 90
 		## Else, the higher your health is, the older you need to be to suffer age-related health problems.
 		AND = {
 			health <= good_health
-			age_in_relation_to_humans_more_than_trigger =  { age = 80 }
+			scope:temp_age >= 80 
 		}
 		AND = {
 			health <= medium_health
-			age_in_relation_to_humans_more_than_trigger =  { age = 70 }
+			scope:temp_age >= 70 
 		}
 		AND = {
 			health <= fine_health
-			age_in_relation_to_humans_more_than_trigger =  { age = 60 }
+			scope:temp_age >= 60 
 		}
 		AND = {
 			health <= poor_health
-			age_in_relation_to_humans_more_than_trigger =  { age = 50 }
+			scope:temp_age >= 50 
 		}
 		AND = {
 			health <= dying_health
-			age_in_relation_to_humans_more_than_trigger =  { age = 40 }
+			scope:temp_age >= 40 
 		}
 	}
 }

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -36,7 +36,7 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		save_temporary_scope_value_as = {
 			name = temp_age
 			value = {
-				value = $AGE$
+				value = age
 				divide = racial_age_multiplier_value
 			}
 		}

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -28,7 +28,7 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		# If you're already having problems...
 		has_trait = infirm
 		# Otherwise, we check health crossed against age.
-		# Warcraft - we have to divide by the age multiplier
+		# Warcraft - we have to divide by the age multiplier to get effective age for paradox purposes
 		save_temporary_scope_value_as = {
 			name = temp_age
 			value = {

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -24,8 +24,9 @@ can_get_non_epidemic_disease_trigger = { #Diseases shouldn't stack. Don't add a 
 
 # Will this character suffer age-related health issues, factoring how healthy they actually are vs. what their age is?
 age_ranked_health_vulnerability_threshold_trigger = {
+	# Warcraft - add flags here that should prevent characters from getting "infirm"
 	NOT = { 
-		has_flag = can_not_get_sick 
+		has_flag = can_not_get_sick
 	}
 	OR = {
 		# If you're already having problems...
@@ -35,7 +36,7 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		save_temporary_scope_value_as = {
 			name = temp_age
 			value = {
-				value = age
+				value = $AGE$
 				divide = racial_age_multiplier_value
 			}
 		}

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -28,29 +28,36 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		# If you're already having problems...
 		has_trait = infirm
 		# Otherwise, we check health crossed against age.
+		# Warcraft - we have to divide by the age multiplier
+		save_temporary_scope_value_as = {
+			name = temp_age
+			value = {
+				value = age
+				divide = racial_age_multiplier_value
+			}
+		}
 		## Characters that are this old are vulnerable regardless of health.
-		# Warcraft - we need to check racial age in relation to humans because different races have longer lifespans
-		age_in_relation_to_humans_greater_than_trigger = { age = 90 } #wc - note that characters might get an extra year out of this!
+		scope:temp_age >= 90
 		## Else, the higher your health is, the older you need to be to suffer age-related health problems.
 		AND = {
 			health <= good_health
-			age_in_relation_to_humans_greater_than_trigger = {age = 80}
+			scope:temp_age >= 80
 		}
 		AND = {
 			health <= medium_health
-			age_in_relation_to_humans_greater_than_trigger = {age = 70}
+			scope:temp_age >= 70
 		}
 		AND = {
 			health <= fine_health
-			age_in_relation_to_humans_greater_than_trigger = {age = 60}
+			scope:temp_age >= 60
 		}
 		AND = {
 			health <= poor_health
-			age_in_relation_to_humans_greater_than_trigger = {age = 50}
+			scope:temp_age >= 50
 		}
 		AND = {
 			health <= dying_health
-			age_in_relation_to_humans_greater_than_trigger = {age = 40}
+			scope:temp_age >= 40
 		}
 	}
 }

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -24,6 +24,9 @@ can_get_non_epidemic_disease_trigger = { #Diseases shouldn't stack. Don't add a 
 
 # Will this character suffer age-related health issues, factoring how healthy they actually are vs. what their age is?
 age_ranked_health_vulnerability_threshold_trigger = {
+	NOT = { 
+		has_flag = can_not_get_sick 
+	}
 	OR = {
 		# If you're already having problems...
 		has_trait = infirm

--- a/common/scripted_triggers/20_health_triggers.txt
+++ b/common/scripted_triggers/20_health_triggers.txt
@@ -33,35 +33,28 @@ age_ranked_health_vulnerability_threshold_trigger = {
 		has_trait = infirm
 		# Otherwise, we check health crossed against age.
 		# Warcraft - we have to divide by the age multiplier to get effective age for paradox purposes
-		save_temporary_scope_value_as = {
-			name = temp_age
-			value = {
-				value = age
-				divide = racial_age_multiplier_value
-			}
-		}
 		## Characters that are this old are vulnerable regardless of health.
-		scope:temp_age >= 90
+		age_in_relation_to_humans_more_than_trigger =  { age = 90 }
 		## Else, the higher your health is, the older you need to be to suffer age-related health problems.
 		AND = {
 			health <= good_health
-			scope:temp_age >= 80
+			age_in_relation_to_humans_more_than_trigger =  { age = 80 }
 		}
 		AND = {
 			health <= medium_health
-			scope:temp_age >= 70
+			age_in_relation_to_humans_more_than_trigger =  { age = 70 }
 		}
 		AND = {
 			health <= fine_health
-			scope:temp_age >= 60
+			age_in_relation_to_humans_more_than_trigger =  { age = 60 }
 		}
 		AND = {
 			health <= poor_health
-			scope:temp_age >= 50
+			age_in_relation_to_humans_more_than_trigger =  { age = 50 }
 		}
 		AND = {
 			health <= dying_health
-			scope:temp_age >= 40
+			age_in_relation_to_humans_more_than_trigger =  { age = 40 }
 		}
 	}
 }

--- a/events/health_events.txt
+++ b/events/health_events.txt
@@ -10768,9 +10768,9 @@ health.7000 = {
 
 	trigger = {
 		NOT = { 
-			has_trait = infirm 
-			age_ranked_health_vulnerability_threshold_trigger = no
-		}
+			has_trait = infirm
+		} 
+		age_ranked_health_vulnerability_threshold_trigger = yes
 	}
 
 	weight_multiplier = {

--- a/events/health_events.txt
+++ b/events/health_events.txt
@@ -10767,21 +10767,9 @@ health.7000 = {
 	theme = physical_health
 
 	trigger = {
-		NOT = { has_trait = infirm }
-		OR = {
-			# Warcraft
-			age >= age_50_value
-
-			AND = {
-				# Warcraft
-				age >= age_30_value
-
-				OR = {
-					has_trait = physique_bad
-					has_trait = spindly
-					has_trait = weak
-				}
-			}
+		NOT = { 
+			has_trait = infirm 
+			age_ranked_health_vulnerability_threshold_trigger = no
 		}
 	}
 

--- a/gui/window_character.gui
+++ b/gui/window_character.gui
@@ -784,7 +784,7 @@ window = {
 								name = "character_age_2"
 								raw_text = "???"
 								default_format = "#low"
-								tooltip =  " [Character.GetAge] [Character.GetDeathOrBirthDateInfo]" #"wc_unknown_birth"
+								tooltip =   "wc_unknown_birth" #" [Character.GetAge] [Character.GetDeathOrBirthDateInfo]"
 								fontsize = 20
 								align = nobaseline
 							}

--- a/gui/window_character.gui
+++ b/gui/window_character.gui
@@ -784,7 +784,7 @@ window = {
 								name = "character_age_2"
 								raw_text = "???"
 								default_format = "#low"
-								tooltip =   "wc_unknown_birth" #" [Character.GetAge] [Character.GetDeathOrBirthDateInfo]"
+								tooltip = "wc_unknown_birth" #" [Character.GetAge] [Character.GetDeathOrBirthDateInfo]"
 								fontsize = 20
 								align = nobaseline
 							}

--- a/gui/window_character.gui
+++ b/gui/window_character.gui
@@ -784,7 +784,7 @@ window = {
 								name = "character_age_2"
 								raw_text = "???"
 								default_format = "#low"
-								tooltip = "wc_unknown_birth"
+								tooltip =  " [Character.GetAge] [Character.GetDeathOrBirthDateInfo]" #"wc_unknown_birth"
 								fontsize = 20
 								align = nobaseline
 							}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Prevent high-longevity characters (Dragons, Elves, Undead, etc) from getting the Infirm trait
- As a result of changes, Infirm is now relatively rare.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Changed how `age_ranked_health_vulnerability_threshold_trigger` in `20_health_triggers.txt` works and made it the source of truth for infirm checks

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
I've been testing by running observer mode and searching "infirm" in the character search tool once a year. Usually about 40 characters show up with Infirm. Please feel free to try to test in your own way though!