### PR TITLE
Fixes Thunder King Crash

### DIFF
--- a/common/decisions/wc_major_pandaria_decisions.txt
+++ b/common/decisions/wc_major_pandaria_decisions.txt
@@ -40,6 +40,7 @@
 	selection_tooltip = create_pandaria_decision_tt
 
 	is_shown = {
+		is_independent_ruler = yes
 		any_held_title = { # Must be in Pandaria Area
 			tier = tier_county
 			title_province = { geographical_region = world_pandaria }
@@ -50,7 +51,6 @@
 				target = flag:create_pandaria_decision
 			}
 		}
-		is_independent_ruler = yes
 	}
 
 	cost = {					
@@ -107,17 +107,17 @@ revive_lei_shen_decision = { # Revive the Thunder King
 	selection_tooltip = revive_lei_shen_decision_tooltip
 
 	is_shown = {
+		is_independent_ruler = yes
 		culture = { has_cultural_pillar = heritage_mogu }
+		NOT = { # AI cant make it on that gamerule
+			is_ai = yes
+			has_game_rule = wc_thunder_king_crisis_never
+		}
 		NOT = {
 			is_target_in_global_variable_list = {
 				name = unavailable_unique_decisions
 				target = flag:revive_lei_shen_decision
 			}
-		}
-		is_independent_ruler = yes
-		NOT = { # AI cant make it on that gamerule
-			is_ai = yes
-			has_game_rule = wc_thunder_king_crisis_never
 		}
 	}
 
@@ -224,6 +224,7 @@ zandalari_lei_shen_decision  = { # Revive the Thunder King - Zandalari Version
 	selection_tooltip = zandalari_lei_shen_decision_tooltip
 
 	is_shown = {
+		is_independent_ruler = yes
 		AND = {	# Zandalari
 			culture = { has_cultural_pillar = heritage_zulite }
 			NOR = {
@@ -247,7 +248,6 @@ zandalari_lei_shen_decision  = { # Revive the Thunder King - Zandalari Version
 				target = flag:revive_lei_shen_decision
 			}
 		}
-		is_independent_ruler = yes
 		NOT = { # AI cant make it on that gamerule
 			is_ai = yes
 			has_game_rule = wc_thunder_king_crisis_never

--- a/common/decisions/wc_major_pandaria_decisions.txt
+++ b/common/decisions/wc_major_pandaria_decisions.txt
@@ -40,7 +40,8 @@
 	selection_tooltip = create_pandaria_decision_tt
 
 	is_shown = {
-		capital_county = {
+		any_held_title = { # Must be in Pandaria Area
+			tier = tier_county
 			title_province = { geographical_region = world_pandaria }
 		}
 		NOT = {

--- a/common/decisions/wc_major_pandaria_decisions.txt
+++ b/common/decisions/wc_major_pandaria_decisions.txt
@@ -248,7 +248,7 @@ zandalari_lei_shen_decision  = { # Revive the Thunder King - Zandalari Version
 				target = flag:revive_lei_shen_decision
 			}
 		}
-		NOT = { # AI cant make it on that gamerule
+		NAND = { # AI cant make it on that gamerule
 			is_ai = yes
 			has_game_rule = wc_thunder_king_crisis_never
 		}

--- a/common/decisions/wc_major_pandaria_decisions.txt
+++ b/common/decisions/wc_major_pandaria_decisions.txt
@@ -109,7 +109,7 @@ revive_lei_shen_decision = { # Revive the Thunder King
 	is_shown = {
 		is_independent_ruler = yes
 		culture = { has_cultural_pillar = heritage_mogu }
-		NOT = { # AI cant make it on that gamerule
+		NAND = { # AI cant make it on that gamerule
 			is_ai = yes
 			has_game_rule = wc_thunder_king_crisis_never
 		}

--- a/common/story_cycles/wc_story_cycle_thunder_king.txt
+++ b/common/story_cycles/wc_story_cycle_thunder_king.txt
@@ -44,9 +44,11 @@
 		
 		# Handles Court setup, troops, etc
 		story_owner = {
-			trigger_event = pandaria_unification.0101
+			trigger_event = {
+				id = pandaria_unification.0101
+				days = 2
+			}
 		}
-		
 	}
 	
 	# Disband his realm, sends news event

--- a/events/decisions_events/wc_major_pandaria_events.txt
+++ b/events/decisions_events/wc_major_pandaria_events.txt
@@ -330,6 +330,9 @@ pandaria_unification.0101 = { # The Rising Storm - Lei Shen Court Setup + Buffs
 	after = {
 		# Notification
 		every_player = { # News Event
+			limit = {
+				is_landed = yes
+			}
 			trigger_event = {
 				id = pandaria_unification.0103
 				days = 5
@@ -367,10 +370,10 @@ pandaria_unification.0102 = { # Thunder quakes the Skies - Reviver swears fealty
 
 	option = {
 		name = pandaria_unification.0102.a
-		set_player_character = scope:lei_shen
 		scope:lei_shen = {
 			lei_shen_effect = yes
 		}
+		set_player_character = scope:lei_shen
 		ai_chance = {
 			base = 0
 		}
@@ -850,10 +853,10 @@ pandaria_unification.0301 = { # Thunder quakes the Skies - Zandalari talk to Thu
 
 	option = {
 		name = pandaria_unification.0301.a
-		set_player_character = scope:lei_shen
 		scope:lei_shen = {
 			lei_shen_zandalari_effect = yes
 		}
+		set_player_character = scope:lei_shen
 		ai_chance = {
 			base = 0
 		}
@@ -867,7 +870,6 @@ pandaria_unification.0301 = { # Thunder quakes the Skies - Zandalari talk to Thu
 	}
 	after = {
 		scope:lei_shen = {	# Lei Shen Setup
-			#trigger_event = pandaria_unification.0101
 			create_story = story_thunder_king
 		}
 	}

--- a/events/wc_events/wc_health_events.txt
+++ b/events/wc_events/wc_health_events.txt
@@ -74,7 +74,7 @@ WCHEA.2000 = { # Age assignment for ancient historical rulers # by juketm
 		
 		character:lineofthunderking1 = { # Lei Shen
 			change_age = 50
-			dynasty = { add_dynasty_prestige = 30000 }
+			dynasty = { add_dynasty_prestige = 10000 add_dynasty_prestige_level = 9 }
 		}
 	}
 }


### PR DESCRIPTION
Fixes a major reoccurring crash associated with the Thunder King Crisis shortly after Reviving him

## Changelog:
- Minor change to Create Pandaria decision requirements - can now be viewed if any held counties are in pandaria
- Fixes to Thunder King event chain, spaces the events out a few days more
- Fixes the damn crash from reviving the Thunder King

## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)
- [x] Thunder King can be revived as a Mogu without crashing the same month
- [x] Thunder King can be revived as a Zandalari without crashing the same month

