### PR TITLE
Fix all nations spawning without legitimacy

### DIFF
--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -426,6 +426,21 @@ on_game_start_after_lobby = {
 
 		#Set starting cultural acceptance
 		# Warcraft
+
+		### CE1 LEGITIMACY SETUP ###
+		every_ruler = {
+			limit = {
+				exists = dynasty
+				highest_held_title_tier >= tier_county
+				# Exclude unplayable for now, they don't use legitimacy 
+				NOR = { 
+					government_has_flag = government_is_republic
+					government_has_flag = government_is_theocracy
+				}
+				is_landed = yes
+			}
+			add_legitimacy = base_legitimacy_value
+		}		
 	}
 
 	events = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fix all nations spawning without legitimacy

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- The piece of code giving all nations legitimacy on game start was not moved over to the mod, this fixes that
- Republic and theocratic nations don't have legitimacy as a mechanic

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
* Check that everyone has legitimacy