### PR TITLE
Break up inappropriate lovers

### DIFF
--- a/common/on_action/relations/relation_on_actions.txt
+++ b/common/on_action/relations/relation_on_actions.txt
@@ -66,6 +66,11 @@ on_set_relation_lover = {
 				OR = {
 					scope:target = { is_adult = no }
 					is_adult = no
+					# Warcraft
+					NOT = {
+						can_have_sexual_relation_with_trigger = { CHARACTER = scope:target }
+					}
+					# End of Warcraft
 				}
 			}
 			trigger_event = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Lovers of inappropriate races who somehow manage to become lovers are automatically broken up

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Check that lovers of inappropriate races break up the day after they become lovers. This can be checked using debug mode to make them lovers.