### PR TITLE
Idolise Magic reform faith fix

### DIFF
--- a/common/scripted_triggers/wc_religious_triggers.txt
+++ b/common/scripted_triggers/wc_religious_triggers.txt
@@ -920,6 +920,7 @@ can_idolise_light_magic_trigger = {
 			doctrine:tenet_light_syncretism = { is_in_list = selected_doctrines }
 			doctrine:tenet_sun_worship = { is_in_list = selected_doctrines }
 			doctrine:tenet_moon_worship = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_light_magic_approved
 		}
 	}
 }
@@ -930,6 +931,7 @@ can_idolise_shadow_magic_trigger = {
 		OR = {
 			religion = { is_in_family = rf_shadow }
 			doctrine:tenet_shadow_syncretism = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_shadow_magic_approved
 		}
 	}
 }
@@ -940,6 +942,7 @@ can_idolise_disorder_magic_trigger = {
 		OR = {
 			religion = { is_in_family = rf_disorder }
 			doctrine:tenet_disorder_syncretism = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_disorder_magic_approved
 		}
 	}
 }
@@ -950,6 +953,7 @@ can_idolise_order_magic_trigger = {
 		OR = {
 			religion = { is_in_family = rf_order }
 			doctrine:tenet_order_syncretism = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_order_magic_approved
 		}
 	}
 }
@@ -960,6 +964,7 @@ can_idolise_life_magic_trigger = {
 		OR = {
 			religion = { is_in_family = rf_life }
 			doctrine:tenet_life_syncretism = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_life_magic_approved
 		}
 	}
 }
@@ -970,6 +975,7 @@ can_idolise_death_magic_trigger = {
 		OR = {
 			religion = { is_in_family = rf_death }
 			doctrine:tenet_death_syncretism = { is_in_list = selected_doctrines }
+			has_doctrine = doctrine_death_magic_approved
 		}
 	}
 }


### PR DESCRIPTION
Updated triggers to allow specific Idolised Magic type when reforming faiths that already have the doctrine.

Fix for this issue: https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/issues/308

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed an issue where certain faiths couldn't be reformed with already held Idolised doctrines

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added trigger to allow faiths with preexisting idolised magic doctrines to reform with current doctrines. 
- Faiths with Idolised magic doctrines can now only change to "Accepted" when reforming, 

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [x] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [x] The mod takes less than 5.5 GB in the Task Manager (Windows)