### PR TITLE
Dragonflight Government

### DIFF
--- a/common/game_concepts/wc_government_game_concepts.txt
+++ b/common/game_concepts/wc_government_game_concepts.txt
@@ -11,3 +11,6 @@ demonic_government = {
 eldritch_government = {
 	parent = dark_government
 }
+dragonflight_government = {
+	parent = clan_government
+}

--- a/common/governments/wc_government_types.txt
+++ b/common/governments/wc_government_types.txt
@@ -37,6 +37,7 @@
 	
 	color = hsv{ 0.55 1 0.4 }
 }
+
 demonic_government = {
 	royal_court = yes
 	create_cadet_branches = yes
@@ -74,6 +75,7 @@ demonic_government = {
 	
 	color = hsv{ 0.3 1 1 }
 }
+
 eldritch_government = {
 	royal_court = yes
 	create_cadet_branches = yes
@@ -111,4 +113,96 @@ eldritch_government = {
 	flag = government_get_void_creatures
 	
 	color = hsv{ 0.7 0.7 0.5 }
+}
+
+dragonflight_government = {
+	primary_holding = castle_holding
+	
+	# Warcraft
+	primary_heritages = { heritage_draconic }
+	
+	# Warcraft
+	preferred_religions = { draconism_religion }
+
+	create_cadet_branches = no
+	rulers_should_have_dynasty = yes
+	royal_court = yes
+
+	valid_holdings = { castle_holding city_holding church_holding }
+	required_county_holdings = { castle_holding }
+	dynasty_named_realms = yes
+	
+	# Warcraft
+	# Type
+	flag = government_is_monarchy
+
+	house_unity = clan_house_unity
+
+	vassal_contract = {
+		feudal_government_taxes
+		feudal_government_levies
+		special_contract
+		religious_rights
+		fortification_rights
+		coinage_rights
+		succession_rights
+		war_declaration_rights
+		council_rights
+		title_revocation_rights
+	}
+	
+	opinion_of_liege = {
+		scope:vassal = {
+			if = {
+				limit = {
+					NOT = {
+						is_allied_to = scope:liege
+					}
+				}
+				if = {
+					limit = {
+						is_powerful_vassal = yes
+					}
+					value = clan_powerful_vassal_no_alliance_opinion_penalty_value
+				}
+				else = {
+					value = clan_vassal_no_alliance_opinion_penalty_value
+				}
+			}
+		}
+	}
+	opinion_of_liege_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:vassal = {
+						NOT = {
+							is_allied_to = scope:liege
+						}
+						is_powerful_vassal = yes
+					}
+				}
+				desc = "GOVERNMENT_CLAN_NOT_ALLIED_POWERFUL"
+			}
+			triggered_desc = {
+				trigger = {
+					scope:vassal = {
+						NOT = {
+							is_allied_to = scope:liege
+						}
+						is_powerful_vassal = no
+					}
+				}
+				desc = "GOVERNMENT_CLAN_NOT_ALLIED"
+			}
+		}
+	}
+
+	# Use flags instead of has_government for moddability if possible (i.e., wherever not visible to the player).
+	flag = government_is_clan
+	flag = may_appoint_viziers
+	
+	# Warcraft
+	flag = government_can_be_matchmaker
+	color = hsv{ 0.98 0.65 0.69 }
 }

--- a/common/governments/wc_government_types.txt
+++ b/common/governments/wc_government_types.txt
@@ -124,7 +124,7 @@ dragonflight_government = {
 	# Warcraft
 	preferred_religions = { draconism_religion }
 
-	create_cadet_branches = no
+	create_cadet_branches = yes
 	rulers_should_have_dynasty = yes
 	royal_court = yes
 
@@ -199,8 +199,6 @@ dragonflight_government = {
 	}
 
 	# Use flags instead of has_government for moddability if possible (i.e., wherever not visible to the player).
-	flag = government_is_clan
-	flag = may_appoint_viziers
 	
 	# Warcraft
 	flag = government_can_be_matchmaker

--- a/history/titles/000_wc_other_titles.txt
+++ b/history/titles/000_wc_other_titles.txt
@@ -284,7 +284,7 @@ d_hammerfall = {
 # Dragonflights
 e_black_dragonflight = {
 	1.1.1={
-		government = feudal_government
+		government = dragonflight_government
 	}
 	20.1.1={holder=62200} #Deathwing
 	593.2.1={holder=0}
@@ -292,28 +292,28 @@ e_black_dragonflight = {
 
 e_blue_dragonflight = {
     1.1.1={
-	    government = feudal_government
+	    government = dragonflight_government
     }
     20.1.1={holder=62600} #Malygos[38150]
 }
 
 e_green_dragonflight = {
     1.1.1={
-	    government = feudal_government
+	    government = dragonflight_government
     }
     20.1.1={holder=62001} #Ysera[38000]
 }
 
 e_red_dragonflight = {
     1.1.1={
-	    government = feudal_government
+	    government = dragonflight_government
     }
     20.1.1={holder=62400} #Alexstrasza[38100]
 }
 
 e_bronze_dragonflight = {
     1.1.1={
-	    government = feudal_government
+	    government = dragonflight_government
     }
     20.1.1={holder=62800} #Nozdormu[38200]
 }

--- a/localization/english/wc_game_concepts_l_english.yml
+++ b/localization/english/wc_game_concepts_l_english.yml
@@ -47,6 +47,11 @@
  game_concept_dark_wo_government:0 "Dark"
  game_concept_dark_government_desc:0 "[government_forms|E] that uses [dark_authority|E] instead of [crown_authority|E]. [levies|E] and [taxes|E] given to a [liege|E] by their [vassals|E] is determined by their [opinion|E] of said Liege. However, the Liege's [dark_authority|E] can increase the minimum amount they must provide regardless of Opinion."
 
+ game_concept_dragonflight_government:0 "Dragonflight"
+ game_concept_dragonflight_governments:0 "Dragonflights"
+ game_concept_dragonflight_wo_government:0 "Dragonflight"
+ game_concept_dragonflight_government_desc:0 "A power structure that is formed by the mysterious Dragons of Azeroth and acts just like a Clan without the unique taxation system. This Government type is only available to Draconic Cultures that follow Draconic Religions."
+
  game_concept_necro_government:1 "$necro_government_adjective$ Government"
  game_concept_necro_government_desc:1 "A [dark_government|E] available to [GetTrait('being_undead').GetName( GetNullCharacter )] with $doctrine_death_magic_name$ accepted.\nHaving high [dark_authority|E], they get bigger [levies|E] and reinforce them faster, their [men_at_arms|E] become cheaper."
 

--- a/localization/english/wc_government_l_english.yml
+++ b/localization/english/wc_government_l_english.yml
@@ -36,3 +36,9 @@
  government_offer_vassalization_turns_undead:0 "[offer_vassalization|E] has an option to turn [GetTrait('being_undead').GetName( GetNullCharacter )]"
 
  government_can_be_matchmaker:0 "Can [marry|E] off [courtiers|E] and [children|E]"
+
+ dragonflight_government:0 "Dragonflight"
+ dragonflight_government_adjective:0 "Dragonflight"
+ dragonflight_government_realm:0 "Draconic Realm"
+ dragonflight_government_desc:0 "\n$game_concept_dragonflight_government_desc$\n\n#F A ruling order that was established shortly after the Ordering of Azeroth. While charged with the protection of Azeroth and given duties by the Titans themselves they operate almost like a family with all the problems that come with such a thing.#!"
+ dragonflight_government_vassals_label:1 "Dragonflight [obligations|E] are based on [opinion|E]."


### PR DESCRIPTION
Creates the Dragonflight Government and gives it to all Dragonflight Titles. Making it technically Opt-Out.

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added Dragonflight Government Type.
- Changed all Dragonflight Titles to grant Dragonflight Government Type.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)
