### PR TITLE
Fix bookmark character appearances

### DIFF
--- a/common/bookmark_portraits/arthas_menethil_character.txt
+++ b/common/bookmark_portraits/arthas_menethil_character.txt
@@ -2,7 +2,7 @@
 # History database id:60003
 arthas_menethil_character={
 	type=male
-	id=32807
+	id=647103076
 	age=0.230000
 	genes={ 		hair_color={ 43 85 30 226 }
  		skin_color={ 19 50 47 43 }
@@ -90,13 +90,13 @@ arthas_menethil_character={
  		face_detail_nose_ridge_def={ "nose_ridge_def_pos" 137 "nose_ridge_def_neg" 8 }
  		face_detail_nose_tip_def={ "nose_tip_def" 66 "nose_tip_def" 240 }
  		face_detail_temple_def={ "temple_def" 77 "temple_def" 166 }
- 		expression_brow_wrinkles={ "brow_wrinkles_04" 255 "brow_wrinkles_04" 218 }
- 		expression_eye_wrinkles={ "eye_wrinkles_02" 0 "eye_wrinkles_02" 207 }
+ 		expression_brow_wrinkles={ "brow_wrinkles_04" 151 "brow_wrinkles_04" 218 }
+ 		expression_eye_wrinkles={ "eye_wrinkles_02" 166 "eye_wrinkles_02" 207 }
  		expression_forehead_wrinkles={ "forehead_wrinkles_02" 0 "forehead_wrinkles_02" 224 }
  		expression_other={ "cheek_wrinkles_both_01" 68 "cheek_wrinkles_left_01" 127 }
  		complexion={ "complexion_3" 170 "complexion_3" 80 }
  		gene_height={ "normal_height" 138 "normal_height" 159 }
- 		gene_bs_body_type={ "body_fat_head_fat_low" 72 "body_fat_head_fat_low" 138 }
+ 		gene_bs_body_type={ "body_fat_head_fat_low" 68 "body_fat_head_fat_low" 138 }
  		gene_bs_body_shape={ "body_shape_triangle_half" 255 "body_shape_triangle_full" 16 }
  		gene_bs_bust={ "bust_clothes" 131 "bust_default" 205 }
  		gene_age={ "old_2" 143 "old_2" 143 }
@@ -106,7 +106,6 @@ arthas_menethil_character={
  		gene_hair_type={ "hair_straight" 127 "hair_straight" 127 }
  		gene_baldness={ "no_baldness" 127 "no_baldness" 127 }
  		eye_accessory={ "normal_eyes" 70 "normal_eyes" 70 }
- 		##eye_left_accessory={ "normal_eyes" 0 "normal_eyes" 0 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 133 "normal_eyelashes" 133 }
  		gene_body_markings={ "no_body_markings" 127 "no_body_markings" 127 }
@@ -140,14 +139,50 @@ arthas_menethil_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
- 		beards={ "no_beard" 201 "no_beard" 0 }
- 		clothes={ "western_low_nobility_clothes" 149 "most_clothes" 0 }
+ 		beards={ "no_beard" 135 "no_beard" 0 }
+ 		cloaks={ "no_cloak" 135 "no_cloak" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 158 "all_hairstyles" 0 }
- 		legwear={ "western_common_legwear" 138 "all_legwear" 0 }
+ 		legwear={ "western_common_legwear" 144 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		clothes={ "western_high_nobility_clothes" 213 "most_clothes" 0 }
+ 		headgear={ "western_high_nobility" 165 "no_headgear" 0 }
+ 		additive_headgear={ "ep2_western_era2_veils" 144 "no_additive" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
-	entity={ 1863162561 1863162561 }
+	entity={ 979141817 979141817 }
+	tags={ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=2635852190
+			invert=no
+		}
+ {
+			hash=1945936758
+			invert=no
+		}
+ }
 }
 

--- a/common/bookmark_portraits/darkhan_character.txt
+++ b/common/bookmark_portraits/darkhan_character.txt
@@ -2,7 +2,7 @@
 # History database id:42078
 darkhan_character={
 	type=male
-	id=7771
+	id=3597984731
 	age=0.372330
 	genes={ 		hair_color={ 14 255 33 109 }
  		skin_color={ 14 45 18 48 }
@@ -93,10 +93,10 @@ darkhan_character={
  		expression_brow_wrinkles={ "brow_wrinkles_04" 255 "brow_wrinkles_01" 109 }
  		expression_eye_wrinkles={ "eye_wrinkles_02" 255 "eye_wrinkles_02" 84 }
  		expression_forehead_wrinkles={ "forehead_wrinkles_03" 0 "forehead_wrinkles_02" 0 }
- 		expression_other={ "cheek_wrinkles_both_01" 44 "cheek_wrinkles_both_01" 99 }
+ 		expression_other={ "cheek_wrinkles_both_01" 49 "cheek_wrinkles_both_01" 99 }
  		complexion={ "complexion_3" 54 "complexion_3" 54 }
  		gene_height={ "normal_height" 133 "normal_height" 133 }
- 		gene_bs_body_type={ "body_fat_head_fat_low" 132 "body_fat_head_fat_low" 96 }
+ 		gene_bs_body_type={ "body_fat_head_fat_low" 131 "body_fat_head_fat_low" 96 }
  		gene_bs_body_shape={ "body_shape_average" 255 "body_shape_average" 126 }
  		gene_bs_bust={ "bust_clothes" 6 "bust_shape_4_full" 11 }
  		gene_age={ "old_beauty_1" 103 "old_beauty_1" 103 }
@@ -106,7 +106,6 @@ darkhan_character={
  		gene_hair_type={ "hair_wavy" 106 "hair_wavy" 106 }
  		gene_baldness={ "male_pattern_baldness" 58 "male_pattern_baldness" 58 }
  		eye_accessory={ "normal_eyes" 172 "normal_eyes" 172 }
- 		##eye_left_accessory={ "normal_eyes" 216 "normal_eyes" 216 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 3 "normal_eyelashes" 3 }
  		gene_body_markings={ "no_body_markings" 255 "no_body_markings" 255 }
@@ -140,18 +139,54 @@ darkhan_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
- 		beards={ "no_beard" 227 "no_beard" 0 }
- 		clothes={ "byzantine_high_nobility_clothes" 131 "most_clothes" 0 }
+ 		beards={ "no_beard" 42 "no_beard" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 221 "all_hairstyles" 0 }
- 		headgear={ "high_elven_crowns" 134 "no_headgear" 0 }
- 		legwear={ "western_common_legwear" 72 "all_legwear" 0 }
+ 		legwear={ "western_common_legwear" 99 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		clothes={ "byzantine_high_nobility_clothes" 231 "most_clothes" 0 }
+ 		headgear={ "high_elven_crowns" 215 "no_headgear" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
 	entity={ 2268070609 2720375217 }
 	tags={ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=3672171019
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
 			hash=1022698243
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=1015114348
+			invert=no
+		}
+ {
+			hash=1945936758
 			invert=no
 		}
  }

--- a/common/bookmark_portraits/garithos_character.txt
+++ b/common/bookmark_portraits/garithos_character.txt
@@ -2,7 +2,7 @@
 # History database id:60030
 garithos_character={
 	type=male
-	id=31915
+	id=2804857459
 	age=0.390000
 	genes={ 		hair_color={ 23 234 46 239 }
  		skin_color={ 28 43 45 50 }
@@ -53,7 +53,7 @@ garithos_character={
  		gene_bs_eye_upper_lid_size={ "eye_upper_lid_size_pos" 255 "eye_upper_lid_size_pos" 7 }
  		gene_bs_forehead_brow_curve={ "forehead_brow_curve_neg" 255 "forehead_brow_curve_pos" 49 }
  		gene_bs_forehead_brow_forward={ "forehead_brow_forward_pos" 81 "forehead_brow_forward_neg" 39 }
- 		gene_bs_forehead_brow_inner_height={ "forehead_brow_inner_height_neg" 228 "forehead_brow_inner_height_neg" 59 }
+ 		gene_bs_forehead_brow_inner_height={ "forehead_brow_inner_height_pos" 102 "forehead_brow_inner_height_neg" 59 }
  		gene_bs_forehead_brow_outer_height={ "forehead_brow_outer_height_pos" 255 "forehead_brow_outer_height_pos" 22 }
  		gene_bs_forehead_brow_width={ "forehead_brow_width_pos" 255 "forehead_brow_width_pos" 98 }
  		gene_bs_jaw_def={ "jaw_def_pos" 116 "jaw_def_pos" 67 }
@@ -90,13 +90,13 @@ garithos_character={
  		face_detail_nose_ridge_def={ "nose_ridge_def_neg" 247 "nose_ridge_def_neg" 247 }
  		face_detail_nose_tip_def={ "nose_tip_def" 225 "nose_tip_def" 225 }
  		face_detail_temple_def={ "temple_def" 92 "temple_def" 92 }
- 		expression_brow_wrinkles={ "brow_wrinkles_04" 204 "brow_wrinkles_01" 2 }
+ 		expression_brow_wrinkles={ "brow_wrinkles_04" 255 "brow_wrinkles_01" 2 }
  		expression_eye_wrinkles={ "eye_wrinkles_01" 255 "eye_wrinkles_01" 52 }
  		expression_forehead_wrinkles={ "forehead_wrinkles_03" 151 "forehead_wrinkles_01" 31 }
- 		expression_other={ "nose_wrinkles_01" 255 "cheek_wrinkles_left_01" 127 }
+ 		expression_other={ "cheek_wrinkles_both_01" 255 "cheek_wrinkles_left_01" 127 }
  		complexion={ "complexion_1" 133 "complexion_5" 133 }
  		gene_height={ "normal_height" 131 "normal_height" 139 }
- 		gene_bs_body_type={ "body_fat_head_fat_full" 154 "body_fat_head_fat_full" 125 }
+ 		gene_bs_body_type={ "body_fat_head_fat_full" 123 "body_fat_head_fat_full" 125 }
  		gene_bs_body_shape={ "body_shape_triangle_full" 255 "body_shape_triangle_half" 0 }
  		gene_bs_bust={ "bust_clothes" 116 "bust_shape_1_full" 183 }
  		gene_age={ "old_3" 22 "old_3" 22 }
@@ -106,10 +106,10 @@ garithos_character={
  		gene_hair_type={ "hair_straight" 127 "hair_straight" 127 }
  		gene_baldness={ "no_baldness" 127 "no_baldness" 127 }
  		eye_accessory={ "normal_eyes" 221 "normal_eyes" 221 }
- 		##eye_left_accessory={ "normal_eyes" 221 "normal_eyes" 221 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 169 "normal_eyelashes" 169 }
  		gene_body_markings={ "no_body_markings" 127 "no_body_markings" 127 }
+ 		gene_facial_markings={ "no_markings" 127 "no_markings" 127 }
  		gene_facial_markings_2={ "no_markings" 127 "no_markings" 127 }
  		special_eyebrows={ "no_eyebrows" 93 "no_eyebrows" 93 }
  		claws={ "no_claws" 0 "no_claws" 0 }
@@ -139,24 +139,44 @@ garithos_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
  		beards={ "scripted_character_beards_01" 188 "no_beard" 0 }
- 		cloaks={ "human_shoulderpad" 172 "no_cloak" 0 }
- 		hairstyles={ "no_hairstyles" 108 "all_hairstyles" 0 }
- 		legwear={ "western_war_legwear" 253 "all_legwear" 0 }
+ 		cloaks={ "ep2_cloak_western_era1_low_nobility" 20 "no_cloak" 0 }
+ 		hairstyles={ "no_hairstyles" 64 "all_hairstyles" 0 }
+ 		legwear={ "western_common_legwear" 204 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
  		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
  		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
- 		clothes={ "western_war_nobility_clothes" 255 "most_clothes" 0 }
- 		headgear={ "western_war" 255 "no_headgear" 0 }
- 		additive_headgear={ "ep2_western_era2_veils" 108 "western_veils" 0 }
+ 		clothes={ "western_high_nobility_clothes" 217 "most_clothes" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
-	override={
-		portrait_modifier_overrides={
-			custom_headgear=m_headgear_sec_western_war_nob_01
+	entity={ 2268070609 2268070609 }
+	tags={ {
+			hash=1367985987
+			invert=no
 		}
-	}
-
-	entity={ 979141817 979141817 }
+ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=1945936758
+			invert=no
+		}
+ }
 }
 

--- a/common/bookmark_portraits/guldan_character.txt
+++ b/common/bookmark_portraits/guldan_character.txt
@@ -2,7 +2,7 @@
 # History database id:10015
 guldan_character={
 	type=male
-	id=30940
+	id=2543826158
 	age=0.790000
 	genes={ 		hair_color={ 45 252 34 233 }
  		skin_color={ 88 196 87 162 }
@@ -53,7 +53,7 @@ guldan_character={
  		gene_bs_eye_upper_lid_size={ "eye_upper_lid_size_pos" 95 "eye_upper_lid_size_pos" 95 }
  		gene_bs_forehead_brow_curve={ "forehead_brow_curve_neg" 255 "forehead_brow_curve_pos" 47 }
  		gene_bs_forehead_brow_forward={ "forehead_brow_forward_pos" 43 "forehead_brow_forward_pos" 186 }
- 		gene_bs_forehead_brow_inner_height={ "forehead_brow_inner_height_neg" 255 "forehead_brow_inner_height_pos" 4 }
+ 		gene_bs_forehead_brow_inner_height={ "forehead_brow_inner_height_pos" 102 "forehead_brow_inner_height_pos" 4 }
  		gene_bs_forehead_brow_outer_height={ "forehead_brow_outer_height_neg" 23 "forehead_brow_outer_height_neg" 4 }
  		gene_bs_forehead_brow_width={ "forehead_brow_width_pos" 203 "forehead_brow_width_pos" 203 }
  		gene_bs_jaw_def={ "jaw_def_pos" 35 "jaw_def_pos" 45 }
@@ -90,15 +90,15 @@ guldan_character={
  		face_detail_nose_ridge_def={ "nose_ridge_def_pos" 22 "nose_ridge_def_pos" 22 }
  		face_detail_nose_tip_def={ "nose_tip_def" 0 "nose_tip_def" 211 }
  		face_detail_temple_def={ "temple_def" 221 "temple_def" 221 }
- 		expression_brow_wrinkles={ "brow_wrinkles_04" 251 "brow_wrinkles_04" 251 }
+ 		expression_brow_wrinkles={ "brow_wrinkles_04" 255 "brow_wrinkles_04" 251 }
  		expression_eye_wrinkles={ "eye_wrinkles_03" 255 "eye_wrinkles_02" 226 }
  		expression_forehead_wrinkles={ "forehead_wrinkles_03" 255 "forehead_wrinkles_03" 197 }
  		expression_other={ "cheek_wrinkles_both_01" 255 "cheek_wrinkles_both_01" 195 }
  		complexion={ "complexion_6" 0 "complexion_3" 242 }
  		gene_height={ "normal_height" 155 "normal_height" 156 }
- 		gene_bs_body_type={ "body_fat_head_fat_low" 68 "body_fat_head_fat_low" 158 }
+ 		gene_bs_body_type={ "body_fat_head_fat_low" 135 "body_fat_head_fat_low" 158 }
  		gene_bs_body_shape={ "body_shape_triangle_half" 255 "body_shape_pear_half" 223 }
- 		gene_bs_bust={ "bust_clothes" 88 "bust_shape_3_full" 138 }
+ 		gene_bs_bust={ "bust_clothes" 70 "bust_shape_3_full" 138 }
  		gene_age={ "old_4" 255 "old_4" 141 }
  		gene_eyebrows_shape={ "no_eyebrows" 0 "avg_spacing_avg_thickness" 141 }
  		gene_eyebrows_fullness={ "no_eyebrows" 0 "layer_2_lower_thickness" 165 }
@@ -106,7 +106,6 @@ guldan_character={
  		gene_hair_type={ "hair_wavy" 185 "hair_wavy" 185 }
  		gene_baldness={ "male_pattern_baldness" 255 "male_pattern_baldness" 255 }
  		eye_accessory={ "normal_eyes" 6 "normal_eyes" 6 }
- 		##eye_left_accessory={ "normal_eyes" 221 "normal_eyes" 221 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "no_eyelashes" 43 "no_eyelashes" 43 }
  		gene_body_markings={ "no_body_markings" 255 "no_body_markings" 255 }
@@ -140,18 +139,58 @@ guldan_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
- 		gene_hunchbacked={ "hunchbacked" 162 "hunchbacked" 0 }
  		beards={ "scripted_character_beards_01" 204 "no_beard" 0 }
- 		clothes={ "religious_northern_high_clothes" 52 "most_clothes" 0 }
- 		hairstyles={ "scripted_character_hairstyles_01" 137 "all_hairstyles" 0 }
- 		legwear={ "western_common_legwear" 131 "all_legwear" 0 }
+ 		cloaks={ "western_royalty" 134 "no_cloak" 0 }
+ 		hairstyles={ "no_hairstyles" 39 "all_hairstyles" 0 }
+ 		legwear={ "western_common_legwear" 130 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		clothes={ "religious_northern_high_clothes" 27 "most_clothes" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
-	entity={ 616600735 616600735 }
+	entity={ 2268070609 2720375217 }
 	tags={ {
+			hash=1367985987
+			invert=no
+		}
+ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=2793867254
+			invert=no
+		}
+ {
+			hash=571730772
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
 			hash=1022698243
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=2842715111
+			invert=no
+		}
+ {
+			hash=1945936758
 			invert=no
 		}
  }

--- a/common/bookmark_portraits/kaelthas_character.txt
+++ b/common/bookmark_portraits/kaelthas_character.txt
@@ -2,11 +2,11 @@
 # History database id:42003
 kaelthas_character={
 	type=male
-	id=836
+	id=520197392
 	age=0.412524
 	genes={ 		hair_color={ 45 91 56 119 }
  		skin_color={ 29 67 46 31 }
- 		eye_color={ 83 128 157 111 }
+ 		eye_color={ 87 115 157 111 }
  		gene_chin_forward={ "chin_forward_neg" 115 "chin_forward_neg" 115 }
  		gene_chin_height={ "chin_height_pos" 192 "chin_height_pos" 181 }
  		gene_chin_width={ "chin_width_neg" 192 "chin_width_neg" 37 }
@@ -96,9 +96,9 @@ kaelthas_character={
  		expression_other={ "cheek_wrinkles_both_01" 137 "cheek_wrinkles_left_01" 127 }
  		complexion={ "complexion_1" 243 "complexion_1" 243 }
  		gene_height={ "full_height" 130 "normal_height" 169 }
- 		gene_bs_body_type={ "body_fat_head_fat_full" 114 "body_fat_head_fat_full" 113 }
- 		gene_bs_body_shape={ "body_shape_average" 132 "body_shape_rectangle_half" 6 }
- 		gene_bs_bust={ "bust_clothes" 35 "bust_shape_3_half" 71 }
+ 		gene_bs_body_type={ "body_fat_head_fat_full" 105 "body_fat_head_fat_full" 113 }
+ 		gene_bs_body_shape={ "body_shape_average" 158 "body_shape_rectangle_half" 6 }
+ 		gene_bs_bust={ "bust_clothes" 44 "bust_shape_3_half" 71 }
  		gene_age={ "old_beauty_1" 0 "old_4" 152 }
  		gene_eyebrows_shape={ "no_eyebrows" 75 "no_eyebrows" 75 }
  		gene_eyebrows_fullness={ "no_eyebrows" 104 "no_eyebrows" 104 }
@@ -106,10 +106,10 @@ kaelthas_character={
  		gene_hair_type={ "hair_straight" 127 "hair_straight" 127 }
  		gene_baldness={ "no_baldness" 127 "no_baldness" 127 }
  		eye_accessory={ "normal_eyes" 51 "normal_eyes" 51 }
- 		##eye_left_accessory={ "normal_eyes" 0 "normal_eyes" 0 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 247 "normal_eyelashes" 247 }
  		gene_body_markings={ "no_body_markings" 127 "no_body_markings" 127 }
+ 		gene_facial_markings={ "no_markings" 127 "no_markings" 127 }
  		gene_facial_markings_2={ "no_markings" 127 "no_markings" 127 }
  		special_eyebrows={ "high_elven_eyebrows" 255 "high_elven_eyebrows" 25 }
  		claws={ "no_claws" 0 "no_claws" 0 }
@@ -139,19 +139,54 @@ kaelthas_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
- 		beards={ "no_beard" 209 "no_beard" 0 }
+ 		beards={ "no_beard" 129 "no_beard" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 158 "all_hairstyles" 0 }
- 		legwear={ "western_common_legwear" 217 "all_legwear" 0 }
+ 		legwear={ "western_common_legwear" 17 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
  		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
  		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
- 		clothes={ "blood_elven_high_nobility_clothes" 87 "most_clothes" 0 }
- 		headgear={ "high_elven_crowns" 207 "no_headgear" 0 }
+ 		clothes={ "byzantine_high_nobility_clothes" 191 "most_clothes" 0 }
+ 		headgear={ "high_elven_crowns" 58 "no_headgear" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
 	entity={ 3942081117 3942081117 }
 	tags={ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
 			hash=1022698243
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=2635852190
+			invert=no
+		}
+ {
+			hash=1015114348
+			invert=no
+		}
+ {
+			hash=1945936758
 			invert=no
 		}
  }

--- a/common/bookmark_portraits/medivh_character.txt
+++ b/common/bookmark_portraits/medivh_character.txt
@@ -2,7 +2,7 @@
 # History database id:5000
 medivh_character={
 	type=male
-	id=29809
+	id=2851296853
 	age=0.250341
 	genes={ 		hair_color={ 30 255 30 255 }
  		skin_color={ 28 45 38 32 }
@@ -96,8 +96,8 @@ medivh_character={
  		expression_other={ "cheek_wrinkles_left_01" 0 "cheek_wrinkles_left_01" 127 }
  		complexion={ "complexion_1" 169 "complexion_2" 169 }
  		gene_height={ "full_height" 128 "normal_height" 128 }
- 		gene_bs_body_type={ "body_fat_head_fat_medium" 132 "body_fat_head_fat_medium" 136 }
- 		gene_bs_body_shape={ "body_shape_average" 142 "body_shape_pear_half" 0 }
+ 		gene_bs_body_type={ "body_fat_head_fat_medium" 144 "body_fat_head_fat_medium" 136 }
+ 		gene_bs_body_shape={ "body_shape_average" 132 "body_shape_pear_half" 0 }
  		gene_bs_bust={ "bust_clothes" 55 "bust_shape_3_full" 87 }
  		gene_age={ "old_1" 0 "old_1" 47 }
  		gene_eyebrows_shape={ "close_spacing_lower_thickness" 188 "avg_spacing_avg_thickness" 122 }
@@ -106,7 +106,6 @@ medivh_character={
  		gene_hair_type={ "hair_wavy" 90 "hair_wavy" 90 }
  		gene_baldness={ "male_pattern_baldness" 197 "male_pattern_baldness" 197 }
  		eye_accessory={ "normal_eyes" 233 "normal_eyes" 233 }
- 		##eye_left_accessory={ "normal_eyes" 221 "normal_eyes" 221 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 211 "normal_eyelashes" 211 }
  		gene_body_markings={ "no_body_markings" 255 "no_body_markings" 255 }
@@ -140,15 +139,50 @@ medivh_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
  		beards={ "scripted_character_beards_01" 155 "no_beard" 0 }
- 		clothes={ "western_high_nobility_clothes" 167 "most_clothes" 0 }
+ 		cloaks={ "ep2_cloak_western_era1_low_nobility" 143 "no_cloak" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 38 "all_hairstyles" 0 }
- 		headgear={ "western_high_nobility" 215 "no_headgear" 0 }
- 		legwear={ "western_common_legwear" 207 "all_legwear" 0 }
+ 		legwear={ "western_common_legwear" 60 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		clothes={ "western_high_nobility_clothes" 142 "most_clothes" 0 }
+ 		headgear={ "western_high_nobility" 157 "no_headgear" 0 }
+ 		additive_headgear={ "ep2_western_era2_veils" 153 "no_additive" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
 	entity={ 3942081117 3942081117 }
+	tags={ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=2793867254
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=1945936758
+			invert=no
+		}
+ }
 }
 

--- a/common/bookmark_portraits/tyrande_character.txt
+++ b/common/bookmark_portraits/tyrande_character.txt
@@ -2,7 +2,7 @@
 # History database id:340003
 tyrande_character={
 	type=female
-	id=461
+	id=3822861726
 	age=0.376968
 	genes={ 		hair_color={ 140 214 129 222 }
  		skin_color={ 206 73 216 74 }
@@ -38,7 +38,7 @@ tyrande_character={
  		gene_mouth_lower_lip_size={ "mouth_lower_lip_size_neg" 167 "mouth_lower_lip_size_neg" 173 }
  		gene_mouth_open={ "mouth_open_pos" 159 "mouth_open_pos" 0 }
  		gene_neck_length={ "neck_length_neg" 136 "neck_length_neg" 119 }
- 		#gene_neck_width={ "neck_width_pos" 56 "neck_width_pos" 56 }
+ 		gene_neck_width={ "neck_width_pos" 56 "neck_width_pos" 56 }
  		gene_bs_cheek_forward={ "cheek_forward_pos" 110 "cheek_forward_pos" 150 }
  		gene_bs_cheek_height={ "cheek_height_pos" 52 "cheek_height_pos" 226 }
  		gene_bs_cheek_width={ "cheek_width_neg" 75 "cheek_width_pos" 11 }
@@ -91,13 +91,13 @@ tyrande_character={
  		face_detail_nose_tip_def={ "nose_tip_def" 210 "nose_tip_def" 107 }
  		face_detail_temple_def={ "temple_def" 130 "temple_def" 181 }
  		expression_brow_wrinkles={ "brow_wrinkles_04" 0 "brow_wrinkles_04" 140 }
- 		expression_eye_wrinkles={ "eye_wrinkles_03" 173 "eye_wrinkles_03" 61 }
+ 		expression_eye_wrinkles={ "eye_wrinkles_03" 131 "eye_wrinkles_03" 61 }
  		expression_forehead_wrinkles={ "forehead_wrinkles_02" 0 "forehead_wrinkles_02" 204 }
  		expression_other={ "cheek_wrinkles_both_01" 0 "cheek_wrinkles_both_01" 164 }
  		complexion={ "complexion_5" 191 "complexion_5" 46 }
  		gene_height={ "normal_height" 185 "normal_height" 177 }
- 		gene_bs_body_type={ "body_fat_head_fat_low" 138 "body_fat_head_fat_low" 94 }
- 		gene_bs_body_shape={ "body_shape_triangle_half" 126 "body_shape_triangle_half" 122 }
+ 		gene_bs_body_type={ "body_fat_head_fat_low" 86 "body_fat_head_fat_low" 94 }
+ 		gene_bs_body_shape={ "body_shape_triangle_half" 152 "body_shape_triangle_half" 122 }
  		gene_bs_bust={ "bust_clothes" 131 "bust_shape_2_half" 96 }
  		gene_age={ "old_beauty_1" 0 "old_beauty_1" 227 }
  		gene_eyebrows_shape={ "no_eyebrows" 117 "no_eyebrows" 117 }
@@ -106,12 +106,11 @@ tyrande_character={
  		gene_hair_type={ "hair_straight" 93 "hair_straight" 93 }
  		gene_baldness={ "male_pattern_baldness" 174 "male_pattern_baldness" 174 }
  		eye_accessory={ "normal_eyes" 211 "normal_eyes" 211 }
- 		##eye_left_accessory={ "normal_eyes" 142 "normal_eyes" 142 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 160 "normal_eyelashes" 160 }
  		gene_body_markings={ "no_body_markings" 255 "no_body_markings" 255 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 255 }
- 		gene_facial_markings_2={ "nathrezim_lipstick" 102 "no_markings" 127 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 255 }
+ 		gene_facial_markings_2={ "no_markings" 127 "no_markings" 127 }
  		special_eyebrows={ "night_elven_eyebrows" 12 "night_elven_eyebrows" 12 }
  		claws={ "no_claws" 0 "no_claws" 0 }
  		hooves={ "no_hoves" 0 "no_hoves" 0 }
@@ -140,21 +139,55 @@ tyrande_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
- 		beards={ "night_elven_straight_beards" 49 "no_beard" 0 }
- 		cloaks={ "no_cloak" 116 "no_cloak" 0 }
+ 		beards={ "night_elven_straight_beards" 63 "no_beard" 0 }
+ 		cloaks={ "no_cloak" 44 "no_cloak" 0 }
  		hairstyles={ "scripted_character_hairstyles_01" 160 "all_hairstyles" 0 }
- 		legwear={ "mena_nobility_legwear" 170 "all_legwear" 0 }
+ 		legwear={ "mena_nobility_legwear" 73 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
  		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
- 		gene_facial_markings={ "tyrande_no_eyelids" 178 "no_markings" 0 }
- 		gene_neck_width={ "neck_width_pos" 51 "neck_width_neg" 0 }
- 		headgear={ "high_elven_crowns" 80 "no_headgear" 0 }
- 		clothes={ "steppe_high_nobility_clothes" 178 "most_clothes" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "tyrande_no_eyelids" 255 "no_markings" 0 }
+ 		clothes={ "steppe_high_nobility_clothes" 87 "most_clothes" 0 }
+ 		headgear={ "high_elven_crowns" 169 "no_headgear" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
 	entity={ 979141817 979141817 }
 	tags={ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=3672171019
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
 			hash=1022698243
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=2842715111
+			invert=no
+		}
+ {
+			hash=1015114348
 			invert=no
 		}
  }

--- a/common/bookmark_portraits/valonforth_character.txt
+++ b/common/bookmark_portraits/valonforth_character.txt
@@ -2,7 +2,7 @@
 # History database id:60693
 valonforth_character={
 	type=male
-	id=32729
+	id=1137262974
 	age=0.310000
 	genes={ 		hair_color={ 30 255 30 255 }
  		skin_color={ 26 39 26 39 }
@@ -96,8 +96,8 @@ valonforth_character={
  		expression_other={ "cheek_wrinkles_both_01" 0 "cheek_wrinkles_both_01" 0 }
  		complexion={ "complexion_3" 250 "complexion_3" 250 }
  		gene_height={ "normal_height" 158 "normal_height" 158 }
- 		gene_bs_body_type={ "body_fat_head_fat_full" 100 "body_fat_head_fat_full" 132 }
- 		gene_bs_body_shape={ "body_shape_pear_full" 255 "body_shape_pear_full" 0 }
+ 		gene_bs_body_type={ "body_fat_head_fat_full" 84 "body_fat_head_fat_full" 132 }
+ 		gene_bs_body_shape={ "body_shape_pear_full" 209 "body_shape_pear_full" 0 }
  		gene_bs_bust={ "bust_clothes" 46 "bust_shape_3_half" 73 }
  		gene_age={ "old_4" 179 "old_4" 179 }
  		gene_eyebrows_shape={ "far_spacing_lower_thickness" 200 "far_spacing_lower_thickness" 200 }
@@ -106,7 +106,6 @@ valonforth_character={
  		gene_hair_type={ "hair_wavy" 119 "hair_wavy" 119 }
  		gene_baldness={ "male_pattern_baldness" 222 "male_pattern_baldness" 222 }
  		eye_accessory={ "normal_eyes" 82 "normal_eyes" 82 }
- 		##eye_left_accessory={ "normal_eyes" 172 "normal_eyes" 172 }
  		teeth_accessory={ "normal_teeth" 0 "normal_teeth" 0 }
  		eyelashes_accessory={ "normal_eyelashes" 248 "normal_eyelashes" 248 }
  		gene_body_markings={ "no_body_markings" 255 "no_body_markings" 255 }
@@ -140,18 +139,54 @@ valonforth_character={
  		tail={ "no_tail" 0 "no_tail" 0 }
  		tendrils={ "no_tendrils" 0 "no_tendrils" 0 }
  		wings={ "no_wings" 0 "no_wings" 0 }
- 		pose={ "" 255 "" 0 }
  		beards={ "scripted_character_beards_03" 84 "no_beard" 0 }
- 		cloaks={ "ep2_cloak_western_era1_high_nobility" 184 "no_cloak" 0 }
+ 		cloaks={ "ep2_cloak_western_era1_low_nobility" 251 "no_cloak" 0 }
  		hairstyles={ "no_hairstyles" 0 "all_hairstyles" 0 }
- 		legwear={ "western_common_legwear" 163 "all_legwear" 0 }
+ 		legwear={ "western_common_legwear" 219 "all_legwear" 0 }
  		gene_shrink_body={ "shrink_all" 255 "" 0 }
  		gene_bs_additive_headgears={ "additive_headgears" 255 "" 0 }
- 		#gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
- 		clothes={ "western_high_nobility_clothes" 201 "most_clothes" 0 }
- 		headgear={ "western_high_nobility" 220 "no_headgear" 0 }
- 		additive_headgear={ "ep2_western_era2_veils" 201 "no_additive" 0 }
+ 		gene_bs_cloak_offset={ "cloak_offset" 255 "" 0 }
+ 		gene_bs_long_beard={ "long_beard" 255 "" 0 }
+ 		gene_bs_no_jaw={ "no_jaw" 255 "" 0 }
+ 		gene_facial_markings={ "no_markings" 255 "no_markings" 0 }
+ 		clothes={ "western_high_nobility_clothes" 54 "most_clothes" 0 }
+ 		headgear={ "western_high_nobility" 132 "no_headgear" 0 }
+ 		additive_headgear={ "ep2_western_era2_veils" 221 "no_additive" 0 }
+ 		gene_balding_hair_effect={ "no_baldness" 255 "no_baldness" 0 }
  }
 	entity={ 3942081117 3942081117 }
+	tags={ {
+			hash=1367985987
+			invert=no
+		}
+ {
+			hash=2125534279
+			invert=no
+		}
+ {
+			hash=681013727
+			invert=no
+		}
+ {
+			hash=2793867254
+			invert=no
+		}
+ {
+			hash=2670398845
+			invert=no
+		}
+ {
+			hash=1500963499
+			invert=no
+		}
+ {
+			hash=1563190100
+			invert=no
+		}
+ {
+			hash=1945936758
+			invert=no
+		}
+ }
 }
 

--- a/common/scripted_triggers/wc_his_character_triggers.txt
+++ b/common/scripted_triggers/wc_his_character_triggers.txt
@@ -364,6 +364,11 @@ is_odilia_whitemane_trigger = {
 	exists = character:60575 # Odilia Whitemane
 	this = character:60575 # Odilia Whitemane
 }
+is_luc_trigger = {
+	exists = this
+	exists = character:60693 # Luc
+	this = character:60693 # Luc
+}
 
 # High Elves
 is_sylvanas_trigger = {
@@ -1046,6 +1051,7 @@ is_any_historical_character_trigger = {
 		is_mary_whitemane_trigger = yes
 		is_patricia_whitemane_trigger = yes
 		is_odilia_whitemane_trigger = yes
+		is_luc_trigger = yes
 
 		# High Elves
 		is_sylvanas_trigger = yes

--- a/gfx/portraits/portrait_modifiers/01_headgear_base.txt
+++ b/gfx/portraits/portrait_modifiers/01_headgear_base.txt
@@ -267,6 +267,8 @@ headgear_base = {
 				portrait_high_nobles_headgear_trigger = {
 					CULTURE_INPUT = western_goblin_dwarven_gnomish
 				}	
+				# Warcraft
+				is_garithos_trigger = no
 			}
 			modifier = {
 				factor = 0

--- a/gfx/portraits/portrait_modifiers/05_hair_situational.txt
+++ b/gfx/portraits/portrait_modifiers/05_hair_situational.txt
@@ -104,6 +104,9 @@ hair_situational = {
 				trigger = {
 					morph_gene_value:gene_baldness > {
 						value = age
+						# Warcraft
+						divide = racial_age_multiplier_value
+						# Warcraft
 						multiply = 0.01
 					}
 				}
@@ -133,6 +136,9 @@ hair_situational = {
 				trigger = {
 					morph_gene_value:gene_baldness > {
 						value = age
+						# Warcraft
+						divide = racial_age_multiplier_value
+						# Warcraft
 						multiply = 0.005
 					}
 				}

--- a/gfx/portraits/portrait_modifiers/05_hair_situational.txt
+++ b/gfx/portraits/portrait_modifiers/05_hair_situational.txt
@@ -50,6 +50,15 @@ hair_situational = {
 					has_trait = beardless_eunuch
 				}
 			}
+			# Warcraft
+			modifier = {
+				add = 1000
+				has_gene = {
+					category = gene_baldness
+					template = no_baldness
+				}
+			}
+			# End Warcraft
 		}
 	}
 

--- a/gfx/portraits/portrait_modifiers/wc_facial_markings.txt
+++ b/gfx/portraits/portrait_modifiers/wc_facial_markings.txt
@@ -1,5 +1,6 @@
 ﻿facial_markings = {
 	usage = both
+	selection_behavior = weighted_random
 	interface_position = 6
 
 	no_facial_markings = {
@@ -18,6 +19,10 @@
 				has_elunes_marks_trigger = yes
 				
 				NOT = { portrait_has_trait_trigger = { TRAIT = cynical } }
+			}
+			modifier = { # Tyrande shouldn't have any facepaint unless teldrasil burns
+				add = 100
+				is_tyrande_trigger = yes
 			}
 		}
 		

--- a/gfx/portraits/portrait_modifiers/wc_scripted_appearances.txt
+++ b/gfx/portraits/portrait_modifiers/wc_scripted_appearances.txt
@@ -1,6 +1,7 @@
 ﻿scripted_appearances = {
 	
 	usage = game
+	priority = 9
 	
 	old_lothar = {
 		dna_modifiers = {

--- a/gfx/portraits/portrait_modifiers/wc_scripted_headgear.txt
+++ b/gfx/portraits/portrait_modifiers/wc_scripted_headgear.txt
@@ -1,0 +1,52 @@
+﻿scripted_appearances = {
+
+    usage = game
+    priority = 9
+
+    western_high_nobility = {
+        dna_modifiers = {
+            accessory = {
+                mode = add
+                gene = headgear
+                template = western_high_nobility
+                range = { 0 1 } # For the randomness to work correctly
+            }
+        }
+        weight = {
+            base = 0
+            modifier = { # Medivh should wear this while he's still in karazhan
+                add = 100
+                is_medivh_trigger = yes
+                NOR = {
+                    is_travelling = yes
+                    is_in_army = yes
+                }
+                title:d_karazhan.holder ?= this
+            }
+            modifier = { # Arthas should wear this if he's heir of Lordaeron
+                add = 30
+                is_arthas_trigger = yes
+                age >= 12
+                NOR = {
+                    is_travelling = yes
+                    is_in_army = yes
+                }
+                exists = title:e_lordaeron.holder
+                is_heir_of = title:e_lordaeron.holder
+            }
+            modifier = { # Luc should wear this after he becomes ruler of the Lordaeron forces
+                add = 30
+                is_luc_trigger = yes
+                NOR = {
+                    is_travelling = yes
+                    is_in_army = yes
+                }
+                is_independent_ruler = yes
+            }
+        }
+
+        is_valid_custom = {
+            has_no_portrait_trigger = no
+        }
+    }
+}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fix characters with `no_baldness` gene balding
- Balding age is adjusted for lifespan
- Fix Medivh, Arthas, Luc, and Garithos headwear
- Tyrande no longer has facial markings by default
- Regenerated all changed bookmark portraits

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
