### PR TITLE
Scaling Knowledge Overflow

### DIFF
--- a/common/modifiers/wc_lifestyle_modifiers.txt
+++ b/common/modifiers/wc_lifestyle_modifiers.txt
@@ -1,5 +1,9 @@
 ﻿long_lived_lifestyle_xp_slowdown = {
 	icon = learning_negative
 	monthly_lifestyle_xp_gain_mult = -0.05
-	stacking = yes
+	scale = {
+		value = long_lived_lifestyle_xp_slowdown_value
+
+		desc = long_lived_lifestyle_xp_slowdown_per_stack
+	}
 }

--- a/common/scripted_effects/wc_lifestyle_effects.txt
+++ b/common/scripted_effects/wc_lifestyle_effects.txt
@@ -6,26 +6,21 @@ set_long_lived_lifestyle_xp_slowdown_delayed_event_effect = {
 }
 set_long_lived_lifestyle_xp_slowdown_effect = {
 	if = {
-		limit = { NOT = { has_variable = current_long_lived_lifestyle_xp_slowdown_value } }
-		set_variable = { name = current_long_lived_lifestyle_xp_slowdown_value value = 0 }
-	}
-	while = {
 		limit = {
-			exists = var:current_long_lived_lifestyle_xp_slowdown_value
-			var:current_long_lived_lifestyle_xp_slowdown_value < long_lived_lifestyle_xp_slowdown_value
+			has_character_modifier = long_lived_lifestyle_xp_slowdown
 		}
-		
+		remove_character_modifier = long_lived_lifestyle_xp_slowdown
+	}
+	if = {
+		limit = {
+			long_lived_lifestyle_xp_slowdown_value > 0
+		}
 		add_character_modifier = {
 			modifier = long_lived_lifestyle_xp_slowdown
 			desc = long_lived_lifestyle_xp_slowdown_custom_desc
 		}
-		change_variable = { name = current_long_lived_lifestyle_xp_slowdown_value add = 1 }
 	}
 }
 clear_long_lived_lifestyle_xp_slowdown_effect = {
-	if = {
-		limit = { exists = var:current_long_lived_lifestyle_xp_slowdown_value }
-		remove_variable = current_long_lived_lifestyle_xp_slowdown_value
-		remove_all_character_modifier_instances = long_lived_lifestyle_xp_slowdown
-	}
+	remove_character_modifier = long_lived_lifestyle_xp_slowdown
 }

--- a/localization/english/modifiers/wc_modifiers_l_english.yml
+++ b/localization/english/modifiers/wc_modifiers_l_english.yml
@@ -60,7 +60,9 @@
 
  long_lived_lifestyle_xp_slowdown:0 "[knowledge_overflow|E]"
 
- long_lived_lifestyle_xp_slowdown_custom_desc:2 "$game_concept_knowledge_overflow_common_desc$\n\nDue to [ROOT.Char.GetShortUINamePossessive] [life_expectancy|E], [lifestyle_experience|E] gain slows down by #N [Scope.ScriptValue('long_lived_lifestyle_xp_slowdown_per_perk_percent_value')|2]%#! per each unlocked [perk|E] starting after [Scope.ScriptValue('long_lived_lifestyle_xp_slowdown_offset_value')|V0] [perk|E].\n\nPer stack:"
+ long_lived_lifestyle_xp_slowdown_per_stack:0 "Base"
+
+ long_lived_lifestyle_xp_slowdown_custom_desc:2 "$game_concept_knowledge_overflow_common_desc$\n\nDue to [ROOT.Char.GetShortUINamePossessive] [life_expectancy|E], [lifestyle_experience|E] gain slows down by #N [Scope.ScriptValue('long_lived_lifestyle_xp_slowdown_per_perk_percent_value')|2]%#! per each unlocked [perk|E] starting after [Scope.ScriptValue('long_lived_lifestyle_xp_slowdown_offset_value')|V0] [perks|E].\n"
 
  plague_recruit_cultists_critical_success_modifier:0 "Cultists Overwhelmed"
  plague_recruit_cultists_success_modifier:0 "Cultists Infiltrated"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Knowledge Overflow is now a scaling modifier, instead of a stacking one
  * According to test, this should make the game run at least 5% faster

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Should reduce lag upon gaining many stacks of Knowledge Overflow

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Get loads of perks `add_<lifestyle>_lifestyle_xp 100000` 
- Wait a day
- Open character panel
- Check that the Knowledge Overflow modifier has been applied correctly, and that there is little/no lag
- Do the same thing in the `dev` branch and compare how laggy it is