### PR TITLE
Peon Leader Hotfix

### DIFF
--- a/common/traits/00_traits.txt
+++ b/common/traits/00_traits.txt
@@ -9668,6 +9668,10 @@ peasant_leader = {
 	icon = {
 		first_valid = {
 			triggered_desc = {
+				trigger = { NOT = { exists = this } }
+				desc = "peasant_leader.dds"
+			}
+			triggered_desc = {
 				trigger = { culture = { has_cultural_pillar = heritage_orcish } }
 				desc = "peon_leader.dds"
 			}
@@ -9679,6 +9683,10 @@ peasant_leader = {
 	# Warcraft
 	name = {
 		first_valid = {
+			triggered_desc = {
+				trigger = { NOT = { exists = this } }
+				desc = trait_peasant_leader
+			}
 			triggered_desc = {
 				trigger = { culture = { has_cultural_pillar = heritage_orcish } }
 				desc = trait_peon_leader


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Removed this error
```
[00:18:26][E][jomini_script_system.cpp:284]: Script system error!
  Error: culture trigger [ Wrong scope for trigger: none, expected character, landed_title, province ]
  Script location: file: common/traits/00_traits.txt line: 9683 (peasant_leader)
```

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Open the game
- Check if error.logs is empty about this error
- Check if the trait is still flavorized for orcs, but stay the same for other