### PR TITLE
Fixes Seer Ixit

### DIFF
--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -1,4 +1,5 @@
-﻿# Empty scope
+﻿# Called from code after history generation
+# Empty scope
 on_game_start = {
 	events = {
 		fp1_scandinavian_adventurers.0004	# FP1 - Organise Norse adventurers.
@@ -444,7 +445,7 @@ on_game_start_after_lobby = {
 				if = { limit = { has_realm_law = crown_authority_0 } remove_realm_law = crown_authority_0 }
 			}
 		}
-
+	
 		### GAME RULE: VIEW ON SAME-SEX RELATIONS
 		if = {
 			limit = { has_game_rule = accepted_same_sex_relations }
@@ -1054,6 +1055,14 @@ on_game_start_after_lobby = {
 						is_landless_adventurer = yes
 					}
 					add_realm_law_skip_effects = camp_purpose_legitimists
+					if = {
+						limit = {
+							character:kilix_the_unraveler = {
+								NOT = { is_courtier_of = character:seer_ixit }
+							}
+						}
+						add_courtier = character:kilix_the_unraveler
+					}
 				}
 			}
 			## John J Keeshan
@@ -1430,36 +1439,6 @@ on_game_start_after_lobby = {
 					add_realm_law_skip_effects = camp_purpose_explorers
 				}
 			}
-			## Markus Wilder - patreon
-			character:310280 ?= {
-				if = {
-					limit = {
-						is_alive = yes
-						is_landless_adventurer = yes
-					}
-					add_realm_law_skip_effects = camp_purpose_mercenaries
-				}
-			}
-			## Nicholas - patreon
-			character:patron310686 ?= {
-				if = {
-					limit = {
-						is_alive = yes
-						is_landless_adventurer = yes
-					}
-					add_realm_law_skip_effects = camp_purpose_mercenaries
-				}
-			}
-			## Akasta - patreon
-			character:patron310689 ?= {
-				if = {
-					limit = {
-						is_alive = yes
-						is_landless_adventurer = yes
-					}
-					add_realm_law_skip_effects = camp_purpose_explorers
-				}
-			}
 
 			every_independent_ruler = {
 				limit = { is_landless_adventurer = yes }
@@ -1726,6 +1705,7 @@ on_game_start_after_lobby = {
 		# }
 		
 	}
+
 	events = {
 		game_rule.1000	#Autopopulate families.
 		# Warcraft

--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -1,5 +1,4 @@
-﻿# Called from code after history generation
-# Empty scope
+﻿# Empty scope
 on_game_start = {
 	events = {
 		fp1_scandinavian_adventurers.0004	# FP1 - Organise Norse adventurers.
@@ -445,7 +444,7 @@ on_game_start_after_lobby = {
 				if = { limit = { has_realm_law = crown_authority_0 } remove_realm_law = crown_authority_0 }
 			}
 		}
-	
+
 		### GAME RULE: VIEW ON SAME-SEX RELATIONS
 		if = {
 			limit = { has_game_rule = accepted_same_sex_relations }
@@ -542,17 +541,630 @@ on_game_start_after_lobby = {
 			}
 		}
 
+		if = {
+			limit = { has_multiple_players = no }
+			every_player = {
+				# Base Title
+				# if = {
+				# 	limit = {
+				# 		exists = character:7757
+				# 		this = character:7757
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_give_a_dog_a_bone_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:1128
+				# 		this = character:1128
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_wily_as_the_fox_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		OR = {
+				# 			AND = {
+				# 				exists = character:108501
+				# 				this = character:108501
+				# 			}
+				# 			AND = {
+				# 				exists = character:107500
+				# 				this = character:107500
+				# 			}
+				# 			AND = {
+				# 				exists = character:107501
+				# 				this = character:107501
+				# 			}
+				# 			AND = {
+				# 				exists = character:108500
+				# 				this = character:108500
+				# 			}
+				# 			AND = {
+				# 				exists = character:109500
+				# 				this = character:109500
+				# 			}
+				# 		}
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_sibling_rivalry_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		OR = {
+				# 			AND = {
+				# 				exists = character:163108
+				# 				this = character:163108
+				# 			}
+				# 			AND = {
+				# 				exists = character:163110
+				# 				this = character:163110
+				# 			}
+				# 			AND = {
+				# 				exists = character:163111
+				# 				this = character:163111
+				# 			}
+				# 			AND = {
+				# 				exists = character:163112
+				# 				this = character:163112
+				# 			}
+				# 			AND = {
+				# 				exists = character:163119
+				# 				this = character:163119
+				# 			}
+				# 		}
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_blood_eagle_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:6448
+				# 		this = character:6448
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_kings_to_the_seventh_generation_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:140
+				# 		this = character:140
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_norman_yoke_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:522
+				# 		this = character:522
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_royal_dignity_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:40605
+				# 		this = character:40605
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_land_of_the_rus_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:251187
+				# 		this = character:251187
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_mother_of_us_all_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		OR = {
+				# 			culture = { has_cultural_pillar = heritage_iberian }
+				# 			culture = culture:andalusian
+				# 		}
+				# 		has_religion = religion:christianity_religion
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_reconquista_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		culture = culture:irish
+				# 		capital_province = { geographical_region = custom_ireland }
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_the_emerald_isle_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		OR = {
+				# 			culture = culture:castilian
+				# 			culture = culture:basque
+				# 			culture = culture:portuguese
+				# 			culture = culture:catalan
+				# 			culture = culture:andalusian
+				# 			culture = culture:visigothic
+				# 			culture = culture:suebi
+				# 		}
+				# 		has_religion = religion:islam_religion
+				# 		capital_province = { geographical_region = world_europe_west_iberia }
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_al_andalus_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:159137
+				# 		this = character:159137
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_almost_there_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:109607
+				# 		this = character:109607
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_last_count_first_king_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# if = {
+				# 	limit = {
+				# 		exists = character:6878
+				# 		this = character:6878
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_going_places_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# FP1
+				## far_from_home_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse-cultured character.
+				# 		fp1_achievement_culture_plus_religion_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_far_from_home_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# ## miklagardariki_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse-cultured character.
+				# 		fp1_achievement_culture_plus_religion_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_miklagardariki_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## canute_the_greater_achievement
+				# add_achievement_global_variable_effect = {
+				# 	VARIABLE = started_canute_the_greater_achievement
+				# 	VALUE = yes
+				# }
+				## king_of_all_the_isles_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse-cultured character.
+				# 		fp1_achievement_culture_plus_religion_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_king_of_all_the_isles_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## faster_than_the_fox_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse-cultured character.
+				# 		fp1_achievement_culture_plus_religion_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_faster_than_the_fox_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## volva_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse-cultured character.
+				# 		fp1_achievement_culture_plus_religion_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_volva_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## saga_in_stone_achievement
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_saga_in_stone_achievement
+					VALUE = yes
+				}
+				## first_of_the_crusader_kings_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse-cultured character.
+				# 		fp1_achievement_culture_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_first_of_the_crusader_kings_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# ## vladimirs_second_choice_achievement
+				# if = {
+				# 	limit = {
+				# 		# Starting as a Norse pagan Norse or Rus-cultured character.
+				# 		fp1_achievement_culture_norse_or_rus_trigger = yes
+				# 		fp1_achievement_religious_norse_trigger = yes
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_vladimirs_second_choice_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## a_dangerous_business_achievement
+				# add_achievement_global_variable_effect = {
+				# 	VARIABLE = started_a_dangerous_business_achievement
+				# 	VALUE = yes
+				# }
+				# EP1
+				##1 Patronage
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_patronage_achievement
+					VALUE = yes
+				}
+				##2 Converging Paths
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_converging_paths_achievement
+					VALUE = yes
+				}
+				##3 Changing course
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_changing_course_achievement
+					VALUE = yes
+				}
+				##4 Hoarder
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_hoarder_achievement
+					VALUE = yes
+				}
+				##5 creme de la creme
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_creme_de_la_creme_achievement
+					VALUE = yes
+				}
+				##6 Give it back!
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_polyglot_achievement
+					VALUE = yes
+				}
+				##7 Inspirational
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_inspirational_achievement
+					VALUE = yes
+				}
+				##8 One of a Kind
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_one_of_a_kind_achievement
+						VALUE = yes
+				}
+				##9 True Tolerance
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_true_tolerance_achievement
+					VALUE = yes
+				}
+				##10 Delusions of Grandeur
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_delusions_of_grandeur_achievement_achievement
+					VALUE = yes
+				}
+				##11 Bod Chen Po
+				# if = {
+				# 	limit = {
+				# 		this.dynasty = dynasty:105800
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_bod_chen_po_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# ##12 Turkish Eagle
+				# if = {
+				# 	limit = {
+				# 		NOT = { this = character:3040 } # Not Alp Arslan
+				# 		house = house:house_seljuk # Seljuk
+				# 		game_start_date < 1067.1.1 # 1066 only, and no Seljuks in 867
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_turkish_eagle_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				##13 Rise of the Ghurids
+				# if = {
+				# 	limit = {
+				# 		has_title = title:d_ghur
+				# 		this.dynasty = dynasty:791 #Ghurid
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_rise_of_the_ghurids_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				# ##14 Brave and Bold
+				# if = {
+				# 	limit = {
+				# 		game_start_date < 868.1.1
+				# 		this.dynasty = dynasty:699 #Piast
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_brave_and_bold_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				##15 Lingua Franca
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_lingua_franca_achievement
+					VALUE = yes
+				}
+				##16 Beta Israel
+				# add_achievement_global_variable_effect = {
+				# 	VARIABLE = started_beta_israel_achievement
+				# 	VALUE = yes
+				# }
+				## 17 They belong in a museum!
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_they_belong_in_a_museum_achievement
+					VALUE = yes
+				}
+				##18 I made this!
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_i_made_this_achievement
+					VALUE = yes
+				}
+				##19 Nobody Comes to Fika!
+				# add_achievement_global_variable_effect = {
+				# 	VARIABLE = started_nobody_comes_to_fika_achievement
+				# 	VALUE = yes
+				# }
+				## 20 The True Royal Court
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_the_true_royal_court_achievement
+						VALUE = yes
+				}
+				# EP2
+				## 01. The Grandest Tour
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_the_grandest_tour_achievement
+					VALUE = yes
+				}
+				## 02. Your Eternal Reward
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_your_eternal_reward_achievement
+					VALUE = yes
+				}
+				## 03. Imperial March
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_imperial_march_achievement
+					VALUE = yes
+				}
+				## 04. Black Dinner
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_black_dinner_achievement
+					VALUE = yes
+				}
+				## 05. There and Back Again
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_there_and_back_again_achievement
+					VALUE = yes
+				}
+				## 06. The Very Best
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_the_very_best_achievement
+					VALUE = yes
+				}
+				## 07. Like No One Ever Was
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_like_no_one_ever_was_achievement
+					VALUE = yes
+				}
+				## 08. A Thousand and One Night
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_a_thousand_and_one_nights_achievement
+					VALUE = yes
+				}
+				## 09. A Knight's Tale
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_a_knights_tale_achievement
+					VALUE = yes
+				}
+				## 10. Hunting Accident
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_hunting_accident_achievement
+					VALUE = yes
+				}
+				## 11. Lions and Tigers and Bears, Oh My!
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_lions_and_tigers_and_bears_oh_my_achievement
+					VALUE = yes
+				}
+				## 12. Fly, my Pretty!
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_fly_my_pretty_achievement
+					VALUE = yes
+				}
+				## 13. Pathway to Heaven
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_pathway_to_heaven_achievement
+					VALUE = yes
+				}
+				## 14. Sir Lance-a-Lot
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_sir_lance_a_lot_achievement
+					VALUE = yes
+				}
+				## 15. I'm in my Element(s)
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_im_in_my_elements_achievement
+					VALUE = yes
+				}
+				## 16. Ahab
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_ahab_achievement
+					VALUE = yes
+				}
+				## 17. Little William Marshal
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_little_william_marshal_achievement
+					VALUE = 0
+				}
+				add_achievement_global_variable_effect = {
+					VARIABLE = little_william_marshal_achievement_tally
+					VALUE = 0
+				}
+				## 18. A True & Perfect Knight
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_a_true_and_perfect_knight_achievement
+					VALUE = yes
+				}
+				## 19. A.E.I.O.U & Me
+				# if = {
+				# 	limit = {
+				# 		# Etichonen, of whom the Hapsburgs are a cadet - we check dynasty rather than house so that an accidental cadet doesn't screw you.
+				# 		this.house ?= house:house_habsburg
+				# 	}
+				# 	add_achievement_global_variable_effect = {
+				# 		VARIABLE = started_a_e_i_o_u_and_me_achievement
+				# 		VALUE = yes
+				# 	}
+				# }
+				## 20. The Iron and Golden King
+				add_achievement_global_variable_effect = {
+					VARIABLE = started_the_iron_and_golden_king_achievement
+					VALUE = yes
+				}
+
+				### RULER DESIGNER ACHIEVEMENT BLOCKS ###
+				if = {
+					limit = {
+						num_virtuous_traits >= 3
+					}
+					add_achievement_flag_effect = { FLAG = rd_character_blocked_paragon_of_virtue_achievement_flag	}
+				}
+				if = {
+					limit = {
+						any_child = {
+							count >= 10
+							is_alive = yes
+						}
+					}
+					add_achievement_flag_effect = { FLAG = rd_character_blocked_the_succession_is_safe_achievement_flag }
+				}
+				if = {
+					limit = {
+						any_child = {
+							has_trait = inbred
+						}
+					}
+					add_achievement_flag_effect = { FLAG = rd_character_blocked_keeping_it_in_the_family_achievement_flag }
+				}
+				if = {
+					limit = {
+						highest_held_title_tier >= tier_empire
+						should_be_naked_trigger = yes
+					}
+					add_achievement_flag_effect = { FLAG = rd_character_blocked_the_emperors_new_clothes_achievement_flag }
+				}
+				# if = {
+				# 	limit = {
+				# 		is_from_ruler_designer = yes
+				# 		OR = {
+				# 			fp1_achievement_culture_norse_trigger = yes
+				# 			fp1_achievement_religious_norse_trigger = yes
+				# 		}
+				# 	}
+				# 	#add_to_global_unavailable_achievements_list_effect = { FLAG = flag:rd_character_blocked_far_from_home_achievement }
+				# 	#add_to_global_unavailable_achievements_list_effect = { FLAG = flag:rd_character_blocked_miklagardariki_achievement }
+				# 	#add_to_global_unavailable_achievements_list_effect = { FLAG = flag:rd_character_blocked_faster_than_the_fox_achievement }
+				# }
+				if = {
+					limit = {
+						any_ruler = {
+							is_from_ruler_designer = yes
+						}
+					}
+					#add_to_global_unavailable_achievements_list_effect = { FLAG = flag:rd_character_blocked_iberia_or_iberia_achievement }
+					#add_to_global_unavailable_achievements_list_effect = { FLAG = flag:rd_character_blocked_el_cid_achievement }
+					add_achievement_global_variable_effect = {
+						VARIABLE = any_ruler_designed_character_achievement
+						VALUE = yes
+					}
+				}
+			}
+		}
+
+		# ### ACHIEVEMENT (FP3): The Ummayad Strikes Back
+		# every_player = {
+		# 	if = {
+		# 		limit = {
+		# 			dynasty = character:73683.dynasty
+		# 			location = { geographical_region = world_europe_west_iberia }
+		# 		}
+		# 		set_global_variable = fp3_the_umma_strikes_back_achievement_tracker # Is not removed (sad!)
+		# 	}
+		# }
+		
+		### ACHIEVEMENT: FROM RAGS TO RICHES TO RAGS TO RICHES 
+		every_player = {
+			limit = { highest_held_title_tier = tier_county }
+			add_achievement_global_variable_effect = {
+				VARIABLE = achievement_rags_to_riches_to_rags_to_riches_valid
+				VALUE = yes
+			}
+		}
+
 		### ACHIEVEMENT: FROM RAGS TO RICHES
-		# Warcraft - Removing
-		# End of Warcraft
-
-		### ACHIEVEMENT (FP2): Holidaying in Iberia
-		# Warcraft - Removing
-		# End of Warcraft
-
-		### ACHIEVEMENT TRACKING FOR STARTING CHARACTERS
-		# Warcraft - Removing
-		# End of Warcraft
+		every_player = {
+			limit = { highest_held_title_tier = tier_county }
+			add_achievement_global_variable_effect = {
+				VARIABLE = achievement_rags_to_riches_valid
+				VALUE = yes
+			}
+		}
 	
 		title:k_goblin_bankers.holder = {
 			create_story = {
@@ -1439,6 +2051,36 @@ on_game_start_after_lobby = {
 					add_realm_law_skip_effects = camp_purpose_explorers
 				}
 			}
+			## Markus Wilder - patreon
+			character:310280 ?= {
+				if = {
+					limit = {
+						is_alive = yes
+						is_landless_adventurer = yes
+					}
+					add_realm_law_skip_effects = camp_purpose_mercenaries
+				}
+			}
+			## Nicholas - patreon
+			character:patron310686 ?= {
+				if = {
+					limit = {
+						is_alive = yes
+						is_landless_adventurer = yes
+					}
+					add_realm_law_skip_effects = camp_purpose_mercenaries
+				}
+			}
+			## Akasta - patreon
+			character:patron310689 ?= {
+				if = {
+					limit = {
+						is_alive = yes
+						is_landless_adventurer = yes
+					}
+					add_realm_law_skip_effects = camp_purpose_explorers
+				}
+			}
 
 			every_independent_ruler = {
 				limit = { is_landless_adventurer = yes }
@@ -1705,7 +2347,6 @@ on_game_start_after_lobby = {
 		# }
 		
 	}
-
 	events = {
 		game_rule.1000	#Autopopulate families.
 		# Warcraft

--- a/history/characters/76000_nerubian.txt
+++ b/history/characters/76000_nerubian.txt
@@ -1,4 +1,4 @@
-# # dynasty = 47000
+﻿# # dynasty = 47000
 # 76000={ #King Anub'Arak
 	# name=Anub'Arak
 	# dynasty = 47000

--- a/history/characters/76000_nerubian.txt
+++ b/history/characters/76000_nerubian.txt
@@ -1,4 +1,4 @@
-﻿# # dynasty = 47000
+# # dynasty = 47000
 # 76000={ #King Anub'Arak
 	# name=Anub'Arak
 	# dynasty = 47000
@@ -183,6 +183,9 @@ kilix_the_unraveler={
 	trait=education_stewardship_2 trait=vengeful
 	give_nickname=nick_the_unraveler
 	575.5.11={ birth=yes trait=creature_nerubian }
+	603.1.1={
+		employer = 32679 # Seer Ixit
+	}
 	777.4.22={ death=yes }
 }
 seer_ixit={
@@ -191,7 +194,13 @@ seer_ixit={
 	culture=nerubian religion=spider_philosophy
 	martial=6 diplomacy=6 stewardship=6 intrigue=5 learning=8
 	trait=education_learning_4 trait=vengeful trait=impatient trait=zealous
+	give_nickname=nick_the_seer
 	565.5.11={ birth=yes trait=creature_nerubian }
+	593.11.1={
+		effect = {
+			add_pressed_claim = title:k_enkilah
+		}
+	}
 	777.4.22={ death=yes }
 }
 


### PR DESCRIPTION
Fixes #1570.
Seer Ixit has an invalid camp purpose, because he's a legitimist with no claims. This gives him a claim to Enkilah, and a nickname. It also is supposed to give him Kilix the Unraveler as a camp follower, but for some reason he leaves immediately after unpausing.