### PR TITLE
Resurrected Characters Skills Fix

### DIFF
--- a/common/culture/cultures/wc_dummy.txt
+++ b/common/culture/cultures/wc_dummy.txt
@@ -1,0 +1,24 @@
+﻿# This is used to give resurrected people a culture that gives
+# no bonuses via traditions or similar, to make their stats accurate
+# It is only used briefly when calculating their stats
+wc_dummy = {
+    color = rgb { 59 158 79 }
+
+    ethos = ethos_spiritual
+    heritage = heritage_draconic
+    language = language_draconic
+    martial_custom = martial_custom_equal
+    traditions = {
+    }
+
+    name_list = name_list_green_dragon
+
+    coa_gfx = { welsh_coa_gfx western_coa_gfx byzantine_group_coa_gfx }
+    building_gfx = { mediterranean_building_gfx }
+    clothing_gfx = { western_clothing_gfx }
+    unit_gfx = { western_unit_gfx }
+
+    ethnicities = {
+        100 = green_dragon_night_elven
+    }
+}

--- a/common/religion/religion_families/00_dummy.txt
+++ b/common/religion/religion_families/00_dummy.txt
@@ -1,0 +1,7 @@
+﻿# This is only used for the wc_dummy religion and faith. This is used to give resurrected people a religion that gives
+# no bonuses via holy sites or similar, to make their stats accurate
+rf_dummy = {
+    graphical_faith = "orthodox_gfx"
+    hostility_doctrine = order_hostility_doctrine
+    doctrine_background_icon = core_tenet_banner_christian.dds
+}

--- a/common/religion/religions/wc_dummy.txt
+++ b/common/religion/religions/wc_dummy.txt
@@ -1,0 +1,313 @@
+﻿# This is used to give resurrected people a religion that gives
+# no bonuses via holy sites or similar, to make their stats accurate
+# It is only used briefly when calculating their stats
+wc_dummy = {
+    family = rf_dummy
+    graphical_faith = pagan_gfx
+
+    doctrine = dragons_hostility_doctrine
+
+    #Main Group
+    doctrine = doctrine_temporal_head
+    doctrine = doctrine_gender_equal
+    doctrine = doctrine_pluralism_pluralistic
+    doctrine = doctrine_theocracy_lay_clergy
+
+    #Marriage
+    doctrine = doctrine_polygamy
+    doctrine = doctrine_divorce_allowed
+    doctrine = doctrine_bastardry_legitimization
+    doctrine = doctrine_consanguinity_unrestricted
+
+    #Crimes
+    doctrine = doctrine_homosexuality_shunned
+    doctrine = doctrine_adultery_men_shunned
+    doctrine = doctrine_adultery_women_shunned
+    doctrine = doctrine_kinslaying_close_kin_crime
+    doctrine = doctrine_deviancy_crime
+    doctrine = doctrine_witchcraft_crime
+
+    #Magic
+    doctrine = doctrine_light_magic_ignored
+    doctrine = doctrine_shadow_magic_crime
+    doctrine = doctrine_disorder_magic_crime
+    doctrine = doctrine_order_magic_approved
+    doctrine = doctrine_life_magic_ignored
+    doctrine = doctrine_death_magic_crime
+    doctrine = doctrine_elemental_fire_magic_accepted
+    doctrine = doctrine_elemental_water_magic_accepted
+    doctrine = doctrine_elemental_air_magic_accepted
+    doctrine = doctrine_elemental_earth_magic_accepted
+
+    #Clerical Functions
+    doctrine = doctrine_clerical_function_recruitment
+    doctrine = doctrine_clerical_gender_either
+    doctrine = doctrine_clerical_marriage_allowed
+    doctrine = doctrine_clerical_succession_temporal_appointment
+
+    #Allow pilgrimages
+    doctrine = doctrine_pilgrimage_encouraged
+
+    #Funeral tradition
+    doctrine = doctrine_funeral_sky_burial
+
+    doctrine = special_doctrine_is_mortal_faith
+
+    # Placeholder
+    traits = {
+        virtues = { generous compassionate calm }
+        sins = { greedy sadistic callous wrathful }
+    }
+
+    # Placeholder
+    reserved_male_names = {
+    }
+    reserved_female_names = {
+    }
+
+    custom_faith_icons = {
+        ## Warcraft
+        # Nightmare
+        wcrtd_nightmare_dragon_religion
+        # Infinite
+        wcrtd_infinite_dragon_religion
+        # Twilight
+        wcrtd_twilight_dragon_religion
+        # Generic
+        wcbb_sect_of_the_dragons
+    }
+
+    holy_order_names = {
+    }
+
+    holy_order_maa = {
+    }
+
+    localization = {
+        #HighGod
+        HighGodName = draconic_high_god_name # Aman'Thul
+        HighGodName2 = draconic_high_god_name_2
+        HighGodName3 = draconic_high_god_name_3
+        HighGodNamePossessive = draconic_high_god_name_possessive
+        HighGodNameSheHe = CHARACTER_SHEHE_HE
+        HighGodHerselfHimself = CHARACTER_HIMSELF
+        HighGodHerHis = CHARACTER_HERHIS_HIS
+        HighGodNameAlternate = draconic_high_god_alternate
+        HighGodNameAlternatePossessive = draconic_high_god_alternate_possessive
+
+        #Creator
+        CreatorName = draconic_creator_god_name # Eonar
+        CreatorNamePossessive = draconic_creator_god_name_possessive
+        CreatorSheHe = CHARACTER_SHEHE_SHE
+        CreatorHerHis = CHARACTER_HERHIS_HER
+        CreatorHerHim = CHARACTER_HERHIM_HER
+
+        #HealthGod
+        HealthGodName = draconic_health_god_name # Eonar
+        HealthGodNamePossessive = draconic_health_god_name_possessive
+        HealthGodSheHe = CHARACTER_SHEHE_SHE
+        HealthGodHerHis = CHARACTER_HERHIS_HER
+        HealthGodHerHim = CHARACTER_HERHIM_HER
+
+        #FertilityGod
+        FertilityGodName = draconic_fertility_god_name # Eonar
+        FertilityGodNamePossessive = draconic_fertility_god_name_possessive
+        FertilityGodSheHe = CHARACTER_SHEHE_SHE
+        FertilityGodHerHis = CHARACTER_HERHIS_HER
+        FertilityGodHerHim = CHARACTER_HERHIM_HER
+
+        #WealthGod
+        WealthGodName = draconic_wealth_god_name # Khaz'Goroth
+        WealthGodNamePossessive = draconic_wealth_god_name_possessive
+        WealthGodSheHe = CHARACTER_SHEHE_HE
+        WealthGodHerHis = CHARACTER_HERHIS_HIS
+        WealthGodHerHim = CHARACTER_HERHIM_HIM
+
+        #HouseholdGod
+        HouseholdGodName = draconic_household_god_name # Khaz'Goroth
+        HouseholdGodNamePossessive = draconic_household_god_name_possessive
+        HouseholdGodSheHe = CHARACTER_SHEHE_HE
+        HouseholdGodHerHis = CHARACTER_HERHIS_HIS
+        HouseholdGodHerHim = CHARACTER_HERHIM_HIM
+
+        #FateGod
+        FateGodName = draconic_fate_god_name # Aman'Thul
+        FateGodNamePossessive = draconic_fate_god_name_possessive
+        FateGodSheHe = CHARACTER_SHEHE_HE
+        FateGodHerHis = CHARACTER_HERHIS_HIS
+        FateGodHerHim = CHARACTER_HERHIM_HIM
+
+        #KnowledgeGod
+        KnowledgeGodName = draconic_knowledge_god_name # Norgannon
+        KnowledgeGodNamePossessive = draconic_knowledge_god_name_possessive
+        KnowledgeGodSheHe = CHARACTER_SHEHE_HE
+        KnowledgeGodHerHis = CHARACTER_HERHIS_HIS
+        KnowledgeGodHerHim = CHARACTER_HERHIM_HIM
+
+        #WarGod
+        WarGodName = draconic_war_god_name # Aggramar
+        WarGodNamePossessive = draconic_war_god_name_possessive
+        WarGodSheHe = CHARACTER_SHEHE_HE
+        WarGodHerHis = CHARACTER_HERHIS_HIS
+        WarGodHerHim = CHARACTER_HERHIM_HIM
+
+        #TricksterGod
+        TricksterGodName = draconic_trickster_god_name # Kil'jaeden
+        TricksterGodNamePossessive = draconic_trickster_god_name_possessive
+        TricksterGodSheHe = CHARACTER_SHEHE_HE
+        TricksterGodHerHis = CHARACTER_HERHIS_HIS
+        TricksterGodHerHim = CHARACTER_HERHIM_HIM
+
+        #NightGod
+        NightGodName = draconic_night_god_name # Elune
+        NightGodNamePossessive = draconic_night_god_name_possessive
+        NightGodSheHe = CHARACTER_SHEHE_SHE
+        NightGodHerHis = CHARACTER_HERHIS_HER
+        NightGodHerHim = CHARACTER_HERHIM_HER
+
+        #WaterGod
+        WaterGodName = draconic_water_god_name # Golganneth
+        WaterGodNamePossessive = draconic_water_god_name_possessive
+        WaterGodSheHe = CHARACTER_SHEHE_HE
+        WaterGodHerHis = CHARACTER_HERHIS_HIS
+        WaterGodHerHim = CHARACTER_HERHIM_HIM
+
+        PantheonTerm = religion_the_titans
+        PantheonTerm2 = religion_the_titans_2
+        PantheonTerm3 = religion_the_titans_3
+        PantheonTermHasHave = pantheon_term_have
+        GoodGodNames = {
+            #Titans
+            draconic_good_god_amanthul
+            draconic_good_god_eonar
+            draconic_good_god_norgannon
+            draconic_good_god_golganneth
+            draconic_good_god_khazgoroth
+            draconic_good_god_aggramar
+
+            #Other gods
+            draconic_good_god_elune
+        }
+
+        DevilName = draconic_devil_name
+        DevilNamePossessive = draconic_devil_name_possessive
+        DevilSheHe = CHARACTER_SHEHE_THEY
+        DevilHerHis = CHARACTER_HERHIS_THEIR
+        DevilHerselfHimself = CHARACTER_HERHIM_THEM
+        EvilGodNames = {
+            #Burning Legion
+            draconic_evil_god_burning_legion
+            draconic_evil_god_sargeras
+            draconic_evil_god_archimonde
+            draconic_evil_god_kiljaeden
+
+            #Eldritch
+            draconic_evil_god_the_old_gods
+            draconic_evil_god_the_void_lords
+            draconic_evil_god_cthun
+            draconic_evil_god_yoggsaron
+            draconic_evil_god_yshaarj
+            draconic_evil_god_nzoth
+        }
+
+        HouseOfWorship = draconic_house_of_worship
+        HouseOfWorship2 = draconic_house_of_worship_2
+        HouseOfWorship3 = draconic_house_of_worship_3
+        HouseOfWorshipPlural = draconic_house_of_worship_plural
+        ReligiousSymbol = draconic_religious_symbol
+        ReligiousSymbol2 = draconic_religious_symbol_2
+        ReligiousSymbol3 = draconic_religious_symbol_3
+        ReligiousText = draconic_religious_text
+        ReligiousText2 = draconic_religious_text_2
+        ReligiousText3 = draconic_religious_text_3
+        ReligiousHeadName = draconic_religious_head_title_male
+        ReligiousHeadNameFemale = draconic_religious_head_title_female
+        ReligiousHeadTitleName = draconic_religious_head_title_name
+        DevoteeMale = draconic_devotee_male
+        DevoteeMalePlural = draconic_devotee_male_plural
+        DevoteeFemale = draconic_devotee_female
+        DevoteeFemalePlural = draconic_devotee_female_plural
+        DevoteeNeuter = draconic_devotee_neuter
+        DevoteeNeuterPlural = draconic_devotee_neuter_plural
+        PriestMale = draconic_priest_male
+        PriestMalePlural = draconic_priest_male_plural
+        PriestFemale = draconic_priest_female
+        PriestFemalePlural = draconic_priest_female_plural
+        PriestNeuter = draconic_priest_male
+        PriestNeuterPlural = draconic_priest_male_plural
+        AltPriestTermPlural = draconic_priest_alternate_plural
+        BishopMale = draconic_bishop_male
+        BishopMalePlural = draconic_bishop_male_plural
+        BishopFemale = draconic_bishop_female
+        BishopFemalePlural = draconic_bishop_female_plural
+        BishopNeuter = draconic_bishop
+        BishopNeuterPlural = draconic_bishop_plural
+        DivineRealm = draconic_divine_realm
+        DivineRealm2 = draconic_divine_realm_2
+        DivineRealm3 = draconic_divine_realm_3
+        PositiveAfterLife = draconic_positive_afterlife
+        PositiveAfterLife2 = draconic_positive_afterlife_2
+        PositiveAfterLife3 = draconic_positive_afterlife_3
+        NegativeAfterLife = draconic_negative_afterlife
+        NegativeAfterLife2 = draconic_negative_afterlife_2
+        NegativeAfterLife3 = draconic_negative_afterlife_3
+        DeathDeityName = draconic_death_deity_name
+        DeathDeityNamePossessive = draconic_death_deity_name_possessive
+        DeathDeitySheHe = CHARACTER_SHEHE_IT
+        DeathDeityHerHis = CHARACTER_HERSHIS_ITS
+        DeathDeityHerHim = CHARACTER_HERHIM_IT
+        WitchGodName = draconic_witchgodname_the_old_gods
+        WitchGodNamePossessive = draconic_witchgodname_the_old_gods_possessive
+        WitchGodHerHis = CHARACTER_SHEHE_THEY
+        WitchGodSheHe = CHARACTER_HERHIS_THEIR
+        WitchGodHerHim = CHARACTER_HERHIM_THEM
+        WitchGodMistressMaster = mistress
+        WitchGodMotherFather = mother
+        WitchGodHerHis = CHARACTER_HERHIS_HER
+
+        GHWName = ghw_great_holy_war
+        GHWNamePlural = ghw_great_holy_wars
+    }
+
+    faiths = {
+        wc_dummy = {
+            color = rgb { 59 158 79 }
+            icon = wcrtd_green_dragon_religion
+
+            #Magic
+            doctrine = doctrine_order_magic_ignored
+            doctrine = doctrine_life_magic_approved
+
+            doctrine = tenet_sanctity_of_nature
+            doctrine = tenet_life_syncretism
+            doctrine = tenet_reincarnation
+
+            localization = {
+                #HighGod
+                HighGodName = yserism_high_god_name # Eonar
+                HighGodName2 = yserism_high_god_name_2
+                HighGodName3 = yserism_high_god_name_3
+                HighGodNamePossessive = yserism_high_god_name_possessive
+                HighGodNameSheHe = CHARACTER_SHEHE_SHE
+                HighGodHerselfHimself = CHARACTER_HERSELF
+                HighGodHerHis = CHARACTER_HERHIS_HER
+                HighGodNameAlternate = yserism_high_god_alternate
+                HighGodNameAlternatePossessive = yserism_high_god_alternate_possessive
+
+                #TricksterGod
+                TricksterGodName = yserism_trickster_god_name # N'Zoth because Emerald Nightmare
+                TricksterGodNamePossessive = yserism_trickster_god_name_possessive
+                TricksterGodSheHe = CHARACTER_SHEHE_HE
+                TricksterGodHerHis = CHARACTER_HERHIS_HIS
+                TricksterGodHerHim = CHARACTER_HERHIM_HIM
+
+                PositiveAfterLife = yserism_positive_afterlife
+                PositiveAfterLife2 = yserism_positive_afterlife_2
+                PositiveAfterLife3 = yserism_positive_afterlife_3
+                NegativeAfterLife = yserism_negative_afterlife
+                NegativeAfterLife2 = yserism_negative_afterlife_2
+                NegativeAfterLife3 = yserism_negative_afterlife_3
+            }
+        }
+    }
+}

--- a/common/scripted_effects/wc_other_effects.txt
+++ b/common/scripted_effects/wc_other_effects.txt
@@ -71,8 +71,8 @@ wc_resurrect_CHARACTER_with_STATUS_effect = {  # STATUS = [alive, undead, lich]
 			age = $CHARACTER$.age
 			gender = $CHARACTER$
 			location = root.location
-			faith = $CHARACTER$.faith
-			culture = $CHARACTER$.culture
+			faith = faith:wc_dummy
+			culture = culture:wc_dummy
 			random_traits = no
 			father = $CHARACTER$.father
 			mother = $CHARACTER$.mother
@@ -96,13 +96,15 @@ wc_resurrect_CHARACTER_with_STATUS_effect = {  # STATUS = [alive, undead, lich]
 		# Has to be done outside of after_creation, otherwise it bugs out
 		scope:resurrected_character ?= {
 			# Copy stats
-			# TODO: Doesn't account for holy site buffs (not possible?)
 			add_diplomacy_skill = 	{ subtract = diplomacy 		add = $CHARACTER$.diplomacy }
 			add_martial_skill = 	{ subtract = martial 		add = $CHARACTER$.martial }
 			add_stewardship_skill = { subtract = stewardship 	add = $CHARACTER$.stewardship }
 			add_intrigue_skill = 	{ subtract = intrigue 		add = $CHARACTER$.intrigue }
 			add_learning_skill = 	{ subtract = learning 		add = $CHARACTER$.learning }
 			add_prowess_skill = 	{ subtract = prowess 		add = $CHARACTER$.prowess }
+
+			set_character_faith = $CHARACTER$.faith
+			set_culture = $CHARACTER$.culture
 
 			wc_resurrection_options_$STATUS$_effect = yes
 			trigger_race_giving_no_gene_effect = yes

--- a/common/scripted_effects/wc_other_effects.txt
+++ b/common/scripted_effects/wc_other_effects.txt
@@ -81,8 +81,8 @@ wc_resurrect_CHARACTER_with_STATUS_effect = {  # STATUS = [alive, undead, lich]
 			save_scope_as = resurrected_character
 			after_creation = {
 				copy_traits = $CHARACTER$
+
 				copy_inheritable_appearance_from = $CHARACTER$
-				wc_resurrection_options_$STATUS$_effect = yes
 				change_first_name = { template_character = $CHARACTER$ }
 				if = {
 					limit = {
@@ -90,44 +90,53 @@ wc_resurrect_CHARACTER_with_STATUS_effect = {  # STATUS = [alive, undead, lich]
 					}
 					set_house = $CHARACTER$.house
 				}
-				trigger_race_giving_no_gene_effect = yes
-				$CHARACTER$ = {
-					purge_historical_character_effect = yes
+			}
+		}
 
-					every_child = {
-						even_if_dead = yes
-						if = {
-							limit = {
-								$CHARACTER$ = {
-									is_male = yes
-								}
-							}
+		# Has to be done outside of after_creation, otherwise it bugs out
+		scope:resurrected_character ?= {
+			# Copy stats
+			# TODO: Doesn't account for holy site buffs (not possible?)
+			add_diplomacy_skill = 	{ subtract = diplomacy 		add = $CHARACTER$.diplomacy }
+			add_martial_skill = 	{ subtract = martial 		add = $CHARACTER$.martial }
+			add_stewardship_skill = { subtract = stewardship 	add = $CHARACTER$.stewardship }
+			add_intrigue_skill = 	{ subtract = intrigue 		add = $CHARACTER$.intrigue }
+			add_learning_skill = 	{ subtract = learning 		add = $CHARACTER$.learning }
+			add_prowess_skill = 	{ subtract = prowess 		add = $CHARACTER$.prowess }
 
-							if = {
-								limit = {
-									exists = father
-									father = $CHARACTER$
-								}
+			wc_resurrection_options_$STATUS$_effect = yes
+			trigger_race_giving_no_gene_effect = yes
 
-								set_father = scope:resurrected_character
-							}
-							if = {
-								limit = {
-									exists = real_father
-									real_father = $CHARACTER$
-								}
+			# Set correct parents and children
+			$CHARACTER$ = {
+				purge_historical_character_effect = yes
 
-								set_real_father = scope:resurrected_character
-							}
+				every_child = {
+					even_if_dead = yes
+
+					if = {
+						limit = {
+							exists = father
+							father = $CHARACTER$
 						}
-						else_if = {
-							limit = {
-								exists = mother
-								mother = $CHARACTER$
-							}
 
-							set_mother = scope:resurrected_character
+						set_father = scope:resurrected_character
+					}
+					else_if = {
+						limit = {
+							exists = real_father
+							real_father = $CHARACTER$
 						}
+
+						set_real_father = scope:resurrected_character
+					}
+					else_if = {
+						limit = {
+							exists = mother
+							mother = $CHARACTER$
+						}
+
+						set_mother = scope:resurrected_character
 					}
 				}
 			}

--- a/localization/english/culture/wc_cultures_l_english.yml
+++ b/localization/english/culture/wc_cultures_l_english.yml
@@ -598,3 +598,7 @@
  northsea_prefix:0 "Northsea"
  skrog_prefix:0 "Skrog"
  makrura_prefix:0 "Makrura"
+
+ wc_dummy:0 "Error"
+ wc_dummy_collective_noun:0 "Error"
+ wc_dummy_prefix:0 "Error"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Resurrected characters will now have the same skills as they did prior to their death, instead of randomly assigned ones

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
