### PR TITLE
enable clan for preferred heritages

### DIFF
--- a/common/decisions/dlc_decisions/fp3_decisions.txt
+++ b/common/decisions/dlc_decisions/fp3_decisions.txt
@@ -298,18 +298,37 @@ fp3_become_clan_government_decision = {
 
 	cost = { prestige = major_prestige_value }
 
+	major = yes
+	sort_order = 3
+
 	is_shown = {
 		has_fp3_dlc_trigger = yes
 		# You are Feudal
 		#government_has_flag = government_is_feudal
 		NOT = { government_has_flag = government_is_clan }
-		# Has a House and is not House Head
-		exists = house
-		NOT = { house.house_head = root }
-		# Religion is Islam (Clan)
 		#like_islam_religion_trigger = yes
-		# House head is Clan
-		house.house_head = { government_has_flag = government_is_clan }
+		OR = { 
+			AND = { 
+				# Has a House and is not House Head
+				exists = house
+				NOT = { house.house_head = root }
+				# Religion is Islam (Clan)
+				# House head is Clan
+				house.house_head = { government_has_flag = government_is_clan }
+			}
+			AND = { 
+				# Has a House and is not House Head 
+				exists = house
+				house.house_head = root
+				OR = { 
+					culture = { has_cultural_pillar = heritage_orcish }
+					culture = { has_cultural_pillar = heritage_tauren }
+					culture = { has_cultural_pillar = heritage_gorian }
+					culture = { has_cultural_pillar = heritage_agamagganic }
+					culture = { has_cultural_pillar = heritage_zaetaric }
+				}
+			}
+		}
 	}
 
 	is_valid = {
@@ -318,10 +337,31 @@ fp3_become_clan_government_decision = {
 		NOT = { government_has_flag = government_is_clan }
 		# Religion is Islam (Clan)
 		#like_islam_religion_trigger = yes
-		# House head is Clan
-		custom_tooltip = {
-			text = fp3_become_clan_government_decision_house_head_tt
-			house.house_head = { government_has_flag = government_is_clan }
+		OR = { 
+			AND = { 
+				# Has a House and is not House Head
+				exists = house
+				NOT = { house.house_head = root }
+				# Religion is Islam (Clan)
+				# House head is Clan
+				house.house_head = { government_has_flag = government_is_clan }
+				custom_tooltip = {
+				text = fp3_become_clan_government_decision_house_head_tt
+				house.house_head = { government_has_flag = government_is_clan }
+		}
+			}
+			AND = { 
+				# Has a House and is not House Head
+				exists = house
+				house.house_head = root
+				OR = { 
+					culture = { has_cultural_pillar = heritage_orcish }
+					culture = { has_cultural_pillar = heritage_tauren }
+					culture = { has_cultural_pillar = heritage_gorian }
+					culture = { has_cultural_pillar = heritage_agamagganic }
+					culture = { has_cultural_pillar = heritage_zaetaric }
+				}
+			}
 		}
 	}
 

--- a/common/decisions/dlc_decisions/fp3_decisions.txt
+++ b/common/decisions/dlc_decisions/fp3_decisions.txt
@@ -298,37 +298,18 @@ fp3_become_clan_government_decision = {
 
 	cost = { prestige = major_prestige_value }
 
-	major = yes
-	sort_order = 3
-
 	is_shown = {
 		has_fp3_dlc_trigger = yes
 		# You are Feudal
 		#government_has_flag = government_is_feudal
 		NOT = { government_has_flag = government_is_clan }
+		# Has a House and is not House Head
+		exists = house
+		NOT = { house.house_head = root }
+		# Religion is Islam (Clan)
 		#like_islam_religion_trigger = yes
-		OR = { 
-			AND = { 
-				# Has a House and is not House Head
-				exists = house
-				NOT = { house.house_head = root }
-				# Religion is Islam (Clan)
-				# House head is Clan
-				house.house_head = { government_has_flag = government_is_clan }
-			}
-			AND = { 
-				# Has a House and is not House Head 
-				exists = house
-				house.house_head = root
-				OR = { 
-					culture = { has_cultural_pillar = heritage_orcish }
-					culture = { has_cultural_pillar = heritage_tauren }
-					culture = { has_cultural_pillar = heritage_gorian }
-					culture = { has_cultural_pillar = heritage_agamagganic }
-					culture = { has_cultural_pillar = heritage_zaetaric }
-				}
-			}
-		}
+		# House head is Clan
+		house.house_head = { government_has_flag = government_is_clan }
 	}
 
 	is_valid = {
@@ -337,31 +318,10 @@ fp3_become_clan_government_decision = {
 		NOT = { government_has_flag = government_is_clan }
 		# Religion is Islam (Clan)
 		#like_islam_religion_trigger = yes
-		OR = { 
-			AND = { 
-				# Has a House and is not House Head
-				exists = house
-				NOT = { house.house_head = root }
-				# Religion is Islam (Clan)
-				# House head is Clan
-				house.house_head = { government_has_flag = government_is_clan }
-				custom_tooltip = {
-				text = fp3_become_clan_government_decision_house_head_tt
-				house.house_head = { government_has_flag = government_is_clan }
-		}
-			}
-			AND = { 
-				# Has a House and is not House Head
-				exists = house
-				house.house_head = root
-				OR = { 
-					culture = { has_cultural_pillar = heritage_orcish }
-					culture = { has_cultural_pillar = heritage_tauren }
-					culture = { has_cultural_pillar = heritage_gorian }
-					culture = { has_cultural_pillar = heritage_agamagganic }
-					culture = { has_cultural_pillar = heritage_zaetaric }
-				}
-			}
+		# House head is Clan
+		custom_tooltip = {
+			text = fp3_become_clan_government_decision_house_head_tt
+			house.house_head = { government_has_flag = government_is_clan }
 		}
 	}
 

--- a/common/scripted_triggers/wc_government_triggers.txt
+++ b/common/scripted_triggers/wc_government_triggers.txt
@@ -79,6 +79,9 @@ can_keep_clan_government_trigger = {
 	OR = {
 		culture = { has_cultural_pillar = heritage_orcish }
 		culture = { has_cultural_pillar = heritage_tauren }
+		culture = { has_cultural_pillar = heritage_gorian }
+		culture = { has_cultural_pillar = heritage_agamagganic }
+		culture = { has_cultural_pillar = heritage_zaetaric }
 		culture = culture:wildhammer
 		culture = {
 			AND = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Centaurs, Quillboars, Orcs, Tauren, and Gorians should now be able to form clans

<img width="1728" alt="Screenshot 2023-12-20 at 1 09 18 PM" src="https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/22644733/dfa77eeb-cb27-485c-ba56-b89359f8d24c">


<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- added an if statement to `fp3_decisions.txt` with the preferred heritages listed in the updated PR

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
