### PR TITLE
Gilblins

### DIFF
--- a/common/dynasties/28000_goblin.txt
+++ b/common/dynasties/28000_goblin.txt
@@ -143,3 +143,12 @@ noggenfogger = {name = "Noggenfogger" culture = goblin}
 ###Gilblin###
 
 28900 = { name = "dynn_Peddlefin" culture = gilblin }
+28901 = { name = "dynn_Mistyreed" culture = gilblin }	# SoS Gilblins
+28902 = { name = "dynn_Sharpfin" culture = gilblin }	# Unshackled
+28903 = { name = "dynn_Gurbfin" culture = gilblin }	# Gurboggle
+28904 = { name = "dynn_Bitterbrine" culture = gilblin }
+28905 = { name = "dynn_Blackfin" culture = gilblin }
+28906 = { name = "dynn_Brackfin" culture = gilblin }
+28907 = { name = "dynn_Deepfin" culture = gilblin }
+28908 = { name = "dynn_Muckskin" culture = gilblin }
+28909 = { name = "dynn_Murkmouth" culture = gilblin }

--- a/history/characters/gilblin.txt
+++ b/history/characters/gilblin.txt
@@ -9,9 +9,19 @@ gilblin001 = { #Generated
 }
 gilblin002 = { #Argurgle
 	name = Argurgle
+	dynasty=28901 #Mistyreed
 	culture = gilblin 
 	religion = water_deities
 	martial=7 diplomacy=4 stewardship=7 intrigue=5 learning=8
 	trait=education_stewardship_4 trait = ambitious trait = just trait = gluttonous trait = patient 
 	554.9.6={ birth = yes trait = creature_gilblin }
+}
+gilblin003 = { #Vez
+	name = Vez
+	dynasty=28906 #Brackfin
+	culture = gilblin 
+	religion = water_deities
+	martial=6 diplomacy=3 stewardship=3 intrigue=8 learning=4
+	trait=education_stewardship_4 trait = greedy trait = callous trait = stubborn trait = arrogant 
+	559.2.1={ birth = yes trait = creature_gilblin }
 }

--- a/history/characters/gilblin.txt
+++ b/history/characters/gilblin.txt
@@ -7,3 +7,11 @@ gilblin001 = { #Generated
 	culture = gilblin
 	557.9.15 = { birth = yes trait = creature_gilblin }
 }
+gilblin002 = { #Argurgle
+	name = Argurgle
+	culture = gilblin 
+	religion = water_deities
+	martial=7 diplomacy=4 stewardship=7 intrigue=5 learning=8
+	trait=education_stewardship_4 trait = ambitious trait = just trait = gluttonous trait = patient 
+	554.9.6={ birth = yes trait = creature_gilblin }
+}

--- a/history/provinces/00_k_dead_morass.txt
+++ b/history/provinces/00_k_dead_morass.txt
@@ -221,7 +221,7 @@
 	religion = water_deities
 	holding = tribal_holding
 
-	600.1.1 = {
+	573.1.1 = {
 		culture = gilblin
 	}
 }

--- a/history/provinces/00_k_zandalar.txt
+++ b/history/provinces/00_k_zandalar.txt
@@ -122,7 +122,7 @@
 ##d_zuldazar ###################################
 ###c_covescale
 2240 = {	# Dreadpearl
-	culture = murloc
+	culture = gilblin
 	religion = water_deities
 	holding = tribal_holding
 }

--- a/history/titles/00_k_dead_morass.txt
+++ b/history/titles/00_k_dead_morass.txt
@@ -191,6 +191,6 @@ c_atalhakkar = {
 }
 c_rotten_beach = {
 	573.1.1={
-		holder=34013
+		holder = gilblin002 #Argurgle
 	}
 }

--- a/history/titles/00_k_zandalar.txt
+++ b/history/titles/00_k_zandalar.txt
@@ -139,12 +139,7 @@ c_covescale = {
 	454.12.08={holder=35778} #Ghrmh[6030]
 	507.08.07={holder=35784} #Gmmrhg[6030]
 	512.12.04={holder=35786} #Hmghh[6030]
-	562.05.07={holder=35790} #Gmmlg[6030]
-	581.02.16={holder=35794} #Mrgmmrgm[6030]
-	607.05.20={holder=35796} #Llgmmr[6030]
-	616.08.04={holder=35801} #Lghhg[6030]
-	654.09.22={holder=35806} #Gmghg[6030]
-	673.04.15={holder=35811} #Rmmrh[6030]
+	559.2.1 = { holder=gilblin003 } # Vez[28906]
 }
 c_tusk_isle = {
 	1.1.1={

--- a/localization/english/dynasties/wc_dynasty_names_l_english.yml
+++ b/localization/english/dynasties/wc_dynasty_names_l_english.yml
@@ -1784,8 +1784,6 @@
  ### Quel'dorei
  ### Sin'dorei
  ### Goblin ###
- ### Gilblin ###
- dynn_Peddlefin:0 "Peddlefin"
  ### Blackwater
  ### Goblin
  ### Dragons ###
@@ -9273,3 +9271,16 @@
  Pestle:0 "Pestle"
  Riverpaw:0 "Riverpaw"
  Spothide:0 "Spothide"
+ 
+ ### Gilblin ###
+ dynn_Peddlefin:0 "Peddlefin"
+ dynn_Mistyreed:0 "Mistyreed"
+ dynn_Sharpfin:0 "Sharpfin"
+ dynn_Gurbfin:0 "Gurbfin"
+ dynn_Seashell:0 "Seashell"
+ dynn_Bitterbrine:0 "Bitterbrine"
+ dynn_Blackfin:0 "Blackfin"
+ dynn_Brackfin:0 "Brackfin"
+ dynn_Deepfin:0 "Deepfin"
+ dynn_Muckskin:0 "Muckskin"
+ dynn_Murkmouth:0 "Murkmouth"


### PR DESCRIPTION
## Changelog:
- Added two Gilblin characters based on lore.

## Developer changelog:
- Added Argurgle, a Gilblin tribal ruler in the Swamp of Sorrows
- Added Vez, a Gilblin tribal ruler in Zandalar (https://warcraft.wiki.gg/wiki/Vez)

## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

# How to test:
- Simply play as either Argurgle or Vez.