### PR TITLE
Fix 1414 missing localization for ep1_flavor.2000 WC MAA modifiers

### DIFF
--- a/localization/english/dlc/ep1/wc_dlc_ep1_flavor_events_l_english.yml
+++ b/localization/english/dlc/ep1/wc_dlc_ep1_flavor_events_l_english.yml
@@ -12,6 +12,15 @@
  ep1_flavor.2000.desc_light_aerial:0 ""Control of every aspect of the battlefield is important, these riders will help us maintain control of the skies.""
  ep1_flavor.2000.desc_massive_aerial:0 ""Death from above must be guaranteed for our enemies; those providing should be evermore vigilant.""
 
+ ep1_2000_caster_modifier:0 "Potent Casters"
+ ep1_2000_caster_modifier_desc:0 "$ep1_2000_generic_modifier_desc$"
+ ep1_2000_massive_infantry_modifier:0 "Overpowering Giants"
+ ep1_2000_massive_infantry_modifier_desc:0 "$ep1_2000_generic_modifier_desc$"
+ ep1_2000_light_aerial_modifier:0 "Swift Fliers"
+ ep1_2000_light_aerial_modifier_desc:0 "$ep1_2000_generic_modifier_desc$"
+ ep1_2000_massive_aerial_modifier:0 "Ravenous Behemoths"
+ ep1_2000_massive_aerial_modifier_desc:0 "$ep1_2000_generic_modifier_desc$"
+
  # Interservice Rivalry
  ep1_flavor.2020.desc_knight_1_caster:0 ""... is that all you got, magician? Well for my next trick, I will make you #EMP disappear#!!""
  ep1_flavor.2020.desc_knight_1_massive_infantry:0 ""... lots of brawn but no brains, huh? Either way, I will #EMP cut you down to size#!!""


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Adds missing English localization for Warcraft Men-At-Arms types' modifiers related to the "Martial Exercise" event. (Casters, Giants, Aerials, Massive Aerials)

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added new English localization into wc_dlc_ep1_flavor_events_l_english.yml for caster/massive_infantry/light_aerial/massive_aerial modifiers related to the ep1_flavor.2000 event.
- Attached `$ep1_2000_generic_modifier_desc$` to each modifier description text.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
With debug mode enabled and a character selected that has created Men-at-Arms of Casters, Giants, Aerials or Massive Aerials, run the following command to trigger the 'Martial Exercise' event:

`event ep1_flavor.2000`

Check the tooltips of the modifiers in the top two options. Repeat for the character until you've encountered each of those four options available for your selection of Men-at-Arms.
