### PR TITLE
Fix/Seize Realm Schemes for Evil Governments

### DIFF
--- a/common/governments/wc_government_types.txt
+++ b/common/governments/wc_government_types.txt
@@ -36,7 +36,6 @@
 	flag = government_dark_frenzy_from_conversions
 	flag = government_resurrect_knights
 	flag = government_offer_vassalization_turns_undead
-	flag = government_is_necro
 	
 	color = hsv{ 0.55 1 0.4 }
 }
@@ -75,7 +74,6 @@ demonic_government = {
 	flag = government_dark_frenzy_from_executions
 	flag = government_dark_frenzy_from_torturing
 	flag = government_get_demon_knight
-	flag = government_is_demonic
 	
 	color = hsv{ 0.3 1 1 }
 }
@@ -115,7 +113,6 @@ eldritch_government = {
 	flag = government_dark_frenzy_from_mental_breaks
 	flag = government_mental_breaks_cant_kill
 	flag = government_get_void_creatures
-	flag = government_is_eldritch
 	
 	color = hsv{ 0.7 0.7 0.5 }
 }

--- a/common/governments/wc_government_types.txt
+++ b/common/governments/wc_government_types.txt
@@ -36,6 +36,7 @@
 	flag = government_dark_frenzy_from_conversions
 	flag = government_resurrect_knights
 	flag = government_offer_vassalization_turns_undead
+	flag = government_is_necro
 	
 	color = hsv{ 0.55 1 0.4 }
 }
@@ -74,6 +75,7 @@ demonic_government = {
 	flag = government_dark_frenzy_from_executions
 	flag = government_dark_frenzy_from_torturing
 	flag = government_get_demon_knight
+	flag = government_is_demonic
 	
 	color = hsv{ 0.3 1 1 }
 }
@@ -113,6 +115,7 @@ eldritch_government = {
 	flag = government_dark_frenzy_from_mental_breaks
 	flag = government_mental_breaks_cant_kill
 	flag = government_get_void_creatures
+	flag = government_is_eldritch
 	
 	color = hsv{ 0.7 0.7 0.5 }
 }

--- a/common/schemes/scheme_types/seize_realm_scheme.txt
+++ b/common/schemes/scheme_types/seize_realm_scheme.txt
@@ -45,12 +45,8 @@
 			custom_tooltip = {
 				text = seize_realm_valid_government_tt
 				OR = {
-					government_has_flag = government_is_feudal
-					government_has_flag = government_is_clan
 					government_has_flag = government_is_tribal
-					government_has_flag = government_is_necro
-					government_has_flag = government_is_demonic
-					government_has_flag = government_is_eldritch
+					government_has_flag = government_is_monarchy
 				}
 			}
 		}
@@ -82,12 +78,8 @@
 			custom_tooltip = {
 				text = seize_realm_valid_government_tt
 				OR = {
-					government_has_flag = government_is_feudal
-					government_has_flag = government_is_clan
 					government_has_flag = government_is_tribal
-					government_has_flag = government_is_necro
-					government_has_flag = government_is_demonic
-					government_has_flag = government_is_eldritch
+					government_has_flag = government_is_monarchy
 				}
 			}
 		}

--- a/common/schemes/scheme_types/seize_realm_scheme.txt
+++ b/common/schemes/scheme_types/seize_realm_scheme.txt
@@ -48,6 +48,9 @@
 					government_has_flag = government_is_feudal
 					government_has_flag = government_is_clan
 					government_has_flag = government_is_tribal
+					government_has_flag = government_is_necro
+					government_has_flag = government_is_demonic
+					government_has_flag = government_is_eldritch
 				}
 			}
 		}
@@ -82,6 +85,9 @@
 					government_has_flag = government_is_feudal
 					government_has_flag = government_is_clan
 					government_has_flag = government_is_tribal
+					government_has_flag = government_is_necro
+					government_has_flag = government_is_demonic
+					government_has_flag = government_is_eldritch
 				}
 			}
 		}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Adventurers will now be able to use "Seize Realm Scheme" against Landed characters with Necro, Demonic and Eldritch Governments.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Only changed the wc_government_types and seize_realm_scheme

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Open the game in debug mode and play as an adventurer. (You need to be inside the realm of the target character to be able to start this scheme.)
