### PR TITLE
Quel'thalas Tweaks

### DIFF
--- a/common/customizable_localization/wc_title_custom_loc.txt
+++ b/common/customizable_localization/wc_title_custom_loc.txt
@@ -1,0 +1,37 @@
+﻿RegentLordQuelThalas = { 
+	type = character
+
+	text = { 
+		localization_key = high_king_male_highelf_emperor_regent
+		trigger = { 
+			primary_title = title:e_quelthalas
+			NOT = { 
+				dynasty = dynasty:20001
+			}
+		}
+	}
+
+	text = { 
+		localization_key = high_king_male_highelf_emperor_ruler
+		fallback = yes
+	}
+}
+
+RegentLadyQuelThalas = { 
+	type = character
+
+	text = { 
+		localization_key = high_queen_female_highelf_emperor_regent
+		trigger = { 
+			primary_title = title:e_quelthalas
+			NOT = { 
+				dynasty = dynasty:20001
+			}
+		}
+	}
+
+	text = { 
+		localization_key = high_queen_female_highelf_emperor_ruler
+		fallback = yes
+	}
+}

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1109,6 +1109,9 @@
 	603.10.1={
 		trait=one_eyed
 		trait=scarred
+		effect = {
+			set_designated_heir = character:42003
+		}
 	}
 	604.1.1={
 		effect = {

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -96,6 +96,9 @@
 	603.10.1={
 		trait=depressed_1 # Got depression after father's death
 		culture=blood_elf
+		effect = {
+			add_pressed_claim = title:e_quelthalas
+		}
 	}
 	605.6.2={
 		add_gold = 300 #Military budget

--- a/localization/english/culture/wc_culture_titles_l_english.yml
+++ b/localization/english/culture/wc_culture_titles_l_english.yml
@@ -30,8 +30,12 @@
  lord_male_highelf_count:0 "Lord"
  lady_female_highelf_count:0 "Lady"
  lordship_highelf_county:0 "Lordship"
- high_king_male_highelf_emperor:0 "High King"
- high_queen_female_highelf_emperor:0 "High Queen"
+ high_king_male_highelf_emperor:0 "[Character.Custom('RegentLordQuelThalas')]"
+ high_king_male_highelf_emperor_ruler:0 "High King"
+ high_king_male_highelf_emperor_regent:0 "Regent Lord"
+ high_queen_female_highelf_emperor:0 "[Character.Custom('RegentLadyQuelThalas')]"
+ high_queen_female_highelf_emperor_ruler:0 "High Queen"
+ high_queen_female_highelf_emperor_regent:0 "Regent Lady"
  high_kingdom_highelf_empire:0 "High Kingdom"
 
  ### Highbornes / Nightbornes ###


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Non Sunstrider High-elven rulers of Quel'thalas are Regent Lords/Ladies
- Kael'thas has a pressed claim on the High Kingdom of Quel'thalas after Lor'themar becomes Regent Lord
- Kael'thas is the primary heir of Lor'themar

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
