### PR TITLE
prevent lore characters from getting roasted

### DIFF
--- a/events/activities/feast_activity/murder_feast_events.txt
+++ b/events/activities/feast_activity/murder_feast_events.txt
@@ -248,7 +248,7 @@ feast_default.8001 = {
 			limit = { 
 				scope:honorary_guest = { OR = { 
 					is_ai = no 
-					has_character_modifer = important_lore_character
+					has_character_modifier = important_lore_character
 				} } 
 			}
 			scope:honorary_guest = { trigger_event = feast_default.8004 }
@@ -261,7 +261,7 @@ feast_default.8001 = {
 						any_entourage_character = {
 							OR = { 
 								is_ai = no 
-								has_character_modifer = important_lore_character
+								has_character_modifier = important_lore_character
 							}
 						}
 					}
@@ -274,7 +274,7 @@ feast_default.8001 = {
 						limit = {
 							OR = { 
 								is_ai = no 
-								has_character_modifer = important_lore_character
+								has_character_modifier = important_lore_character
 							}
 						}
 						trigger_event = feast_default.8004

--- a/events/activities/feast_activity/murder_feast_events.txt
+++ b/events/activities/feast_activity/murder_feast_events.txt
@@ -244,24 +244,38 @@ feast_default.8001 = {
 	option = {
 		name = feast_default.8001.a
 		if = {
-			limit = { scope:honorary_guest = { is_ai = no } }
+			# Warcraft - Give lore characters a chance to escape
+			limit = { 
+				scope:honorary_guest = { OR = { 
+					is_ai = no 
+					has_character_modifer = important_lore_character
+				} } 
+			}
 			scope:honorary_guest = { trigger_event = feast_default.8004 }
 		}
 		else_if = {
 			limit = {
 				scope:honorary_guest = {
 					current_travel_plan ?= {
+						# Warcraft - Give lore characters a chance to escape
 						any_entourage_character = {
-							is_ai = no #there's a player entourage member
+							OR = { 
+								is_ai = no 
+								has_character_modifer = important_lore_character
+							}
 						}
 					}
 				}
 			}
 			scope:honorary_guest = {
 				current_travel_plan = {
+					# Warcraft - Give lore characters a chance to escape
 					every_entourage_character = {
 						limit = {
-							is_ai = no #there's a player entourage member
+							OR = { 
+								is_ai = no 
+								has_character_modifer = important_lore_character
+							}
 						}
 						trigger_event = feast_default.8004
 					}
@@ -843,7 +857,12 @@ feast_default.8004 = {
 					multiplier = -3.5
 					min = -49
 				}
-				min = 5
+				# Warcraft - Lore important characters get an additional -80% chance to die, minum decreased to 1
+				modifier = {
+					is_imporant_lore_character = yes
+					factor = 0.2
+				}
+				min = 1
 				desc = feast_default.8004.a.tt.success
 				#no need for your own toast if you die
 				scope:activity = {
@@ -884,7 +903,6 @@ feast_default.8004 = {
 					multiplier = 3.5
 					min = -49
 				}
-				min = 5
 				desc = feast_default.8004.a.tt.failure
 				send_interface_toast = {
 					title = feast_default.8004.a.tt.failure

--- a/events/harm_events.txt
+++ b/events/harm_events.txt
@@ -6167,9 +6167,10 @@ harm.1051 = {
 				modifier = { add = harm_event_random_list_low_odd_failure_value }
 				# Warcraft - Lore important characters get an additional -90% chance to die
 				modifier = {
-					is_imporant_lore_character = yes
+					has_character_modifier = important_lore_character
 					factor = 0.1
 				}
+				min = 1
 				desc = harm.1051.a.tt.failure
 				send_interface_toast = {
 					type = event_toast_effect_bad

--- a/events/harm_events.txt
+++ b/events/harm_events.txt
@@ -6165,6 +6165,11 @@ harm.1051 = {
 			# You perish.
 			0 = {
 				modifier = { add = harm_event_random_list_low_odd_failure_value }
+				# Warcraft - Lore important characters get an additional -90% chance to die
+				modifier = {
+					is_imporant_lore_character = yes
+					factor = 0.1
+				}
 				desc = harm.1051.a.tt.failure
 				send_interface_toast = {
 					type = event_toast_effect_bad


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
Resolves https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth-2/issues/1532

## Changelog:
- Prevent Lore characters from dying in a fire as much

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- added a chance for lore characters to escape murder feasts like player characters can
- added an 80% stacking reduction to feast_default.8004 (murder feast) and decreased minimum to 1% chance
- added a 90% stacking reduction to harm.1051 and decreased minimum to 1% chance

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
