### PR TITLE
ethnicity weights fix

### DIFF
--- a/common/culture/cultures/wc_argusean.txt
+++ b/common/culture/cultures/wc_argusean.txt
@@ -27,6 +27,6 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = draenei_ethnicity
+		100 = draenei_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_avianic.txt
+++ b/common/culture/cultures/wc_avianic.txt
@@ -21,9 +21,9 @@
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		10 = green_harpy_ethnicity
-		10 = yellow_harpy_ethnicity
-		10 = blue_harpy_ethnicity
-		10 = elven_harpy_ethnicity
+		25 = green_harpy_ethnicity
+		25 = yellow_harpy_ethnicity
+		25 = blue_harpy_ethnicity
+		25 = elven_harpy_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_azsharic.txt
+++ b/common/culture/cultures/wc_azsharic.txt
@@ -22,6 +22,6 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = naga_ethnicity
+		100 = naga_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_cenaric.txt
+++ b/common/culture/cultures/wc_cenaric.txt
@@ -31,7 +31,7 @@
 	
 	ethnicities = {
 		# 10 = night_elven # disabled because of eyebrows
-		5 = caucasian_blond
+		100 = caucasian_blond
 	}
 }
 
@@ -62,6 +62,6 @@ frostnymph = {
 	
 	ethnicities = {
 		# 10 = night_elven # disabled because of eyebrows
-		5 = caucasian_blond
+		100 = caucasian_blond
 	}
 }

--- a/common/culture/cultures/wc_darnassian.txt
+++ b/common/culture/cultures/wc_darnassian.txt
@@ -30,7 +30,7 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = night_elven
+		100 = night_elven
 	}
 }
 
@@ -57,6 +57,6 @@ protector = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = night_elven
+		100 = night_elven
 	}
 }

--- a/common/culture/cultures/wc_demonic.txt
+++ b/common/culture/cultures/wc_demonic.txt
@@ -21,7 +21,7 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = manari_ethnicity
+		100 = manari_ethnicity
 	}
 }
 
@@ -48,7 +48,7 @@ annihilan = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = manari_ethnicity
+		100 = manari_ethnicity
 	}
 }
 
@@ -75,7 +75,7 @@ eredruin = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = manari_ethnicity
+		100 = manari_ethnicity
 	}
 }
 
@@ -103,7 +103,7 @@ shivarra = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = manari_ethnicity
+		100 = manari_ethnicity
 	}
 }
 
@@ -130,9 +130,9 @@ sayaadi = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = succubus_red
-		1 = succubus_blue
-		1 = succubus_magenta
+		40 = succubus_red
+		30 = succubus_blue
+		30 = succubus_magenta
 	}
 }
 
@@ -159,7 +159,7 @@ observer = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = manari_ethnicity
+		100 = manari_ethnicity
 	}
 }
 
@@ -187,10 +187,10 @@ nathrezim = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = nathrezim_tint1
-		1 = nathrezim_tint2
-		1 = nathrezim_tint3
-		1 = nathrezim_tint4
-		1 = nathrezim_tint5
+		20 = nathrezim_tint1
+		20 = nathrezim_tint2
+		20 = nathrezim_tint3
+		20 = nathrezim_tint4
+		20 = nathrezim_tint5
 	}
 }

--- a/common/culture/cultures/wc_draconic.txt
+++ b/common/culture/cultures/wc_draconic.txt
@@ -22,8 +22,8 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		6 = green_dragon_night_elven
-		3 = green_dragon_high_elven
+		67 = green_dragon_night_elven
+		33 = green_dragon_high_elven
 	}
 }
 
@@ -57,8 +57,8 @@ black_dragon = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		11 = black_dragon_human
-		1 = black_dragon_high_elven
+		80 = black_dragon_human
+		20 = black_dragon_high_elven
 	}
 }
 
@@ -86,8 +86,8 @@ red_dragon = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		9 = red_dragon_human
-		7 = red_dragon_high_elven
+		80 = red_dragon_human
+		20 = red_dragon_high_elven
 	}
 }
 
@@ -115,9 +115,9 @@ blue_dragon = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		3 = blue_dragon_human
-		8 = blue_dragon_high_elven
-		1 = blue_dragon_gnome
+		30 = blue_dragon_human
+		60 = blue_dragon_high_elven
+		10 = blue_dragon_gnome
 	}
 }
 
@@ -145,9 +145,9 @@ bronze_dragon = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		11 = bronze_dragon_high_elven
-		4 = bronze_dragon_human
-		2 = bronze_dragon_gnome
+		70 = bronze_dragon_high_elven
+		20 = bronze_dragon_human
+		10 = bronze_dragon_gnome
 	}
 
 }

--- a/common/culture/cultures/wc_dwarven.txt
+++ b/common/culture/cultures/wc_dwarven.txt
@@ -21,7 +21,7 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = dwarven_ethnicity
+		100 = dwarven_ethnicity
 	}
 }
 
@@ -77,7 +77,7 @@ wildhammer = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = wildhammer_ethnicity
+		100 = wildhammer_ethnicity
 	}
 }
 
@@ -110,7 +110,7 @@ dark_iron = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = dark_iron_ethnicity
+		100 = dark_iron_ethnicity
 	}
 }
 
@@ -148,6 +148,6 @@ frostborn = {
 	unit_gfx = { northern_unit_gfx }
 	
 	ethnicities = {
-		1 = frostborn_ethnicity
+		100 = frostborn_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_gnomic.txt
+++ b/common/culture/cultures/wc_gnomic.txt
@@ -26,6 +26,6 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = gnome_ethnicity
+		100 = gnome_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_goblin.txt
+++ b/common/culture/cultures/wc_goblin.txt
@@ -22,7 +22,7 @@
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = goblin_ethnicity
+		100 = goblin_ethnicity
 	}
 }
 
@@ -55,7 +55,7 @@ blackwater = {
 	unit_gfx = { western_unit_gfx }
 
 	ethnicities = {
-		1 = goblin_ethnicity
+		100 = goblin_ethnicity
 	}
 }
 
@@ -82,6 +82,6 @@ gilblin = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = gilblin_ethnicity
+		100 = gilblin_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_gorian.txt
+++ b/common/culture/cultures/wc_gorian.txt
@@ -27,6 +27,6 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = ogre_ethnicity
+		100 = ogre_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_grummle.txt
+++ b/common/culture/cultures/wc_grummle.txt
@@ -24,6 +24,6 @@
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		10 = asian
+		100 = asian
 	}
 }

--- a/common/culture/cultures/wc_highborne.txt
+++ b/common/culture/cultures/wc_highborne.txt
@@ -36,7 +36,7 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = highborne_ethnicity
+		100 = highborne_ethnicity
 	}
 }
 
@@ -72,7 +72,7 @@ high_elf = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = high_elven
+		100 = high_elven
 	}
 }
 
@@ -108,7 +108,7 @@ blood_elf = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = high_elven
+		100 = high_elven
 	}
 }
 
@@ -144,7 +144,7 @@ void_elf = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = high_elven
+		100 = high_elven
 	}
 }
 
@@ -175,7 +175,7 @@ nightborne = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = nightborne_ethnicity
+		100 = nightborne_ethnicity
 	}
 }
 faldorei = {
@@ -202,6 +202,6 @@ faldorei = {
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = faldorei_ethnicity
+		100 = faldorei_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_jinyu.txt
+++ b/common/culture/cultures/wc_jinyu.txt
@@ -22,7 +22,7 @@
 	unit_gfx = { indian_unit_gfx }
 	
 	ethnicities = {
-		10 = asian
+		100 = asian
 	}
 }
 
@@ -49,6 +49,6 @@ ankoan = {
 	unit_gfx = { indian_unit_gfx }
 	
 	ethnicities = {
-		10 = asian
+		100 = asian
 	}
 }

--- a/common/culture/cultures/wc_mogu.txt
+++ b/common/culture/cultures/wc_mogu.txt
@@ -28,6 +28,6 @@
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = mogu_ethnicity
+		100 = mogu_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_odobenus.txt
+++ b/common/culture/cultures/wc_odobenus.txt
@@ -28,6 +28,6 @@
 	unit_gfx = { northern_unit_gfx }
 	
 	ethnicities = {
-		1 = tuskarr_ethnicity
+		100 = tuskarr_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_orcish.txt
+++ b/common/culture/cultures/wc_orcish.txt
@@ -439,7 +439,7 @@ twilights_hammer = {
 	
 	ethnicities = {
 		90 = pale_orcish
-		10 = ogre_ethnicity
+		10 = green_orcish
 	}
 }
 

--- a/common/culture/cultures/wc_orcish.txt
+++ b/common/culture/cultures/wc_orcish.txt
@@ -579,6 +579,6 @@ moknathal = {
 	unit_gfx = { northern_unit_gfx }
 	
 	ethnicities = {
-		1 = moknathal_ethnicity
+		100 = moknathal_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_pandaren.txt
+++ b/common/culture/cultures/wc_pandaren.txt
@@ -27,11 +27,11 @@
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 mountain_pandaren = { # Kun-li - The Pandaren of the Kun-Lai mountains. Martial and monastic.
@@ -66,11 +66,11 @@ mountain_pandaren = { # Kun-li - The Pandaren of the Kun-Lai mountains. Martial 
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 spiritual_pandaren = { # Xue-li - The pandaren of the lowlands and the Vale of Eternal Blossoms Spiritual and traditionalist.
@@ -105,11 +105,11 @@ spiritual_pandaren = { # Xue-li - The pandaren of the lowlands and the Vale of E
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 mainland_pandaren = { # Shei-li - The pandaren of the prosperous Valley of Four Winds. Agrarian and industrious.
@@ -139,11 +139,11 @@ mainland_pandaren = { # Shei-li - The pandaren of the prosperous Valley of Four 
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 forest_pandaren = { # Jian-li - The Pandaren of the Jade Forest. Spiritual and open.
@@ -174,11 +174,11 @@ forest_pandaren = { # Jian-li - The Pandaren of the Jade Forest. Spiritual and o
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 fisher_pandaren = { # Chui-li - The Pandaren of the Krasarang Jungles. Anglers and hardy survivalists.
@@ -208,11 +208,11 @@ fisher_pandaren = { # Chui-li - The Pandaren of the Krasarang Jungles. Anglers a
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }
 wandering_pandaren = { # Shen-zin - Nomadic Pandaren
@@ -241,10 +241,10 @@ wandering_pandaren = { # Shen-zin - Nomadic Pandaren
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		1 = pandaren_black_ethnicity
-		1 = pandaren_brown_ethnicity
-		1 = pandaren_red_ethnicity
-		1 = pandaren_gray_ethnicity
-		1 = pandaren_white_ethnicity
+		20 = pandaren_black_ethnicity
+		20 = pandaren_brown_ethnicity
+		20 = pandaren_red_ethnicity
+		20 = pandaren_gray_ethnicity
+		20 = pandaren_white_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_pygmy.txt
+++ b/common/culture/cultures/wc_pygmy.txt
@@ -24,6 +24,6 @@
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = pygmy_ethnicity
+		100 = pygmy_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_southern.txt
+++ b/common/culture/cultures/wc_southern.txt
@@ -22,11 +22,11 @@
 	unit_gfx = { iranian_unit_gfx }
 
 	ethnicities = {
-		10 = arab
-		4 = african
-		2 = east_african
-		1 = indian
-		1 = south_indian
+		30 = arab
+		30 = african
+		20 = east_african
+		10 = indian
+		10 = south_indian
 	}
 }
 
@@ -56,7 +56,7 @@ wastewander = {
 	unit_gfx = { mena_unit_gfx }
 
 	ethnicities = {
-		8 = arab
-		5 = mediterranean
+		80 = arab
+		20 = mediterranean
 	}
 }

--- a/common/culture/cultures/wc_uldamanic.txt
+++ b/common/culture/cultures/wc_uldamanic.txt
@@ -24,7 +24,7 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = trogg_ethnicity
+		100 = trogg_ethnicity
 	}
 }
 
@@ -61,6 +61,6 @@ drogbar = {
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-			1 = drogbar_ethnicity
+			100 = drogbar_ethnicity
 		}
 }

--- a/common/culture/cultures/wc_ulduaric.txt
+++ b/common/culture/cultures/wc_ulduaric.txt
@@ -35,7 +35,7 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = watcher_ethnicity
+		100 = watcher_ethnicity
 	}
 }
 
@@ -62,7 +62,7 @@ frozen_giant = {
 	unit_gfx = { northern_unit_gfx }
 	
 	ethnicities = {
-		1 = frost_giant_ethnicity
+		100 = frost_giant_ethnicity
 	}
 }
 
@@ -88,7 +88,7 @@ storm_giant = {
 	unit_gfx = { northern_unit_gfx }
 	
 	ethnicities = {
-		1 = storm_giant_ethnicity
+		100 = storm_giant_ethnicity
 	}
 }
 
@@ -125,7 +125,7 @@ mechagnome = {
 	unit_gfx = { western_unit_gfx }
 	
 	ethnicities = {
-		1 = gnome_ethnicity
+		100 = gnome_ethnicity
 	}
 }
 
@@ -152,6 +152,6 @@ skrog = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = skrog_ethnicity
+		100 = skrog_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_vrykulic.txt
+++ b/common/culture/cultures/wc_vrykulic.txt
@@ -33,7 +33,7 @@
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = vrykul_ethnicity
+		100 = vrykul_ethnicity
 	}
 }
 
@@ -73,7 +73,7 @@ hyldnir = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = frost_vrykul_ethnicity
+		100 = frost_vrykul_ethnicity
 	}
 }
 
@@ -112,7 +112,7 @@ frost_vrykul = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = frost_vrykul_ethnicity
+		100 = frost_vrykul_ethnicity
 	}
 }
 
@@ -163,7 +163,7 @@ stormheimir = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = vrykul_ethnicity
+		100 = vrykul_ethnicity
 	}
 }
 
@@ -196,7 +196,7 @@ kvaldir = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = kvaldir_ethnicity
+		100 = kvaldir_ethnicity
 	}
 }
 
@@ -223,7 +223,7 @@ drust = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = drust_ethnicity
+		100 = drust_ethnicity
 	}
 }
 
@@ -271,6 +271,6 @@ lucardir = {
 	unit_gfx = { norse_unit_gfx }
 	
 	ethnicities = {
-		1 = vrykul_ethnicity
+		100 = vrykul_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_xavic.txt
+++ b/common/culture/cultures/wc_xavic.txt
@@ -26,6 +26,6 @@
 	unit_gfx = { eastern_unit_gfx }
 	
 	ethnicities = {
-		1 = satyr_ethnicity
+		100 = satyr_ethnicity
 	}
 }

--- a/common/culture/cultures/wc_yaungolic.txt
+++ b/common/culture/cultures/wc_yaungolic.txt
@@ -27,6 +27,6 @@
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		10 = asian
+		100 = asian
 	}
 }

--- a/common/culture/cultures/wc_zaetaric.txt
+++ b/common/culture/cultures/wc_zaetaric.txt
@@ -25,6 +25,6 @@
 	unit_gfx = { mongol_unit_gfx }
 	
 	ethnicities = {
-		10 = asian
+		100 = asian
 	}
 }

--- a/common/culture/cultures/wc_zulite.txt
+++ b/common/culture/cultures/wc_zulite.txt
@@ -29,7 +29,7 @@
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = zandalari_troll_ethnicity
+		100 = zandalari_troll_ethnicity
 	}
 }
 
@@ -59,7 +59,7 @@ gurubashi = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = darkspear_trollish
+		100 = darkspear_trollish
 	}
 }
 
@@ -89,7 +89,7 @@ amani = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = forest_troll_ethnicity
+		100 = forest_troll_ethnicity
 	}
 }
 
@@ -119,7 +119,7 @@ drakkari = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = ice_troll_ethnicity
+		100 = ice_troll_ethnicity
 	}
 }
 
@@ -154,7 +154,7 @@ farraki = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		1 = sand_troll_ethnicity
+		100 = sand_troll_ethnicity
 	}
 }
 
@@ -211,8 +211,8 @@ blood_troll = {
 	unit_gfx = { sub_sahran_unit_gfx }
 	
 	ethnicities = {
-		5 = blood_troll_light
-		3 = blood_troll_dark
-		1 = blood_troll_green
+		60 = blood_troll_light
+		30 = blood_troll_dark
+		10 = blood_troll_green
 	}
 }


### PR DESCRIPTION
<!--
When creating a divergent or mix of two cultures, ethnicities will now correctly attribute a value of 50/50 from each parent ethnicity. This means if you are merging for example a night elf culture and a troll culture, your new culture will spawn a 50% chance of each parent ethnicity.
-->
## Changelog:
- Ethnicity weights modified to be based on a value of 100
- Some individual cultures have their existing ethnicity assignments reweighted to be more balanced
