### PR TITLE
Alterac changes and fixes

### DIFF
--- a/common/dynasties/34000_alteraci.txt
+++ b/common/dynasties/34000_alteraci.txt
@@ -4,7 +4,7 @@
 	motto = dynn_Perenolde_motto
 }
 # 34001 = {name = "dynn_Prestor" culture = alteraci} now a Perenolde branch
-34002 = {name = "dynn_Falconcrest" culture = alteraci}
+34002 = {name = "dynn_Falconcrest" culture = alteraci motto = dynn_Falconcrest_motto}
 34003 = {name = "Ravenholdt" culture = alteraci motto = Ravenholdt_motto}
 34004 = {name = "dynn_Mordis" culture = alteraci}
 34005 = {name = "dynn_Carlton" culture = alteraci}

--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -257,7 +257,7 @@
 	martial=7 diplomacy=7 stewardship=5 intrigue=4 learning=5
 	trait=education_martial_2 trait=lifestyle_reveler trait=content trait=zealous trait=diligent 
 	trait=lustful
-	537.1.15={ birth=yes trait=creature_human 
+	537.1.15={ birth=yes trait=creature_human
 		effect = {
 			add_trait_xp = {
 				trait = lifestyle_reveler
@@ -273,19 +273,7 @@
 		# trait=physical_lifestyle_endurance_2
 		# trait=physical_lifestyle_strength_2
 	}
-	600.1.1={
-		employer=58002
-		trait=gallowsbait
-	}
-	604.4.17={
-		effect = {
-			appoint_court_position = {
-				recipient = character:otto
-				court_position = bodyguard_court_position
-			}
-		}
-	}
-	608.6.10={ death=yes }
+	589.12.29={ death=yes } #died in the Second War
 }
 58014={
 	name=Gunthar
@@ -314,14 +302,43 @@
 	572.5.26={ birth=yes trait=creature_human }
 	603.8.24={ death=yes }
 }
-58016={
+58016={ #Lord Falconcrest in WoW
 	name=Kevin
 	dynasty=34002
 	culture=alteraci religion=holy_light
 	martial=6 diplomacy=4 stewardship=6 intrigue=8 learning=6
-	trait=education_intrigue_3 trait=ambitious  trait=patient  trait=deceitful
+	trait=education_intrigue_3 trait=ambitious trait=patient trait=deceitful
 	father=58013	#Willichar
-	580.12.3={ birth=yes trait=creature_human }
+	580.12.3={ #was but a boy when his family was deposed(RPG book. Dark Factions says that he's in his 30s while Lands of Conflict claims he's in his 40s)
+		birth=yes trait=creature_human
+	}
+	596.1.15={
+		trait=gallowsbait
+		effect={
+			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
+			set_variable = { name = wc_strength_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_1_physical_trait_value }
+			set_variable = { name = wc_dexterity_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }
+			add_trait_xp = {
+				trait = gallowsbait
+				track = bandit #is more familiar with the ways of a bandit than a courtier
+				value = 25
+			}
+		}
+		# trait=physical_lifestyle_endurance_2
+		# trait=physical_lifestyle_strength_1
+		# trait=physical_lifestyle_dexterity_2
+	}
+	600.1.1={
+		employer=58002
+	}
+	604.4.17={
+		effect = {
+			appoint_court_position = {
+				recipient = character:otto
+				court_position = bodyguard_court_position
+			}
+		}
+	}
 	608.2.26={ death=yes }
 }
 #dynasty=34003
@@ -2328,7 +2345,7 @@ otto={ #Falconcrest's bodyguard
 	trait=education_martial_1 trait=education_martial_prowess_2 trait=stubborn trait=brave trait=paranoid trait=physique_good_1
 	561.4.24={ birth=yes }
 	604.4.17={
-		employer = 58013 #Falconcrest
+		employer = 58016 #Lord Falconcrest
 		trait=gallowsbait
 	}
 	620.12.8={ death=yes }
@@ -2500,7 +2517,7 @@ jailor_eston={ #found in Durnholde Keep in the Hillsbrad Foothills
 		employer=58002
 	}
 	604.4.17={
-		employer=58013 #Falconcrest
+		employer=58016 #Lord Falconcrest
 	}
 	608.1.14={
 		death = {
@@ -2519,7 +2536,7 @@ jailor_marlgen={ #found in Durnholde Keep in the Hillsbrad Foothills
 		employer=58002
 	}
 	604.4.17={
-		employer=58013 #Falconcrest
+		employer=58016 #Lord Falconcrest
 	}
 	608.1.14={
 		death = {
@@ -2631,7 +2648,7 @@ darbel_montrose={ #found roaming with a minion in Stromgarde Keep in the Arathi 
 		effect = { make_character_crypto_religionist_effect = { CRYPTO_RELIGION = faith:orcish_fel } }
 	}
 	604.4.17={
-		employer=58013 #Falconcrest
+		employer=58016 #Lord Falconcrest
 	}
 	616.7.11={ death=yes }
 }

--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -81,6 +81,13 @@
 		add_pressed_claim=title:k_alterac
 		add_pressed_claim=title:c_alterac
 		trait=gallowsbait
+		effect={
+			add_trait_xp = {
+				trait = gallowsbait
+				track = bandit
+				value = 20
+			}
+		}
 	}
 	608.1.8={ 
 		death = {
@@ -309,10 +316,10 @@
 	martial=6 diplomacy=4 stewardship=6 intrigue=8 learning=6
 	trait=education_intrigue_3 trait=ambitious trait=patient trait=deceitful
 	father=58013	#Willichar
-	580.12.3={ #was but a boy when his family was deposed(RPG book. Dark Factions says that he's in his 30s while Lands of Conflict claims he's in his 40s)
+	579.12.3={ #was but a boy when his family was deposed(RPG book. Dark Factions says that he's in his 30s while Lands of Conflict claims he's in his 40s)
 		birth=yes trait=creature_human
 	}
-	596.1.15={
+	595.1.15={
 		trait=gallowsbait
 		effect={
 			set_variable = { name = wc_endurance_physical_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_2_physical_trait_value }

--- a/history/titles/00_k_alterac.txt
+++ b/history/titles/00_k_alterac.txt
@@ -88,8 +88,11 @@ c_headland = {
 	1.1.1={
 		liege=k_alterac
 	}
-	573.1.1={
+	553.1.1={
 		holder = 58013
+	}
+	589.12.29={
+		holder = 58016 #Lord Falconcrest
 	}
 	600.1.1={
 		holder = 58002 #Aliden Perenolde

--- a/history/titles/00_k_hillsbrad.txt
+++ b/history/titles/00_k_hillsbrad.txt
@@ -121,7 +121,7 @@ c_durnholde = {
 		liege = 0
 	}
 	604.4.17={
-		holder=58013
+		holder=58016 #Lord Falconcrest
 		liege=d_syndicate
 	}
 }
@@ -154,7 +154,7 @@ c_eastpoint = {
 	490.8.12={holder=53059} #Reginhard[32003]
 	573.1.1={holder=53007} #Rainald[32003]
 	604.4.17={
-		holder=58013
+		holder=58016 #Lord Falconcrest
 		liege=d_syndicate
 	}
 }

--- a/history/titles/00_k_stromgarde.txt
+++ b/history/titles/00_k_stromgarde.txt
@@ -205,7 +205,7 @@ c_northreach = {
 	570.1.1={holder=38005} #
 	583.1.1={holder=310090} #Magnus[patron]
 	604.9.15={
-		holder=58013
+		holder=58016 #Lord Falconcrest
 		liege=d_syndicate
 	}
 }
@@ -229,7 +229,7 @@ c_kilcliff = {
 		holder=38014
 	}
 	604.9.15={
-		holder=58013
+		holder=58016 #Lord Falconcrest
 		liege=d_syndicate
 	}
 }

--- a/localization/english/wc_mottos_l_english.yml
+++ b/localization/english/wc_mottos_l_english.yml
@@ -16,9 +16,10 @@
  dynn_Garithos_motto:0 "Humanity Will Rise Again"
 
  ### Alteraci
- dynn_Perenolde_motto:0 "The Falcon Rises Still"
+ dynn_Perenolde_motto:0 "Alterac Stands"
  dynn_Blackmoore_motto:0 "Never Forget Home"
  Ravenholdt_motto:0 "The Shadows Call"
+ dynn_Falconcrest_motto:0 "The Falcon Rises Still"
  Bloodhill_motto:0 "Take Everything"
 
  ### Orcs ###


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Made Willichar Falconcrest die shortly after the Second War. The titles he's supposed to have are now held by his son Kevin.
- Gave Willichar Falconcrest's attributes such as gallowsbait and his bodyguard Otto to his son Kevin Falconcrest since he's the Falconcrest who's supposed to be in WoW.
- Characters who are supposed to be [Lord Falconcrest](https://warcraft.wiki.gg/wiki/Lord_Falconcrest)'s underlings now have Kevin as an employer instead of Willichar.
- Renamed the Perenolde motto to "Alterac Stands".
- Perenolde's old motto, "The Falcon Rises Still" is given to the Falconcrest dynasty.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added this thing.
- Changed that thing.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
