### PR TITLE
Mogu ethnicity

### DIFF
--- a/common/ethnicities/wc_ethnicities_mogu.txt
+++ b/common/ethnicities/wc_ethnicities_mogu.txt
@@ -33,37 +33,46 @@ mogu_ethnicity = {
 		gene_race = { 1 = { name = creature_mogu range = { 0 1 } } }
 		
 		skin_color = {
-			10 = { 0.3 0.5 0.35 0.7 }
+			1 = { 0.3 0.5 0.6 0.7 } ##Green to Green/Blue
+			1 = { 0.004 0.443 0.1 1 } #Red/Orange
+			1 = { 0.055 0.820 0.078 1 } #Brown/Black
+			1 = { 0.714 0.75 0.75 0.75 } # Gray
 		}
 		hair_color = {
 			# Brown
 			30 = { @brown_color_x_min @brown_color_y_min @brown_color_x_max @brown_color_y_max }
-			# Red
-			1 = { @red_color_x_min @red_color_y_min @red_color_x_max @red_color_y_max }
 			# Black
 			69 = { @brown_color_x_min @black_color_y_min @brown_color_x_max @black_color_y_max }
+			1 = { 0.71 0.078 0.71 0.239 } #White/Silver
 		}
 		
+		eye_color = {
+			# White
+			1 = { 0.702 0.114 0.702 0.3 } #White
+			1 = { 0.118 0.388 0.176 0.447 } #Blonde/Yellow
+			1 = { 0.71 0.078 0.71 0.239 } #White/Silver
+		}
+
 		#Height
 		gene_height = {
-        1 = { name = normal_height  range = { 1 1 }      }
+        1 = { name = normal_height  range = { 0.92 1 }      }
    		}
 		
 		#Neck
 		gene_neck_length = {
-			1 = { name = neck_length_pos  range = { 0.55 0.6 }      }
+			1 = { name = neck_length_pos  range = { 0 0.4 }      }
 		}
 		gene_neck_width = {
-			1 = { name = neck_width_pos  range = { 0.4 0.7 }      }
+			1 = { name = neck_width_pos  range = { 0.5 1 }      }
 		}
 		
 		###Cheeks
 		gene_bs_cheek_forward = {
-			1 = { name = cheek_forward_neg  range = { 0.05 0.09 }      }
+			1 = { name = cheek_forward_neg  range = { 0.1 0.9 }      }
 		}
 		gene_bs_cheek_height = {
-			1 = { name = cheek_height_neg  range = { 0.1 0.2 }      }
-			1 = { name = cheek_height_pos  range = { 0 0.8 }      }
+			1 = { name = cheek_height_neg  range = { 0.5 1 }      }
+			1 = { name = cheek_height_pos  range = { 0.5 1 }      }
 		}
 		gene_bs_cheek_width = {
 			1 = { name = cheek_width_pos  range = { 0.5 0.7 }      }
@@ -82,10 +91,10 @@ mogu_ethnicity = {
 		
 		###Chin
 		gene_chin_forward = {
-			1 = { name = chin_forward_neg    range = { 0.4 0.5 }    }
+			1 = { name = chin_forward_neg    range = { 0.2 0.5 }    }
 		}
 		gene_chin_height = {
-			1 = { name = chin_height_neg    range = { 0.5 0.9 }    }
+			1 = { name = chin_height_neg    range = { 0.5 1 }    }
 		}
 		gene_chin_width = {
 			1 = { name = chin_width_neg    range = { 0.6 1 }    }
@@ -105,7 +114,8 @@ mogu_ethnicity = {
 			1 = { name = jaw_forward_neg    range = { 0.9 1 }    }
 		}
 		gene_jaw_height = {
-			1 = { name = jaw_height_neg    range = { 0.75 1 }    }
+			#1 = { name = jaw_height_neg    range = { 0.75 1 }    }
+			1 = { name = jaw_height_pos    range = { 0.75 1 }    }
 		}
 		gene_jaw_width = {
 			1 = { name = jaw_width_pos    range = { 0.7 1 }    }
@@ -178,18 +188,21 @@ mogu_ethnicity = {
 			1 = { name = mouth_lower_lip_width_pos    range = { 0 0.4 }    }
 		}
 		
-		###Nose
+			###Nose
 		gene_bs_nose_length = {
-			1 = { name = nose_length_neg    range = { 0.25 0.75 }    }
+			#1 = { name = nose_length_pos    range = { 0 0.5 }    }
+			1 = { name = nose_length_neg    range = { 0.3 0.8 }    }
 		}
 		gene_bs_nose_size = {
-			1 = { name = nose_size_pos    range = { 0 1 }    }
+			1 = { name = nose_size_pos    range = { 0.65 1 }    }
 		}
 		gene_bs_nose_forward = {
-			1 = { name = nose_forward_pos    range = { 0 1 }    }
+			#1 = { name = nose_forward_pos    range = { 0 1 }    }
+			1 = { name = nose_forward_neg    range = { 0.2 1 }    }
 		}
 		gene_bs_nose_height = {
-			1 = { name = nose_height_pos    range = { 0.7 1 }    }
+			#1 = { name = nose_height_pos    range = { 0.7 1 }    }
+			1 = { name = nose_height_neg    range = { 0.7 1 }    }
 		}
 		face_detail_nasolabial = {
 			1 = { name = nasolabial_01    range = { 0.5 1 }    }
@@ -201,28 +214,28 @@ mogu_ethnicity = {
 		#Nose tip
 		gene_bs_nose_tip_forward = {
 			1 = { name = nose_tip_forward_neg    range = { 0.5 1 }    }
+			1 = { name = nose_tip_forward_pos    range = { 0 0.5 }    }
 		}
 		gene_bs_nose_tip_width = {
-			 1 = { name = nose_tip_width_neg    range = { 0 1 }    }
+			1 = { name = nose_tip_width_neg    range = { 0 1 }    }
 		}
 		gene_bs_nose_tip_angle = {
-			1 = { name = nose_tip_angle_pos    range = { 0.5 1   }    }
+			1 = { name = nose_tip_angle_pos    range = { 0 1   }    }
 		}
 		face_detail_nose_tip_def = {
-			1 = {  name = nose_tip_def             range = { 0 1 }     }
+			1 = {  name = nose_tip_def             range = { 0 0.5 }     }
 		}
 		
 		#Ridge
 		gene_bs_nose_profile = {
-			1 = { name = nose_profile_pos    range = { 0 1 }    }
-			1 = { name = nose_profile_hawk_pos    range = { 0 0.55 }    }
+			#1 = { name = nose_profile_pos    range = { 0 1 }    }
+			1 = { name = nose_profile_neg    range = { 0.8 1 }    }
 		}
 		gene_bs_nose_ridge_angle = {
 			1 = { name = nose_ridge_angle_pos    range = { 0 1 }    }
 		}
 		gene_bs_nose_ridge_width = {
-			1 = { name = nose_ridge_width_pos    range = { 0 0.8 }    }
-			1 = { name = nose_ridge_width_neg    range = { 0 0.5 }    }
+			1 = { name = nose_ridge_width_pos    range = { 0.5 0.8 }    }
 		}
 		face_detail_nose_ridge_def = {
 			1 = { name = nose_ridge_def_pos    range = { 0 1 }    }
@@ -231,18 +244,18 @@ mogu_ethnicity = {
 		
 		#Nostril
 		gene_bs_nose_nostril_height = {
-			1 = { name = nose_nostril_height_pos    range = { 0.6 1   }    }
+			1 = { name = nose_nostril_height_pos    range = { 0.8 1   }    }
+			1 = { name = nose_nostril_height_neg    range = { 0.8 1   }    }
 		}
 		gene_bs_nose_nostril_width = {
-			1 = { name = nose_nostril_width_neg    range = { 0.5 1 }    }
+			1 = { name = nose_nostril_width_pos    range = { 0.8 1 }    }
 		}
-		
 		###Ear
 		gene_bs_ear_lenght = {
-			1 = { name = erect_ear_lenght    range = { 0.1 0.2 } }
+			1 = { name = back_ear_lenght    range = { 0.2 0.5 } }
 		}
 		gene_bs_ear_angle = {
-			1 = { name = ear_angle_pos    range = { 0 1 } }
+			1 = { name = ear_angle_pos    range = { 0 0.5 } }
 		}
 		gene_bs_ear_inner_shape = {
 			1 = { name = ear_inner_shape_pos    range = { 0.18 0.18 } }
@@ -308,7 +321,7 @@ mogu_ethnicity = {
 			1 = { name = head_top_height_neg    range = { 0.1 0.3  }    }
 		}
 		gene_head_top_width = {
-			1 = { name = head_top_width_neg    range = { 0.15 0.4  }    }
+			1 = { name = head_top_width_neg    range = { 0.8 1  }    }
 		}
 		
 		#Eyes
@@ -416,52 +429,18 @@ mogu_ethnicity = {
 			1 = {  name = complexion_6             range = { 0 1 }     }
 			1 = {  name = complexion_7             range = { 0 1 }     }
 		}
+
+		special_eyebrows = {
+			1 = {  name = dwarven_eyebrows             range = { 0 1 }     }
+		}
 	
 		# Orc Eyeliner
 		gene_facial_markings = {
 			5 = { name = no_markings range = { 0 1 } }
 			1 = { name = orc_eyeliner range = { 0.7 1 } }
 		}
-	}
-	
-	brown_orcish = {
-		template = "green_orcish"
-		using = "maghar"
-		
-		skin_color = {
-			10 = { 0.15 0.7 0.2 0.85 }
-		}
-	}
-	
-	gray_orcish = {
-		template = "green_orcish"
-		using = "blackrock"
-		
-		skin_color = {
-			25 = { @ash_color_x_min @ash_color_y_min @ash_color_x_max @ash_color_y_max }
-			25 = { 0.631 0.239 0.718 0.294 } # Default
-			5 = { 0.008 0.012 0.008 0.012 } # Dark Gray/Brown
-			1 = { 0.373 0.196 0.494 0.239 } # Sickly Green
-		}
-	}
-	
-	pale_orcish = {
-		template = "gray_orcish"
-		using = "twilights_hammer"
-		
-		# hairstyles = {
-			# 10 = { name = no_hairstyles 		range = { 0.0 1.0 } }
-		# }
-		# beards = {
-			# 10 = { name = no_beard 		range = { 0.0 1.0 } }
-		# }
-		
-		#Body
-		#To make them WEAK!
-		gene_bs_body_shape = {
-			1 = { name = body_shape_pear_half     range = { 0 0.25 }      }
-		}
-		gene_bs_body_type = {
-			1 = { name = body_fat_head_fat_low   range = { 0 0.2 }   }
+
+		special_eyes = {
+			1 = { name = magic_no_pupils_eyes      range = { 0.5 0.5 } }
 		}
 	}

--- a/common/scripted_triggers/GH_portrait_effects_triggers.txt
+++ b/common/scripted_triggers/GH_portrait_effects_triggers.txt
@@ -33,7 +33,6 @@ GH_must_use_statue_effect_stone = {
 			is_alive = yes
 			has_variable = GH_is_stone_statue
 		}
-		stone_mogu_appearance_trigger = yes
 	}
 }
 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Deleted stone portrait modifier for creature_mogu
- Added 4 skin tones for mogu_ethnicity (Green, Red/Orange, Dark Brown and Blueish Gray), currently all have an equal chance to appear
- Tweaked ethnicity template

![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/cd676e86-ebd4-4f12-849f-152a96e7da1b)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/7242195e-a602-441d-9aab-b3b072cb848c)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/60f96cd1-6dda-48fc-94ee-a4cddc9a1223)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/a0e7f70c-f24e-4a82-8c1d-21695ae8410e)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/3a867600-4dc9-4dcd-9602-f221e25e5a64)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/0cbbba99-14a3-4856-a1bc-c3884799cff0)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/9389ab7d-eb1f-4c52-8cb1-edf2b862c482)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/53b30631-14a6-42b8-9086-12a82ffa474e)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/565d92d3-5c52-40a3-8d79-e9d9814dbd4c)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/d35e98d1-6175-4799-81ea-34b9ea0490bd)
![image](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/assets/10171904/3d93085d-ce54-4700-8579-240b97cd64c9)
