### PR TITLE
Give important lore modifier in any bookmark

### DIFF
--- a/common/scripted_character_templates/wc_exodar_templates.txt
+++ b/common/scripted_character_templates/wc_exodar_templates.txt
@@ -9,7 +9,7 @@
 	trait = lifestyle_blademaster
 	random_traits = no
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		give_nickname = nick_vindicator
 		add_character_flag = maraad_flag
 		copy_inheritable_appearance_from = character:maraad
@@ -26,7 +26,7 @@ velen_character_template = {
 	trait=creature_draenei trait = lifestyle_mystic trait = magic_good_3
 	random_traits = no
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		add_character_flag = velen_flag
 		copy_inheritable_appearance_from = character:velen
 	}
@@ -42,7 +42,7 @@ ishanah_character_template = {
 	trait=creature_draenei trait = lifestyle_mystic trait = magic_good_3
 	random_traits = no
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		give_nickname = nick_high_priestess
 		add_character_flag = ishanah_flag
 		copy_inheritable_appearance_from = character:ishanah
@@ -59,7 +59,7 @@ admetius_character_template = {
 	trait=creature_draenei
 	random_traits = no
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		give_nickname = nick_exarch
 		add_character_flag = admetius_flag
 		copy_inheritable_appearance_from = character:admetius
@@ -76,7 +76,7 @@ proenitus_character_template = {
 	trait=creature_draenei
 	random_traits = no
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		give_nickname = nick_exarch
 		add_character_flag = proenitus_flag
 		copy_inheritable_appearance_from = character:proenitus

--- a/common/scripted_character_templates/wc_historical_demonic_templates.txt
+++ b/common/scripted_character_templates/wc_historical_demonic_templates.txt
@@ -19,7 +19,7 @@ tichondrius_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 varimathras_character_template = {
@@ -41,7 +41,7 @@ varimathras_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 mephistroth_character_template = {
@@ -63,7 +63,7 @@ mephistroth_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 anetheron_character_template = {
@@ -85,7 +85,7 @@ anetheron_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 balnazzar_character_template = {
@@ -108,7 +108,7 @@ balnazzar_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 detheroc_character_template = {
@@ -130,7 +130,7 @@ detheroc_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 malganis_character_template = {
@@ -152,6 +152,6 @@ malganis_character_template = {
 			track = travel
 			value = 100
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }

--- a/common/scripted_character_templates/wc_historical_draenor_templates.txt
+++ b/common/scripted_character_templates/wc_historical_draenor_templates.txt
@@ -15,7 +15,7 @@
 			trait = lifestyle_blademaster
 			value = 80
 		}
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }
 
@@ -102,7 +102,7 @@ grommash_character_template = {
 			copy_inheritable_appearance_from = character:10200 #Grommash
 		}
 		
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		add_trait_xp = {
 			trait = lifestyle_blademaster
 			value = 100
@@ -133,7 +133,7 @@ garrosh_character_template = {
 			copy_inheritable_appearance_from = character:garrosh
 		}
 		
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		
 		set_global_variable = { name = garrosh value = this } # Saves Garrosh to global
 		
@@ -193,7 +193,7 @@ lich_nerzhul_character_template = {
 	trait = lich_king
 	trait = in_ice_prison
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		
 		set_global_variable = { name = nerzhul value = this } # Saves Ner'zhul to global
 	}

--- a/common/scripted_character_templates/wc_scourge_templates.txt
+++ b/common/scripted_character_templates/wc_scourge_templates.txt
@@ -6,6 +6,6 @@ high_scourge_cultist_character_template = {
 	trait = education_learning_4
 	trait = creature_human
 	after_creation = {
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 	}
 }

--- a/common/scripted_effects/wc_exodar_effects.txt
+++ b/common/scripted_effects/wc_exodar_effects.txt
@@ -32,7 +32,7 @@
 	scope:velen = {
 		save_scope_as = owner
 		set_artifact_rarity_famed = yes
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		create_artifact = {
 			creator = scope:velen
 			type = regalia
@@ -50,7 +50,7 @@
 	scope:maraad = {
 		save_scope_as = owner
 		set_artifact_rarity_masterwork = yes
-		make_important_lore_character_effect = yes
+		really_make_important_lore_character_effect = yes
 		create_artifact = {
 			creator = scope:maraad
 			type = hammer
@@ -80,7 +80,7 @@
 		}
 		scope:newly_created_artifact = { equip_artifact_to_owner = yes }
 	}
-	scope:ishanah = { make_important_lore_character_effect = yes }
+	scope:ishanah = { really_make_important_lore_character_effect = yes }
 }
 
 update_opinions_exodar_effect = {

--- a/common/scripted_effects/wc_health_effects.txt
+++ b/common/scripted_effects/wc_health_effects.txt
@@ -1,6 +1,11 @@
 ﻿make_important_lore_character_effect = {
-	set_scripted_appearance_effect = yes
-	add_character_modifier = { modifier = important_lore_character years = 5 }
+	#set_scripted_appearance_effect = yes
+	set_variable = give_me_important_lore_character
+}
+
+really_make_important_lore_character_effect = {
+	add_character_modifier = { modifier = important_lore_character years = 10 }
+	remove_variable = give_me_important_lore_character
 }
 remove_beauty_good_group_effect = {
 	remove_trait = beauty_good_1

--- a/common/scripted_effects/wc_race_effects.txt
+++ b/common/scripted_effects/wc_race_effects.txt
@@ -6,6 +6,10 @@ trigger_race_giving_no_gene_effect = {
 }
 trigger_on_game_start_effect = {
 	trigger_event = WCRAC.30
+	if = {
+		limit = { has_variable = give_me_important_lore_character }
+		really_make_important_lore_character_effect = yes
+	}
 }
 
 try_to_set_race_effect = {

--- a/events/wc_events/wc_central_kalimdor_events.txt
+++ b/events/wc_events/wc_central_kalimdor_events.txt
@@ -5436,7 +5436,7 @@ cen_kal.1085 = {
 			after_creation = {
 				remove_trait = wc_druid_of_the_fang
 				add_character_flag = blocked_from_leaving
-				make_important_lore_character_effect = yes
+				really_make_important_lore_character_effect = yes
 				remove_nickname = yes
 			}
 			save_scope_as = ebru


### PR DESCRIPTION
## Changelog:
- We were not giving important lore modifier correctly, so it worked only in first bookmark. Because we were giving it on birth. Storm event already has trigger to not happen for important lore ones. Now i fixed it, and it give lore modifier for 10 years.

## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log`

# How to test:
For example open jaina in any bookmark, she always gets it for 10 years