### PR TITLE
Nerubian character view texture

### DIFF
--- a/common/scripted_triggers/wc_illustration_triggers.txt
+++ b/common/scripted_triggers/wc_illustration_triggers.txt
@@ -204,3 +204,10 @@ has_thunder_king_illustration_trigger = {
 		has_trait = thunder_king
 	}
 }
+has_nerubian_illustration_trigger = { 
+	location = {
+		province_owner ?= {
+			is_race_no_gene_trigger = { RACE = creature_nerubian }
+		}
+	}
+}

--- a/gfx/interface/illustrations/scripted_illustrations/ingame.txt
+++ b/gfx/interface/illustrations/scripted_illustrations/ingame.txt
@@ -438,6 +438,15 @@ character_view_bg = {
 			is_character_window_main_character = no
 		}
 	}
+
+	# Nerubian
+	texture = { 
+		reference = "character_view/nerubian.dds"
+
+		trigger = { 
+			has_nerubian_illustration_trigger = yes
+		}
+	}
 	
 	######################################
 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Added loading screen from TWW as character background for Nerubians

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)
