### PR TITLE
Fix union block error spamming

### DIFF
--- a/common/scripted_effects/wc_pol_faction_effects.txt
+++ b/common/scripted_effects/wc_pol_faction_effects.txt
@@ -998,5 +998,5 @@ remove_block_character_unions_effect = {
 
 	remove_character_modifier = union_block_modifier
 
-	remove_from_list = union_blocked_characters
+	remove_list_global_variable  = { name = union_blocked_characters target = prev }
 }


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Fix union block spamming the error log because wrong effect to remove characters from global variable list was used

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
