### PR TITLE
Fix 1417 localization for progressivist opinions and pacifist counties

### DIFF
--- a/localization/english/religion/wc_core_tenets_l_english.yml
+++ b/localization/english/religion/wc_core_tenets_l_english.yml
@@ -53,6 +53,8 @@
  tenet_progressivism_name:0 "Progressivism"
  tenet_progressivism_desc:0 "We see progress as an absolute good. Our society focuses on technological development and highly values tinkers and scientists."
  doctrine_parameter_progressivist_opinion_active:0 ""
+ progressivist_opinion_active_opinion_name:0 "Hated Progressivist"
+ progressivist_opinion_active_county_opinion_name:0 "Hated Progressivist County"
  doctrine_parameter_opinion_of_progressivist_opinion_active:0 "[opinion|E] of Progressivists: $VALUE|+=0$"
  INCOMPATIBLE_TENET_PROGRESSIVISM_TRIGGER:1 "Incompatible with the [core_tenet|E] [GetFaithDoctrine('tenet_progressivism').GetName( GetPlayer.GetFaith )]"
  INCOMPATIBLE_TENET_INTOLERANCE_TRIGGER:1 "We have nothing to learn from these inferior faiths"

--- a/localization/german/religion/wc_core_tenets_l_german.yml
+++ b/localization/german/religion/wc_core_tenets_l_german.yml
@@ -52,7 +52,7 @@
  tenet_progressivism_desc:0 "Für uns ist der Fortschritt ein absoluter Wert. Unsere Gesellschaft konzentriert sich auf technologische Entwicklung und schätzt Tüftler und Wissenschaftler sehr."
  doctrine_parameter_progressivist_opinion_active:0 ""
  progressivist_opinion_active_opinion_name:0 "Gehasster Progressivist"
- pacifist_opinion_active_county_opinion_name:0 "Gehasste progressive Grafschaft"
+ progressivist_opinion_active_county_opinion_name:0 "Gehasste progressive Grafschaft"
  doctrine_parameter_opinion_of_progressivist_opinion_active:0 "[opinion|E] von Progressivisten: $VALUE|+=0$"
  INCOMPATIBLE_TENET_PROGRESSIVISM_TRIGGER:1 "Inkompatibel mit dem [core_tenet|E] [GetFaithDoctrine('tenet_progressivism').GetName( GetPlayer.GetFaith )]"
  INCOMPATIBLE_TENET_INTOLERANCE_TRIGGER:1 "Wir haben nichts von diesen minderwertigen Glauben zu lernen"

--- a/localization/replace/english/wc_replacements_l_english.yml
+++ b/localization/replace/english/wc_replacements_l_english.yml
@@ -95,8 +95,6 @@
  doctrine_core_tenets_name:0 "Tenet"
  christian_saint_bone_name:0 "Saint's [saint_bone_owner.Custom('RandomSaintBone')]"
 
- pacifist_opinion_active_county_opinion_name:0 "Hated Progressivist County"
-
  #Hashish-Shimmerweed replacement
  trait_hashishiyah:0 "Shimmerweed Habit"
  trait_hashishiyah_desc:0 "This character is dependent on the consumption of shimmerweed to deal with the stress of everyday life."

--- a/localization/replace/french/wc_replacements_l_french.yml
+++ b/localization/replace/french/wc_replacements_l_french.yml
@@ -95,8 +95,6 @@
  doctrine_core_tenets_name:0 "Principe"
  christian_saint_bone_name:0 "Os de saint [saint_bone_owner.Custom('RandomSaintBone')]"
 
- pacifist_opinion_active_county_opinion_name:0 "Comté Progressiste Détesté"
-
  #Hashish-Shimmerweed replacement
 trait_hashishiyah: "Habitude de la Chatoyante"
 trait_hashishiyah_desc: "Ce personnage est dépendant de la consommation de la chatoyante pour faire face au stress de la vie quotidienne."

--- a/localization/spanish/religion/wc_core_tenets_l_spanish.yml
+++ b/localization/spanish/religion/wc_core_tenets_l_spanish.yml
@@ -52,7 +52,7 @@
  tenet_progressivism_desc:0 "We see progress as an absolute good. Our society focuses on technological development and highly values tinkers and scientists."
  doctrine_parameter_progressivist_opinion_active:0 ""
  progressivist_opinion_active_opinion_name:0 "Hated Progressivist"
- pacifist_opinion_active_county_opinion_name:0 "Hated Progressivist County"
+ progressivist_opinion_active_county_opinion_name:0 "Hated Progressivist County"
  doctrine_parameter_opinion_of_progressivist_opinion_active:0 "[opinion|E] of Progressivists: $VALUE|+=0$"
  INCOMPATIBLE_TENET_PROGRESSIVISM_TRIGGER:1 "Incompatible with the [core_tenet|E] [GetFaithDoctrine('tenet_progressivism').GetName( GetPlayer.GetFaith )]"
  INCOMPATIBLE_TENET_INTOLERANCE_TRIGGER:1 "We have nothing to learn from these inferior faiths"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixes all three issues in #1417.
  - Returns the vanilla CK3 pacifist county opinion modifier name, 'Fellow Pacifist County'.
  - Add localization of the -10 opinion malus of Progressivist characters/counties for Faiths with the Consumerist tenet.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- (English/French) Removed `pacifist_opinion_active_county_opinion_name` override from wc_replacements_l_english/french.yml as it is not needed
- (English only) Added `progressivist_opinion_active_opinion_name` to wc_core_tenets_l_english.yml
- (English only) Added `progressivist_opinion_active_county_opinion_name` to wc_core_tenets_l_english.yml
- (German/Spanish) Modified `pacifist_opinion_active_county_opinion_name` key name to `progressivist_opinion_active_county_opinion_name` in wc_core_tenets_l_german/spanish.yml

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- To test the Pacifist county modifier name, play as a Pacifist religion that owns land of either your own Pacifist religion or another Pacifist religion (Velenism or Alexstraszism as an example) OR look at an existing pacifist ruler's county of their religion. Mouse over the number value of **Popular Opinion**. Check for the 'Fellow Pacifist County' +10 opinion bonus.
- To test the Progressivist character modifier malus, play as a character that has a faith with the Progressivist tenet (Rationalism) and select a character that has a faith with the Consumerist tenet (Fortunistic) and ensure localization on the -10 opinion modifier of that character is correct.
- To test the Progressivist county modifier malus, play as a character that has a faith with the Consumerist tenet (Fortunistic). Take over a county that has the Progressivism tenet (Rationalism). Select the county and mouse over the number value of **Popular Opinion**. Check for the 'Hated Progressivist County' -10 opinion malus.