### PR TITLE
Secret faiths

### DIFF
--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -2021,9 +2021,11 @@ garneg_charskull={
 	disallow_random_traits = yes
 	575.1.5={ birth=yes trait=creature_orc }
 	596.1.9={
-		effect={ set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_magic_trait_value } }
+		effect={ 
+			set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_magic_trait_value }
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel }
+		}
 		religion = orcish_shamanism
-		# secret_religion = orcish_fel
 	}
 	601.11.1={
 		employer=10021
@@ -2984,7 +2986,7 @@ xerash_fireblade={
 	}
 	596.1.9={
 		religion = orcish_shamanism
-		# secret_religion = orcish_fel
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel } }
 	}
 	638.2.19={ death=yes }
 }

--- a/history/characters/16000_gnome.txt
+++ b/history/characters/16000_gnome.txt
@@ -1245,7 +1245,6 @@
 	name=Silas
 	dynasty=10008
 	culture=gnome religion=rationalism
-	#secret_religion=nzoth_worship
 	martial=6 diplomacy=6 stewardship=8 intrigue=5 learning=7
 	trait=education_stewardship_4 trait=shrewd trait=lunatic_1 trait=lifestyle_mystic 
 	trait=greedy trait=gregarious
@@ -1256,6 +1255,7 @@
 				trait = lifestyle_mystic
 				value = 50
 			}
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:nzoth_worship }
 		}
 	}
 	583.1.1 = {

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -10276,54 +10276,54 @@
 1300={
 	name=Whittaker
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=7 stewardship=7 intrigue=8 learning=5
 	trait=education_stewardship_4 trait=diligent trait=sadistic trait=patient trait=honest 
-	2.6.23={ birth=yes }
+	2.6.23={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	83.8.17={ death=yes }
 }
 1301={
 	name=Shayne
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=8 stewardship=4 intrigue=4 learning=5
 	trait=education_learning_3 trait=deceitful trait=sadistic trait=temperate trait=generous 
 	father=1300	#Whittaker
-	25.11.2={ birth=yes }
+	25.11.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	102.1.17={ death=yes }
 }
 1302={
 	name=Alma
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1300	#Whittaker
-	29.4.1={ birth=yes }
+	29.4.1={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	110.7.16={ death=yes }
 }
 1303={
 	name=Sydell
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=5 stewardship=6 intrigue=7 learning=6
 	trait=education_intrigue_1 trait=deceitful trait=ambitious 
 	father=1300	#Whittaker
-	35.11.25={ birth=yes }
+	35.11.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	127.11.7={ death=yes }
 }
 1304={
 	name=Martinga
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1301	#Shayne
-	58.8.20={ birth=yes }
+	58.8.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	143.3.26={ death=yes }
 }
 1305={
 	name=Brodie
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_intrigue_1 trait=lifestyle_mystic trait=paranoid trait=content trait=generous 
 	trait=ill 
@@ -10334,6 +10334,7 @@
 				trait = lifestyle_mystic
 				value = 50
 			}
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow }
 		}
 	}
 	137.12.30={ death=yes }
@@ -10342,648 +10343,660 @@
 	name=Nials
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1301	#Shayne
-	68.3.12={ birth=yes }
+	68.3.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	178.2.13={ death=yes }
 }
 1307={
 	name=Dwenn
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=6 stewardship=8 intrigue=8 learning=8
 	trait=education_diplomacy_4 trait=lazy trait=lustful trait=zealous trait=craven 
 	father=1301	#Shayne
-	74.7.13={ birth=yes }
+	74.7.13={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	147.9.1={ death=yes }
 }
 1308={
 	name=Brandon
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=4 stewardship=6 intrigue=8 learning=8
 	trait=education_diplomacy_4 trait=lifestyle_herbalist trait=compassionate trait=greedy
 	trait=chaste 
 	father=1305	#Brodie
-	92.9.6={ birth=yes }
+	92.9.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	190.5.4={ death=yes }
 }
 1309={
 	name=Anduin
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=5 stewardship=7 intrigue=8 learning=5
 	trait=education_stewardship_4 trait=zealous trait=paranoid 
 	father=1305	#Brodie
-	97.7.16={ birth=yes }
+	97.7.16={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	174.9.26={ death=yes }
 }
 1310={
 	name=Fitzgerald
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	trait=education_learning_2 trait=cynical trait=ambitious trait=honest trait=brave 
 	father=1305	#Brodie
-	102.3.4={ birth=yes }
+	102.3.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	174.5.31={ death=yes }
 }
 1311={
 	name=Bradney
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=8 stewardship=4 intrigue=4 learning=4
 	trait=education_stewardship_4 trait=arbitrary trait=diligent trait=craven trait=gluttonous 
 	father=1305	#Brodie
-	108.9.18={ birth=yes }
+	108.9.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	174.3.23={ death=yes }
 }
 1312={
 	name=Caledra
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1305	#Brodie
-	113.12.27={ birth=yes }
+	113.12.27={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	205.6.20={ death=yes }
 }
 1313={
 	name=Mierelle
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1305	#Brodie
-	117.8.13={ birth=yes }
+	117.8.13={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	211.10.3={ death=yes }
 }
 1314={
 	name=Milton
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=4 stewardship=7 intrigue=5 learning=6
 	trait=education_stewardship_4 trait=arrogant trait=paranoid trait=wrathful 
 	trait=just 
 	father=1308	#Brandon
-	120.9.2={ birth=yes }
+	120.9.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	195.5.3={ death=yes }
 }
 1315={
 	name=Constance
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1308	#Brandon
-	127.8.6={ birth=yes }
+	127.8.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	221.4.5={ death=yes }
 }
 1316={
 	name=Eliza
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1308	#Brandon
-	134.10.19={ birth=yes }
+	134.10.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	193.9.15={ death=yes }
 }
 1317={
 	name=Aldwin
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=4 stewardship=4 intrigue=6 learning=4
 	trait=education_stewardship_1 trait=chaste trait=compassionate trait=deceitful trait=patient 
 	father=1314	#Milton
-	145.5.20={ birth=yes }
+	145.5.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	210.12.29={ death=yes }
 }
 1318={
 	name=Rose
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	148.10.14={ birth=yes }
+	148.10.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	211.3.8={ death=yes }
 }
 1319={
 	name=Alma
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	155.2.25={ birth=yes }
+	155.2.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	243.6.8={ death=yes }
 }
 1320={
 	name=Isobel
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	160.2.26={ birth=yes }
+	160.2.26={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	227.3.20={ death=yes }
 }
 1321={
 	name=Ansley
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	171.7.21={ birth=yes }
+	171.7.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	255.10.16={ death=yes }
 }
 1322={
 	name=Akyssa
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	177.2.6={ birth=yes }
+	177.2.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	260.4.1={ death=yes }
 }
 1323={
 	name=Theodelinda
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	181.9.2={ birth=yes }
+	181.9.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	273.2.7={ death=yes }
 }
 1324={
 	name=Catrina
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	185.3.5={ birth=yes }
+	185.3.5={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	273.8.27={ death=yes }
 }
 1325={
 	name=Anson
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=7 stewardship=6 intrigue=8 learning=6
 	trait=education_diplomacy_3 trait=brave trait=chaste trait=shy 
 	father=1317	#Aldwin
-	191.2.12={ birth=yes }
+	191.2.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	297.6.16={ death=yes }
 }
 1326={
 	name=Welborne
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=6 stewardship=5 intrigue=6 learning=6
 	trait=education_intrigue_3 trait=temperate trait=honest trait=sadistic trait=arbitrary 
 	father=1325	#Anson
-	214.9.3={ birth=yes }
+	214.9.3={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	283.10.9={ death=yes }
 }
 1327={
 	name=Egerton
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=8 stewardship=4 intrigue=8 learning=8
 	trait=education_martial_2 trait=arrogant trait=generous 
 	father=1325	#Anson
-	219.2.5={ birth=yes }
+	219.2.5={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	307.7.27={ death=yes }
 }
 1328={
 	name=Elbridge
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=7 stewardship=4 intrigue=7 learning=5
 	trait=education_diplomacy_4 trait=deceitful trait=gregarious trait=gluttonous trait=content 
 	father=1325	#Anson
-	224.3.25={ birth=yes }
+	224.3.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	298.11.15={ death=yes }
 }
 1329={
 	name=Brandon
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=4 stewardship=8 intrigue=7 learning=8
 	trait=education_intrigue_4 trait=greedy trait=gregarious trait=paranoid trait=patient 
 	father=1326	#Welborne
-	245.6.18={ birth=yes }
+	245.6.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	332.8.5={ death=yes }
 }
 1330={
 	name=Redmund
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=8 stewardship=8 intrigue=6 learning=7
 	trait=education_martial_1 trait=scholar trait=trusting trait=zealous trait=content 
 	trait=deceitful 
 	father=1326	#Welborne
-	253.5.17={ birth=yes }
+	253.5.17={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	322.10.17={ death=yes }
 }
 1331={
 	name=Marjory
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1329	#Brandon
-	268.7.12={ birth=yes }
+	268.7.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	327.8.24={ death=yes }
 }
 1332={
 	name=Newall
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=7 stewardship=4 intrigue=4 learning=5
 	trait=education_intrigue_1 trait=generous trait=diligent trait=sadistic trait=trusting 
 	father=1329	#Brandon
-	271.11.22={ birth=yes }
+	271.11.22={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	364.7.17={ death=yes }
 }
 1333={
 	name=Nielas
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=4 diplomacy=5 stewardship=6 intrigue=7 learning=4
 	trait=education_diplomacy_3 trait=ambitious trait=trusting trait=ill trait=beauty_good_3 
 	father=1329	#Brandon
-	278.12.19={ birth=yes }
+	278.12.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	367.1.5={ death=yes }
 }
 1334={
 	name=Bailey
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=6 stewardship=5 intrigue=5 learning=6
 	trait=education_learning_4 trait=gluttonous trait=paranoid trait=sadistic 
 	trait=patient  
 	father=1329	#Brandon
-	284.2.11={ birth=yes }
+	284.2.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	363.5.10={ death=yes }
 }
 1335={
 	name=Alize
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1329	#Brandon
-	288.6.11={ birth=yes }
+	288.6.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	383.11.29={ death=yes }
 }
 1336={
 	name=Gavin
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=8 stewardship=6 intrigue=8 learning=4
 	trait=education_intrigue_1 trait=temperate trait=honest trait=patient trait=shy 
 	father=1332	#Newall
-	296.10.6={ birth=yes }
+	296.10.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	388.8.30={ death=yes }
 }
 1337={
 	name=Bruce
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=7 stewardship=7 intrigue=7 learning=8
 	trait=education_intrigue_1 trait=patient trait=shy trait=honest 
 	father=1332	#Newall
-	299.5.24={ birth=yes }
+	299.5.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	362.8.22={ death=yes }
 }
 1338={
 	name=Carla
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1332	#Newall
-	304.8.11={ birth=yes }
+	304.8.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	399.2.9={ death=yes }
 }
 1339={
 	name=Jillia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	329.2.3={ birth=yes }
+	329.2.3={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	423.4.14={ death=yes }
 }
 1340={
 	name=Lauffer
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=6 stewardship=8 intrigue=5 learning=5
 	trait=education_stewardship_1 trait=trusting trait=humble trait=cynical trait=arbitrary 
 	father=1336	#Gavin
-	331.4.15={ birth=yes }
+	331.4.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	412.6.6={ death=yes }
 }
 1341={
 	name=Bazzil
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=7
 	trait=education_intrigue_4 trait=content trait=arrogant trait=zealous 
 	father=1336	#Gavin
-	335.12.12={ birth=yes }
+	335.12.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	404.9.2={ death=yes }
 }
 1342={
 	name=Mercy
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	340.9.24={ birth=yes }
+	340.9.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	430.6.15={ death=yes }
 }
 1343={
 	name=Alicia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	344.10.4={ birth=yes }
+	344.10.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	417.3.14={ death=yes }
 }
 1344={
 	name=Bradney
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=4 diplomacy=6 stewardship=5 intrigue=4 learning=8
 	trait=education_learning_2 trait=generous trait=chaste trait=arrogant 
 	father=1340	#Lauffer
-	357.1.8={ birth=yes }
+	357.1.8={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	453.7.15={ death=yes }
 }
 1345={
 	name=Camilla
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	360.11.21={ birth=yes }
+	360.11.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	458.12.13={ death=yes }
 }
 1346={
 	name=Landina
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	367.10.15={ birth=yes }
+	367.10.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	431.8.4={ death=yes }
 }
 1347={
 	name=Taylor
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=8 stewardship=8 intrigue=7 learning=6
 	trait=education_intrigue_3 trait=arbitrary trait=patient trait=craven 
 	father=1340	#Lauffer
-	371.11.18={ birth=yes }
+	371.11.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	445.11.25={ death=yes }
 }
 1348={
 	name=Dorothea
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	377.9.18={ birth=yes }
+	377.9.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	453.1.21={ death=yes }
 }
 1349={
 	name=Dagena
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	381.8.12={ birth=yes }
+	381.8.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	464.7.1={ death=yes }
 }
 1350={
 	name=Fitzgerald
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=5 stewardship=7 intrigue=5 learning=8
 	trait=education_intrigue_1 trait=lazy trait=zealous trait=ambitious 
 	father=1340	#Lauffer
-	384.1.15={ birth=yes }
+	384.1.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	478.1.27={ death=yes }
 }
 1351={
 	name=Varia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	378.6.4={ birth=yes }
+	378.6.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	465.1.4={ death=yes }
 }
 1352={
 	name=Ann
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	384.2.18={ birth=yes }
+	384.2.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	455.9.3={ death=yes }
 }
 1353={
 	name=Rubia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	390.6.24={ birth=yes }
+	390.6.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	473.12.14={ death=yes }
 }
 1354={
 	name=Johan
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=4 stewardship=8 intrigue=6 learning=7
 	trait=education_learning_3 trait=trusting trait=cynical trait=sadistic 
 	father=1344	#Bradney
-	398.11.2={ birth=yes }
+	398.11.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	481.3.27={ death=yes }
 }
 1355={
 	name=Bruno
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=8 stewardship=5 intrigue=6 learning=4
 	trait=education_diplomacy_1 trait=sadistic trait=trusting trait=generous trait=lustful 
 	trait=lunatic_1 
 	father=1354	#Johan
-	430.5.22={ birth=yes }
+	430.5.22={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	511.6.26={ death=yes }
 }
 1356={
 	name=Bryan
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=4 diplomacy=7 stewardship=5 intrigue=5 learning=7
 	trait=education_intrigue_3 trait=trusting trait=deceitful trait=gregarious trait=ambitious 
 	father=1354	#Johan
-	434.8.2={ birth=yes }
+	434.8.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	507.12.2={ death=yes }
 }
 1357={
 	name=Egerton
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=6 stewardship=6 intrigue=8 learning=4
 	trait=education_learning_2 trait=shy trait=craven trait=lunatic_1 
 	father=1354	#Johan
-	440.12.18={ birth=yes }
+	440.12.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	506.3.29={ death=yes }
 }
 1358={
 	name=Asha
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1355	#Bruno
-	458.7.15={ birth=yes }
+	458.7.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	525.5.17={ death=yes }
 }
 1359={
 	name=Barathen
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=7 stewardship=4 intrigue=5 learning=6
 	trait=education_diplomacy_4 trait=patient trait=paranoid trait=sadistic trait=shy 
 	father=1355	#Bruno
-	462.1.4={ birth=yes }
+	462.1.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	524.1.26={ death=yes }
 }
 1360={
 	name=Joseph
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	trait=education_intrigue_3 trait=torturer trait=craven trait=sadistic trait=diligent 
 	trait=chaste 
 	father=1355	#Bruno
-	468.4.4={ birth=yes }
+	468.4.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	548.3.30={ death=yes }
 }
 1361={
 	name=Amber
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1355	#Bruno
-	470.7.12={ birth=yes }
+	470.7.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	542.6.6={ death=yes }
 }
 1362={
 	name=Alyn
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=4 diplomacy=8 stewardship=8 intrigue=5 learning=5
 	trait=education_diplomacy_1 trait=greedy trait=ambitious trait=temperate 
 	father=1355	#Bruno
-	476.4.19={ birth=yes }
+	476.4.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	542.1.30={ death=yes }
 }
 1363={
 	name=Ang
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=4 stewardship=8 intrigue=7 learning=6
 	trait=education_diplomacy_3 trait=craven trait=temperate trait=patient 
 	trait=ambitious 
 	father=1355	#Bruno
-	481.12.21={ birth=yes }
+	481.12.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	573.3.22={ death=yes }
 }
 1364={
 	name=Marcia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1359	#Barathen
-	489.8.17={ birth=yes }
+	489.8.17={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	545.4.26={ death=yes }
 }
 1365={
 	name=Wade
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=5 stewardship=5 intrigue=4 learning=7
 	trait=education_stewardship_1 trait=gluttonous trait=arbitrary trait=trusting 
 	trait=ill 
 	father=1359	#Barathen
-	493.6.11={ birth=yes }
+	493.6.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	575.4.15={ death=yes }
 }
 1366={
 	name=Gwen
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1359	#Barathen
-	498.8.24={ birth=yes }
+	498.8.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	579.12.12={ death=yes }
 }
 1367={
 	name=Nico
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=5 stewardship=5 intrigue=6 learning=8
 	trait=education_intrigue_3 trait=humble trait=gregarious trait=zealous trait=patient 
 	father=1365	#Wade
-	516.9.1={ birth=yes }
+	516.9.1={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	601.12.24={ death=yes }
 }
 1368={
 	name=Spenser
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=7 stewardship=4 intrigue=6 learning=5
 	trait=education_stewardship_2 trait=trusting trait=gluttonous trait=content trait=lustful 
 	father=1365	#Wade
-	520.1.10={ birth=yes }
+	520.1.10={ birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	612.3.11={ death=yes }
 }
 1369={
 	name=Role
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=7 diplomacy=6 stewardship=6 intrigue=6 learning=7
 	trait=education_martial_1 trait=wrathful trait=arbitrary trait=lazy trait=paranoid 
 	father=1365	#Wade
-	522.9.2={ birth=yes }
+	522.9.2={ birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	605.2.22={ death=yes }
 }
 1370={
 	name=Eliza
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1365	#Wade
-	528.10.7={ birth=yes }
+	528.10.7={ birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	626.8.21={ death=yes }
 }
 1371={
 	name=Felita
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1365	#Wade
-	533.3.14={ birth=yes }
+	533.3.14={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	583.4.24={ death=yes }
 }
 1372={
 	name=Bernard
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=8 diplomacy=5 stewardship=4 intrigue=6 learning=7
 	trait=education_martial_1 trait=torturer trait=gregarious trait=chaste trait=just 
 	trait=sadistic 
 	father=1367	#Nico
-	542.1.8={ birth=yes }
+	542.1.8={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	597.3.13={ death=yes }
 }
 # Baroness Dorothea Millstipe
@@ -10991,11 +11004,13 @@
 	name=Dorothea
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=5 diplomacy=7 stewardship=8 intrigue=4 learning=7
 	trait=education_learning_3 trait=content trait=gregarious trait=sadistic trait=lustful 
 	father=1367	#Nico
-	547.6.19={ birth=yes }
+	547.6.19={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	567.1.1={
 		effect={ set_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 	}
@@ -11018,131 +11033,141 @@
 	name=Akyssa
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1372	#Bernard
-	580.6.3={ birth=yes }
+	580.6.3={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	650.7.8={ death=yes }
 }
 1376={
 	name=Jillia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1372	#Bernard
-	584.8.14={ birth=yes }
+	584.8.14={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	672.6.13={ death=yes }
 }
 1377={
 	name=Jagger
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=8 stewardship=5 intrigue=8 learning=7
 	trait=education_learning_4 trait=trusting trait=sadistic trait=arrogant trait=wrathful 
 	father=1372	#Bernard
-	590.5.16={ birth=yes }
+	590.5.16={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	659.2.6={ death=yes }
 }
 1378={
 	name=Bruce
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=7 stewardship=4 intrigue=7 learning=7
 	trait=education_intrigue_3 trait=humble trait=wrathful trait=gregarious 
 	father=1374	#Brodie
-	600.3.3={ birth=yes }
+	600.3.3={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	647.1.8={ death=yes }
 }
 1379={
 	name=Taria
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1374	#Brodie
-	606.11.11={ birth=yes }
+	606.11.11={ birth=yes
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } }
+	}
 	684.9.1={ death=yes }
 }
 1380={
 	name=Catarina
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1374	#Brodie
-	609.3.23={ birth=yes }
+	609.3.23={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	673.7.25={ death=yes }
 }
 1381={
 	name=Edwina
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1374	#Brodie
-	613.8.10={ birth=yes }
+	613.8.10={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	687.4.17={ death=yes }
 }
 1382={
 	name=Rose
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1378	#Bruce
-	620.5.8={ birth=yes }
+	620.5.8={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	684.8.12={ death=yes }
 }
 1383={
 	name=Jackson
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=6 stewardship=5 intrigue=6 learning=6
 	trait=education_intrigue_3 trait=deceitful trait=chaste trait=patient 
 	father=1378	#Bruce
-	627.12.12={ birth=yes }
+	627.12.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	710.6.19={ death=yes }
 }
 1384={
 	name=Medivh
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=7 stewardship=5 intrigue=7 learning=4
 	trait=education_diplomacy_3 trait=gluttonous trait=gregarious 
 	father=1383	#Jackson
-	651.3.14={ birth=yes }
+	651.3.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	731.9.10={ death=yes }
 }
 1385={
 	name=Newton
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	martial=6 diplomacy=7 stewardship=5 intrigue=5 learning=6
 	trait=education_diplomacy_4 trait=lazy trait=trusting trait=ill 
 	father=1383	#Jackson
-	656.5.14={ birth=yes }
+	656.5.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	741.11.13={ death=yes }
 }
 1386={
 	name=Theodelinda
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	659.5.4={ birth=yes }
+	659.5.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	730.2.13={ death=yes }
 }
 1387={
 	name=Lucretia
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	665.9.20={ birth=yes }
+	665.9.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	739.6.27={ death=yes }
 }
 1388={
 	name=Jazel
 	female=yes
 	dynasty=12
-	culture=azerothian religion=holy_light # secret_religion=forgotten_shadow
+	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	670.12.1={ birth=yes }
+	670.12.1={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
 	714.9.4={ death=yes }
 }
 
@@ -13295,7 +13320,6 @@
 	father=5001
 	mother=60578
 	culture=azerothian religion=kirin_tor
-	# secret_religion=burning_legion_religion
 	sexuality = heterosexual
 	martial=6 diplomacy=6 stewardship=7 intrigue=6 learning=8
 	trait=education_learning_4
@@ -13324,6 +13348,7 @@
 		effect = {
 			set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value }
 			add_character_flag = is_medivh_flag
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion }
 		}
 	}
 	584.1.1={

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -10279,7 +10279,10 @@
 	culture=azerothian religion=holy_light
 	martial=8 diplomacy=7 stewardship=7 intrigue=8 learning=5
 	trait=education_stewardship_4 trait=diligent trait=sadistic trait=patient trait=honest 
-	2.6.23={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	2.6.23={ 
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	83.8.17={ death=yes }
 }
 1301={
@@ -10289,7 +10292,10 @@
 	martial=6 diplomacy=8 stewardship=4 intrigue=4 learning=5
 	trait=education_learning_3 trait=deceitful trait=sadistic trait=temperate trait=generous 
 	father=1300	#Whittaker
-	25.11.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	25.11.2={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	102.1.17={ death=yes }
 }
 1302={
@@ -10298,7 +10304,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1300	#Whittaker
-	29.4.1={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	29.4.1={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	110.7.16={ death=yes }
 }
 1303={
@@ -10308,7 +10317,10 @@
 	martial=6 diplomacy=5 stewardship=6 intrigue=7 learning=6
 	trait=education_intrigue_1 trait=deceitful trait=ambitious 
 	father=1300	#Whittaker
-	35.11.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	35.11.25={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	127.11.7={ death=yes }
 }
 1304={
@@ -10317,7 +10329,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1301	#Shayne
-	58.8.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	58.8.20={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	143.3.26={ death=yes }
 }
 1305={
@@ -10345,7 +10360,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1301	#Shayne
-	68.3.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	68.3.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	178.2.13={ death=yes }
 }
 1307={
@@ -10355,7 +10373,10 @@
 	martial=6 diplomacy=6 stewardship=8 intrigue=8 learning=8
 	trait=education_diplomacy_4 trait=lazy trait=lustful trait=zealous trait=craven 
 	father=1301	#Shayne
-	74.7.13={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	74.7.13={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	147.9.1={ death=yes }
 }
 1308={
@@ -10366,7 +10387,10 @@
 	trait=education_diplomacy_4 trait=lifestyle_herbalist trait=compassionate trait=greedy
 	trait=chaste 
 	father=1305	#Brodie
-	92.9.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	92.9.6={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	190.5.4={ death=yes }
 }
 1309={
@@ -10376,7 +10400,10 @@
 	martial=5 diplomacy=5 stewardship=7 intrigue=8 learning=5
 	trait=education_stewardship_4 trait=zealous trait=paranoid 
 	father=1305	#Brodie
-	97.7.16={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	97.7.16={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	174.9.26={ death=yes }
 }
 1310={
@@ -10386,7 +10413,10 @@
 	martial=5 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	trait=education_learning_2 trait=cynical trait=ambitious trait=honest trait=brave 
 	father=1305	#Brodie
-	102.3.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	102.3.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	174.5.31={ death=yes }
 }
 1311={
@@ -10396,7 +10426,10 @@
 	martial=5 diplomacy=8 stewardship=4 intrigue=4 learning=4
 	trait=education_stewardship_4 trait=arbitrary trait=diligent trait=craven trait=gluttonous 
 	father=1305	#Brodie
-	108.9.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	108.9.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	174.3.23={ death=yes }
 }
 1312={
@@ -10405,7 +10438,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1305	#Brodie
-	113.12.27={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	113.12.27={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	205.6.20={ death=yes }
 }
 1313={
@@ -10414,7 +10450,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1305	#Brodie
-	117.8.13={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	117.8.13={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	211.10.3={ death=yes }
 }
 1314={
@@ -10425,7 +10464,10 @@
 	trait=education_stewardship_4 trait=arrogant trait=paranoid trait=wrathful 
 	trait=just 
 	father=1308	#Brandon
-	120.9.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	120.9.2={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	195.5.3={ death=yes }
 }
 1315={
@@ -10434,7 +10476,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1308	#Brandon
-	127.8.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	127.8.6={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	221.4.5={ death=yes }
 }
 1316={
@@ -10443,7 +10488,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1308	#Brandon
-	134.10.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	134.10.19={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	193.9.15={ death=yes }
 }
 1317={
@@ -10453,7 +10501,10 @@
 	martial=6 diplomacy=4 stewardship=4 intrigue=6 learning=4
 	trait=education_stewardship_1 trait=chaste trait=compassionate trait=deceitful trait=patient 
 	father=1314	#Milton
-	145.5.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	145.5.20={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	210.12.29={ death=yes }
 }
 1318={
@@ -10462,7 +10513,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	148.10.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	148.10.14={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	211.3.8={ death=yes }
 }
 1319={
@@ -10471,7 +10525,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	155.2.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	155.2.25={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	243.6.8={ death=yes }
 }
 1320={
@@ -10480,7 +10537,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1314	#Milton
-	160.2.26={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	160.2.26={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	227.3.20={ death=yes }
 }
 1321={
@@ -10489,7 +10549,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	171.7.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	171.7.21={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	255.10.16={ death=yes }
 }
 1322={
@@ -10498,7 +10561,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	177.2.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	177.2.6={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	260.4.1={ death=yes }
 }
 1323={
@@ -10507,7 +10573,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	181.9.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	181.9.2={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	273.2.7={ death=yes }
 }
 1324={
@@ -10516,7 +10585,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1317	#Aldwin
-	185.3.5={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	185.3.5={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	273.8.27={ death=yes }
 }
 1325={
@@ -10526,7 +10598,10 @@
 	martial=7 diplomacy=7 stewardship=6 intrigue=8 learning=6
 	trait=education_diplomacy_3 trait=brave trait=chaste trait=shy 
 	father=1317	#Aldwin
-	191.2.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	191.2.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	297.6.16={ death=yes }
 }
 1326={
@@ -10536,7 +10611,10 @@
 	martial=8 diplomacy=6 stewardship=5 intrigue=6 learning=6
 	trait=education_intrigue_3 trait=temperate trait=honest trait=sadistic trait=arbitrary 
 	father=1325	#Anson
-	214.9.3={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	214.9.3={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	283.10.9={ death=yes }
 }
 1327={
@@ -10546,7 +10624,10 @@
 	martial=7 diplomacy=8 stewardship=4 intrigue=8 learning=8
 	trait=education_martial_2 trait=arrogant trait=generous 
 	father=1325	#Anson
-	219.2.5={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	219.2.5={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	307.7.27={ death=yes }
 }
 1328={
@@ -10556,7 +10637,10 @@
 	martial=8 diplomacy=7 stewardship=4 intrigue=7 learning=5
 	trait=education_diplomacy_4 trait=deceitful trait=gregarious trait=gluttonous trait=content 
 	father=1325	#Anson
-	224.3.25={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	224.3.25={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	298.11.15={ death=yes }
 }
 1329={
@@ -10566,7 +10650,10 @@
 	martial=7 diplomacy=4 stewardship=8 intrigue=7 learning=8
 	trait=education_intrigue_4 trait=greedy trait=gregarious trait=paranoid trait=patient 
 	father=1326	#Welborne
-	245.6.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	245.6.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	332.8.5={ death=yes }
 }
 1330={
@@ -10577,7 +10664,10 @@
 	trait=education_martial_1 trait=scholar trait=trusting trait=zealous trait=content 
 	trait=deceitful 
 	father=1326	#Welborne
-	253.5.17={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	253.5.17={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	322.10.17={ death=yes }
 }
 1331={
@@ -10586,7 +10676,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1329	#Brandon
-	268.7.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	268.7.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	327.8.24={ death=yes }
 }
 1332={
@@ -10596,7 +10689,10 @@
 	martial=6 diplomacy=7 stewardship=4 intrigue=4 learning=5
 	trait=education_intrigue_1 trait=generous trait=diligent trait=sadistic trait=trusting 
 	father=1329	#Brandon
-	271.11.22={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	271.11.22={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	364.7.17={ death=yes }
 }
 1333={
@@ -10606,7 +10702,10 @@
 	martial=4 diplomacy=5 stewardship=6 intrigue=7 learning=4
 	trait=education_diplomacy_3 trait=ambitious trait=trusting trait=ill trait=beauty_good_3 
 	father=1329	#Brandon
-	278.12.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	278.12.19={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	367.1.5={ death=yes }
 }
 1334={
@@ -10617,7 +10716,10 @@
 	trait=education_learning_4 trait=gluttonous trait=paranoid trait=sadistic 
 	trait=patient  
 	father=1329	#Brandon
-	284.2.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	284.2.11={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	363.5.10={ death=yes }
 }
 1335={
@@ -10626,7 +10728,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1329	#Brandon
-	288.6.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	288.6.11={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	383.11.29={ death=yes }
 }
 1336={
@@ -10636,7 +10741,10 @@
 	martial=5 diplomacy=8 stewardship=6 intrigue=8 learning=4
 	trait=education_intrigue_1 trait=temperate trait=honest trait=patient trait=shy 
 	father=1332	#Newall
-	296.10.6={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	296.10.6={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	388.8.30={ death=yes }
 }
 1337={
@@ -10646,7 +10754,10 @@
 	martial=5 diplomacy=7 stewardship=7 intrigue=7 learning=8
 	trait=education_intrigue_1 trait=patient trait=shy trait=honest 
 	father=1332	#Newall
-	299.5.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	299.5.24={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	362.8.22={ death=yes }
 }
 1338={
@@ -10655,7 +10766,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1332	#Newall
-	304.8.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	304.8.11={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	399.2.9={ death=yes }
 }
 1339={
@@ -10664,7 +10778,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	329.2.3={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	329.2.3={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	423.4.14={ death=yes }
 }
 1340={
@@ -10674,7 +10791,10 @@
 	martial=7 diplomacy=6 stewardship=8 intrigue=5 learning=5
 	trait=education_stewardship_1 trait=trusting trait=humble trait=cynical trait=arbitrary 
 	father=1336	#Gavin
-	331.4.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	331.4.15={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	412.6.6={ death=yes }
 }
 1341={
@@ -10684,7 +10804,10 @@
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=7
 	trait=education_intrigue_4 trait=content trait=arrogant trait=zealous 
 	father=1336	#Gavin
-	335.12.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	335.12.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	404.9.2={ death=yes }
 }
 1342={
@@ -10693,7 +10816,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	340.9.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	340.9.24={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	430.6.15={ death=yes }
 }
 1343={
@@ -10702,7 +10828,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1336	#Gavin
-	344.10.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	344.10.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	417.3.14={ death=yes }
 }
 1344={
@@ -10712,7 +10841,10 @@
 	martial=4 diplomacy=6 stewardship=5 intrigue=4 learning=8
 	trait=education_learning_2 trait=generous trait=chaste trait=arrogant 
 	father=1340	#Lauffer
-	357.1.8={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	357.1.8={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	453.7.15={ death=yes }
 }
 1345={
@@ -10721,7 +10853,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	360.11.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	360.11.21={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	458.12.13={ death=yes }
 }
 1346={
@@ -10730,7 +10865,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	367.10.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	367.10.15={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	431.8.4={ death=yes }
 }
 1347={
@@ -10740,7 +10878,10 @@
 	martial=7 diplomacy=8 stewardship=8 intrigue=7 learning=6
 	trait=education_intrigue_3 trait=arbitrary trait=patient trait=craven 
 	father=1340	#Lauffer
-	371.11.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	371.11.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	445.11.25={ death=yes }
 }
 1348={
@@ -10749,7 +10890,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	377.9.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	377.9.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	453.1.21={ death=yes }
 }
 1349={
@@ -10758,7 +10902,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1340	#Lauffer
-	381.8.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	381.8.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	464.7.1={ death=yes }
 }
 1350={
@@ -10768,7 +10915,10 @@
 	martial=6 diplomacy=5 stewardship=7 intrigue=5 learning=8
 	trait=education_intrigue_1 trait=lazy trait=zealous trait=ambitious 
 	father=1340	#Lauffer
-	384.1.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	384.1.15={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	478.1.27={ death=yes }
 }
 1351={
@@ -10777,7 +10927,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	378.6.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	378.6.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	465.1.4={ death=yes }
 }
 1352={
@@ -10786,7 +10939,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	384.2.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	384.2.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	455.9.3={ death=yes }
 }
 1353={
@@ -10795,7 +10951,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1344	#Bradney
-	390.6.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	390.6.24={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	473.12.14={ death=yes }
 }
 1354={
@@ -10805,7 +10964,10 @@
 	martial=8 diplomacy=4 stewardship=8 intrigue=6 learning=7
 	trait=education_learning_3 trait=trusting trait=cynical trait=sadistic 
 	father=1344	#Bradney
-	398.11.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	398.11.2={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	481.3.27={ death=yes }
 }
 1355={
@@ -10816,7 +10978,10 @@
 	trait=education_diplomacy_1 trait=sadistic trait=trusting trait=generous trait=lustful 
 	trait=lunatic_1 
 	father=1354	#Johan
-	430.5.22={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	430.5.22={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	511.6.26={ death=yes }
 }
 1356={
@@ -10826,7 +10991,10 @@
 	martial=4 diplomacy=7 stewardship=5 intrigue=5 learning=7
 	trait=education_intrigue_3 trait=trusting trait=deceitful trait=gregarious trait=ambitious 
 	father=1354	#Johan
-	434.8.2={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	434.8.2={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	507.12.2={ death=yes }
 }
 1357={
@@ -10836,7 +11004,10 @@
 	martial=5 diplomacy=6 stewardship=6 intrigue=8 learning=4
 	trait=education_learning_2 trait=shy trait=craven trait=lunatic_1 
 	father=1354	#Johan
-	440.12.18={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	440.12.18={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	506.3.29={ death=yes }
 }
 1358={
@@ -10845,7 +11016,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1355	#Bruno
-	458.7.15={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	458.7.15={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	525.5.17={ death=yes }
 }
 1359={
@@ -10855,7 +11029,10 @@
 	martial=8 diplomacy=7 stewardship=4 intrigue=5 learning=6
 	trait=education_diplomacy_4 trait=patient trait=paranoid trait=sadistic trait=shy 
 	father=1355	#Bruno
-	462.1.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	462.1.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	524.1.26={ death=yes }
 }
 1360={
@@ -10866,7 +11043,10 @@
 	trait=education_intrigue_3 trait=torturer trait=craven trait=sadistic trait=diligent 
 	trait=chaste 
 	father=1355	#Bruno
-	468.4.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	468.4.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	548.3.30={ death=yes }
 }
 1361={
@@ -10875,7 +11055,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1355	#Bruno
-	470.7.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	470.7.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	542.6.6={ death=yes }
 }
 1362={
@@ -10885,7 +11068,10 @@
 	martial=4 diplomacy=8 stewardship=8 intrigue=5 learning=5
 	trait=education_diplomacy_1 trait=greedy trait=ambitious trait=temperate 
 	father=1355	#Bruno
-	476.4.19={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	476.4.19={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	542.1.30={ death=yes }
 }
 1363={
@@ -10896,7 +11082,10 @@
 	trait=education_diplomacy_3 trait=craven trait=temperate trait=patient 
 	trait=ambitious 
 	father=1355	#Bruno
-	481.12.21={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	481.12.21={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	573.3.22={ death=yes }
 }
 1364={
@@ -10905,7 +11094,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1359	#Barathen
-	489.8.17={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	489.8.17={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	545.4.26={ death=yes }
 }
 1365={
@@ -10916,7 +11108,10 @@
 	trait=education_stewardship_1 trait=gluttonous trait=arbitrary trait=trusting 
 	trait=ill 
 	father=1359	#Barathen
-	493.6.11={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	493.6.11={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	575.4.15={ death=yes }
 }
 1366={
@@ -10925,7 +11120,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1359	#Barathen
-	498.8.24={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	498.8.24={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	579.12.12={ death=yes }
 }
 1367={
@@ -11092,7 +11290,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1374	#Brodie
-	609.3.23={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	609.3.23={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	673.7.25={ death=yes }
 }
 1381={
@@ -11101,7 +11302,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1374	#Brodie
-	613.8.10={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	613.8.10={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	687.4.17={ death=yes }
 }
 1382={
@@ -11110,7 +11314,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1378	#Bruce
-	620.5.8={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	620.5.8={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	684.8.12={ death=yes }
 }
 1383={
@@ -11120,7 +11327,10 @@
 	martial=6 diplomacy=6 stewardship=5 intrigue=6 learning=6
 	trait=education_intrigue_3 trait=deceitful trait=chaste trait=patient 
 	father=1378	#Bruce
-	627.12.12={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	627.12.12={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	710.6.19={ death=yes }
 }
 1384={
@@ -11130,7 +11340,10 @@
 	martial=6 diplomacy=7 stewardship=5 intrigue=7 learning=4
 	trait=education_diplomacy_3 trait=gluttonous trait=gregarious 
 	father=1383	#Jackson
-	651.3.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	651.3.14={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	731.9.10={ death=yes }
 }
 1385={
@@ -11140,7 +11353,10 @@
 	martial=6 diplomacy=7 stewardship=5 intrigue=5 learning=6
 	trait=education_diplomacy_4 trait=lazy trait=trusting trait=ill 
 	father=1383	#Jackson
-	656.5.14={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	656.5.14={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	741.11.13={ death=yes }
 }
 1386={
@@ -11149,7 +11365,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	659.5.4={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	659.5.4={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	730.2.13={ death=yes }
 }
 1387={
@@ -11158,7 +11377,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	665.9.20={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	665.9.20={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	739.6.27={ death=yes }
 }
 1388={
@@ -11167,7 +11389,10 @@
 	dynasty=12
 	culture=azerothian religion=holy_light
 	father=1383	#Jackson
-	670.12.1={ birth=yes effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } }
+	670.12.1={  
+		birth=yes 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow } } 
+	}
 	714.9.4={ death=yes }
 }
 

--- a/history/characters/310000_patron_characters.txt
+++ b/history/characters/310000_patron_characters.txt
@@ -65,9 +65,11 @@
 		effect={add_patron_trait_character_effect=yes}
 	}
 	600.1.1={
-		# secret_religion=forgotten_shadow
 		trait=education_martial_4
-		effect={ set_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
+		effect={ 
+			set_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value }
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow
+		}
 		trait=brave trait=zealous trait=wrathful trait=education_martial_prowess_4 
 		trait=shy
 	}
@@ -281,13 +283,12 @@
 	name=Garmanosh
 	dynasty=125011
 	culture=bonechewer religion=orcish_shamanism
-	# secret_religion=orcish_fel
 	martial=6 diplomacy=8 stewardship=6 intrigue=4 learning=7
 	trait=education_learning_2
 	trait=intellect_good_2 trait=lustful trait=wrathful trait=arbitrary trait=brave 
 	566.10.1={ birth=yes trait=creature_orc }
 	566.10.1={
-		effect={add_patron_trait_character_effect=yes}
+		effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel }}
 	}
 	582.10.1={ effect={ set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } } }
 	615.2.6={ death=yes }
@@ -316,13 +317,13 @@
 310130={
 	name=Rimaka
 	dynasty=125013
-	culture=gurubashi religion=gurubism # secret_religion=cult_of_hakkar
+	culture=gurubashi religion=gurubism
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_martial_2
 	trait=lifestyle_hunter trait=physique_good_3 trait=sadistic trait=wrathful trait=paranoid trait=ambitious
 	561.2.10={ birth=yes trait=creature_troll }
 	561.2.10={
-		effect={add_patron_trait_character_effect=yes}
+		effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:cult_of_hakkar } }
 	}
 	577.2.10={
 		effect={
@@ -392,13 +393,13 @@
 310160={
 	name=Captain_Boo
 	dynasty=125016
-	culture=quilboar religion=holy_light # secret_religion=scarlet_light
+	culture=quilboar religion=holy_light
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=trusting trait=one_eyed trait=stubborn trait=zealous
 	trait=strong
 	trait=lifestyle_mystic
-	560.1.1={ birth=yes trait=creature_quilboar culture=lordaeronian effect={add_fan_trait_character_effect=yes} }
+	560.1.1={ birth=yes trait=creature_quilboar culture=lordaeronian effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light }} }
 	576.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -480,13 +481,13 @@
 310200={
 	name=Anerian
 	dynasty=125020
-	culture=high_elf religion=cult_of_sunwell # secret_religion=burning_legion_religion
+	culture=high_elf religion=cult_of_sunwell
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=paranoid trait=sadistic trait=cynical trait=ambitious
 	trait=intellect_good_3
 	trait=schemer
-	560.1.1={ birth=yes trait=creature_high_elf effect={add_fan_trait_character_effect=yes} }
+	560.1.1={ birth=yes trait=creature_high_elf effect={add_fan_trait_character_effect=yes effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion } } }
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 	}
@@ -500,16 +501,16 @@
 310210={
 	name=Balovar
 	dynasty=125021
-	culture=lordaeronian religion=holy_light # secret_religion=maldraxxi
+	culture=lordaeronian religion=holy_light
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_intrigue_4
 	trait=physique_bad_3 trait=diligent trait=stubborn
 	trait=shrewd
 	trait=schemer
-	560.1.1={ birth=yes trait=creature_human effect={add_fan_trait_character_effect=yes} }
+	560.1.1={ birth=yes trait=creature_human effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:maldraxxi } } }
 	576.1.1={ effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } } }
 	600.1.1={
-		# secret_religion=death_god
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god } }
 	}
 	643.2.23={ death=yes }
 }
@@ -733,7 +734,7 @@
 		trait=lifestyle_hunter
 	}
 	600.1.1={
-		# secret_religion=death_god
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god } }
 	}
 	603.8.1={
 		religion=death_god
@@ -810,11 +811,11 @@
 310350={ #Count #SimYRuler
 	name=Alexander
 	dynasty=125035
-	culture=azerothian religion=rationalism # secret_religion=holy_light
+	culture=azerothian religion=rationalism
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=intellect_good_3
-	552.9.5={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes} }
+	552.9.5={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:holy_light } } }
 	583.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -932,12 +933,12 @@
 310410={ #Count #Daruthyr
 	name=Gyliad
 	dynasty=125041
-	culture=arathorian religion=holy_light # secret_religion=old_ways
+	culture=arathorian religion=holy_light
 	martial=0 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait = legitimized_bastard
 	#trait = lefthanded
 	trait=beauty_good_3
-	560.1.27={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes} }
+	560.1.27={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways } } }
 	580.1.1={
 		trait=education_martial_4
 		effect={
@@ -972,10 +973,10 @@
 310430={ #Count #Adam M
 	name=Glarr'glarr
 	dynasty=125043
-	culture=gurubashi religion=gurubism # secret_religion=kirin_tor
+	culture=gurubashi religion=gurubism
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_learning_3
-	559.3.22={ birth=yes trait=creature_troll effect={add_patron_trait_character_effect=yes} }
+	559.3.22={ birth=yes trait=creature_troll effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:kirin_tor } } }
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 		trait=magic_good_1
@@ -1063,12 +1064,12 @@
 	name=Lana
 	female=yes
 	dynasty=125047
-	culture=gilnean religion=holy_light # secret_religion=old_ways
+	culture=gilnean religion=holy_light
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_diplomacy_3
 	trait=beauty_good_3
 	trait=temperate trait=lustful trait=greedy trait=stubborn
-	558.2.14={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes} }
+	558.2.14={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways } } }
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 		trait=seducer
@@ -1083,11 +1084,11 @@
 310480={ #Count #Tyler Wilson
 	name=Rumus
 	dynasty=125048
-	culture=lordaeronian religion=holy_light # secret_religion=scarlet_light
+	culture=lordaeronian religion=holy_light
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=chaste trait=arrogant trait=wrathful trait=honest 
-	580.10.4={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes} }
+	580.10.4={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light } } }
 	600.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -1204,7 +1205,7 @@
 	}
 	604.1.1={
 		religion=scarlet_light
-		# secret_religion=holy_light
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:holy_light } }
 	}
 	620.8.7={ death=yes }
 }
@@ -1233,7 +1234,7 @@
 		trait=torturer
 	}
 	603.1.1={
-		# secret_religion=death_god
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god } }
 	}
 	620.9.8={ death=yes }
 }
@@ -1265,11 +1266,11 @@
 310545={	#Shaun Flanagan #Count
 	name=Tronis
 	dynasty=125055
-	culture=high_elf religion=holy_light # secret_religion=scarlet_light
+	culture=high_elf religion=holy_light
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_diplomacy_3
 	trait=magic_good_1
-	548.8.17={ birth=yes trait=creature_high_elf effect={add_patron_trait_character_effect=yes} }
+	548.8.17={ birth=yes trait=creature_high_elf effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light } } }
 	568.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -1652,9 +1653,9 @@ patron310621={ #Kyr Darkcore
 		trait=sadistic trait=honest trait=journaller trait=reclusive trait=deviant trait=logistician
 	}
 	602.8.19={
-		#secret_religion = death_god
 		effect = {
 			#join_society_cult_of_the_damned_effect = yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god }
 		}
 	}
 	603.2.24={

--- a/history/characters/310000_patron_characters.txt
+++ b/history/characters/310000_patron_characters.txt
@@ -288,7 +288,10 @@
 	trait=intellect_good_2 trait=lustful trait=wrathful trait=arbitrary trait=brave 
 	566.10.1={ birth=yes trait=creature_orc }
 	566.10.1={
-		effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel }}
+		effect={
+			add_patron_trait_character_effect=yes 
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel }
+		}
 	}
 	582.10.1={ effect={ set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } } }
 	615.2.6={ death=yes }
@@ -323,7 +326,10 @@
 	trait=lifestyle_hunter trait=physique_good_3 trait=sadistic trait=wrathful trait=paranoid trait=ambitious
 	561.2.10={ birth=yes trait=creature_troll }
 	561.2.10={
-		effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:cult_of_hakkar } }
+		effect={
+			add_patron_trait_character_effect=yes 
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:cult_of_hakkar }
+		}
 	}
 	577.2.10={
 		effect={
@@ -399,7 +405,12 @@
 	trait=trusting trait=one_eyed trait=stubborn trait=zealous
 	trait=strong
 	trait=lifestyle_mystic
-	560.1.1={ birth=yes trait=creature_quilboar culture=lordaeronian effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light }} }
+	560.1.1={ birth=yes trait=creature_quilboar culture=lordaeronian 
+		effect={
+			add_fan_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light }
+		}
+	}
 	576.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -487,7 +498,12 @@
 	trait=paranoid trait=sadistic trait=cynical trait=ambitious
 	trait=intellect_good_3
 	trait=schemer
-	560.1.1={ birth=yes trait=creature_high_elf effect={add_fan_trait_character_effect=yes effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion } } }
+	560.1.1={ birth=yes trait=creature_high_elf 
+		effect={
+			add_fan_trait_character_effect=yes 
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion }
+		} 
+	}
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 	}
@@ -507,7 +523,12 @@
 	trait=physique_bad_3 trait=diligent trait=stubborn
 	trait=shrewd
 	trait=schemer
-	560.1.1={ birth=yes trait=creature_human effect={add_fan_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:maldraxxi } } }
+	560.1.1={ birth=yes trait=creature_human
+		effect={
+			add_fan_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:maldraxxi }
+		} 
+	}
 	576.1.1={ effect={ set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } } }
 	600.1.1={
 		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god } }
@@ -815,7 +836,12 @@
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=intellect_good_3
-	552.9.5={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:holy_light } } }
+	552.9.5={ birth=yes trait=creature_human 
+		effect={
+			add_patron_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:holy_light }
+		} 
+	}
 	583.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -938,7 +964,12 @@
 	trait = legitimized_bastard
 	#trait = lefthanded
 	trait=beauty_good_3
-	560.1.27={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways } } }
+	560.1.27={ birth=yes trait=creature_human
+		effect={
+			add_patron_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways } 
+		}
+	}
 	580.1.1={
 		trait=education_martial_4
 		effect={
@@ -976,7 +1007,12 @@
 	culture=gurubashi religion=gurubism
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_learning_3
-	559.3.22={ birth=yes trait=creature_troll effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:kirin_tor } } }
+	559.3.22={ birth=yes trait=creature_troll
+		effect={
+			add_patron_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:kirin_tor }
+		}
+	}
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 		trait=magic_good_1
@@ -1069,7 +1105,12 @@
 	trait=education_diplomacy_3
 	trait=beauty_good_3
 	trait=temperate trait=lustful trait=greedy trait=stubborn
-	558.2.14={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways } } }
+	558.2.14={ birth=yes trait=creature_human
+		effect={
+			add_patron_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:old_ways }
+		}
+	}
 	580.1.1={
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
 		trait=seducer
@@ -1088,7 +1129,12 @@
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_martial_3
 	trait=chaste trait=arrogant trait=wrathful trait=honest 
-	580.10.4={ birth=yes trait=creature_human effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light } } }
+	580.10.4={ birth=yes trait=creature_human
+		effect={
+			add_patron_trait_character_effect=yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light } 
+		}
+	}
 	600.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
@@ -1270,7 +1316,12 @@
 	martial=5 diplomacy=5 stewardship=5 intrigue=5 learning=5
 	trait=education_diplomacy_3
 	trait=magic_good_1
-	548.8.17={ birth=yes trait=creature_high_elf effect={add_patron_trait_character_effect=yes make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light } } }
+	548.8.17={ birth=yes trait=creature_high_elf 
+		effect={
+			add_patron_trait_character_effect=yes 
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:scarlet_light }
+		}
+	}
 	568.1.1={
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }

--- a/history/characters/310000_patron_characters.txt
+++ b/history/characters/310000_patron_characters.txt
@@ -68,7 +68,7 @@
 		trait=education_martial_4
 		effect={ 
 			set_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value }
-			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:forgotten_shadow }
 		}
 		trait=brave trait=zealous trait=wrathful trait=education_martial_prowess_4 
 		trait=shy

--- a/history/characters/330000_highborne.txt
+++ b/history/characters/330000_highborne.txt
@@ -93,7 +93,7 @@
 	}
 	604.1.1={
 		religion = illidari
-		#secret_religion=nzoth_worship
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:nzoth_worship } }
 	}
 	605.6.2={
 		add_gold = 300 #Military budget
@@ -141,9 +141,11 @@
 		effect={ set_variable = { name = wc_order_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_magic_trait_value } }
 	}
 	505.1.1={
-		#secret_religion = burning_legion_religion
 		trait = adventurer
-		effect={ set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value } }
+		effect={ 
+			set_variable = { name = wc_disorder_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value }
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion }
+		}
 	}
 	531.5.18={ death=yes }
 }

--- a/history/characters/340000_night_elf.txt
+++ b/history/characters/340000_night_elf.txt
@@ -40,7 +40,6 @@
 		add_spouse=340000
 	}
 	603.1.1={ 
-		#secret_religion = cthun_worship
 		remove_trait = honest
 		remove_trait = chaste
 		add_trait = deceitful
@@ -48,6 +47,7 @@
 			add_character_flag = { flag = wc_light_magic_lifestyle_perks_were_reset_flag }
 			set_variable = { name = wc_shadow_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_3_magic_trait_value }
 			#join_society_twilights_hammer_cult_effect = yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:cthun_worship }
 		}
 	}
 	609.4.2={ death=yes }

--- a/history/characters/38000_arathorian.txt
+++ b/history/characters/38000_arathorian.txt
@@ -488,9 +488,9 @@
 		religion = kirin_tor
 	}
 	602.8.19={
-		#secret_religion = death_god
 		effect = {
 			#join_society_cult_of_the_damned_effect = yes
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god }
 		}
 	}
 	603.2.24={

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1987,14 +1987,13 @@
 	name=Mellaen
 	dynasty=20020
 	culture=high_elf religion=cult_of_sunwell
-	#secret_religion=nzoth_worship
 	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=6
 	trait=education_learning_2
 	trait=intellect_good_2 trait=paranoid trait=patient trait=humble trait=zealous
 	disallow_random_traits = yes
 	father=42200			# Qaeyas
 	mother=42201			# Nelea
-	563.6.23={ birth=yes trait=creature_high_elf }
+	563.6.23={ birth=yes trait=creature_high_elf effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:nzoth_worship } } }
 	563.6.23={
 		effect={add_patron_trait_character_effect=yes}
 	}

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1993,7 +1993,10 @@
 	disallow_random_traits = yes
 	father=42200			# Qaeyas
 	mother=42201			# Nelea
-	563.6.23={ birth=yes trait=creature_high_elf effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:nzoth_worship } } }
+	563.6.23={ 
+		birth=yes trait=creature_high_elf 
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:nzoth_worship } }
+	}
 	563.6.23={
 		effect={add_patron_trait_character_effect=yes}
 	}

--- a/history/characters/430000_nathrezim.txt
+++ b/history/characters/430000_nathrezim.txt
@@ -87,7 +87,7 @@
 	#Joins Sylvanas' forces
 	605.5.5={
 		religion = forsaken_cult
-		#secret_religion = burning_legion_religion # Fake defector
+		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:burning_legion_religion } } # Fake defector
 		employer = 42076 # Sylvanas
 		learn_language = language_gutterspeak
 	}

--- a/history/characters/59000_dalaranian.txt
+++ b/history/characters/59000_dalaranian.txt
@@ -207,6 +207,11 @@
 		}
 		give_council_position = councillor_spymaster
 	}
+	598.1.1={
+		effect={
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god }
+		}
+	}
 	601.1.1={
 		effect={
 			set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_4_magic_trait_value }
@@ -504,10 +509,9 @@
 		}
 	}
 	602.6.3={
-		#secret_religion = death_god
 		effect={
 			set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_magic_trait_value }
-
+			make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:death_god }
 			# join_society_cult_of_the_damned_effect = yes
 			# society_rank_up = 1
 		}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Replaced every instance of the commented out `secret_religion=[insert faith]` with `effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:[insert faith] } }` so that they could properly have secret faiths

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added this thing.
- Changed that thing.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Check if the characters have the related secrets. I think observer mode shows them?
And if there are any characters with no secret faith that should have one or the reverse let me know.