### PR TITLE
[FIX] harm reduction

### DIFF
--- a/common/on_action/health_on_actions.txt
+++ b/common/on_action/health_on_actions.txt
@@ -20,19 +20,19 @@ yearly_health_pulse = { #Fired from the birthday pulse
 		## Rare but not never-seen on reduced values.
 		## Increased without being ludicrous on high values.
 		### Reduced down drastically per community feedback.
-		10000 = 0
-		20000 = harm.9501	# Nothingness event.
+		600 = 0
 		
 		#Infirm 
-		1000 = health.7000	# Become infirm
-		1000 = health.7100	# Become depressed while infirm
-		2000 = harm.0001		# Becoming incapable due to age: culmination.
-		2000 = harm.0002		# Becoming incapable due to age: mental problems.
-		2000 = harm.0003		# Becoming incapable due to age: physical problems.
+		20 = health.7000	# Become infirm
+		20 = health.7100	# Become depressed while infirm
+		40 = harm.0001		# Becoming incapable due to age: culmination.
+		40 = harm.0002		# Becoming incapable due to age: mental problems.
+		40 = harm.0003		# Becoming incapable due to age: physical problems.
 
 		# Random death & incapability
 		15 = harm.9501		# Try to fire a harm event.
 	}
+	
 	# Warcraft - Menopause / Andropause
 	events = {
 		delay = { days = { 10 180 } }

--- a/common/script_values/10_health_values.txt
+++ b/common/script_values/10_health_values.txt
@@ -768,14 +768,14 @@ harm_event_random_list_medium_odd_success_value = {
 	value = 60
 	if = { 
 		limit = { culture = { has_cultural_parameter = elder_culture } }
-		add = 10
+		add = 13
 	}
 }
 harm_event_random_list_medium_odd_failure_value = {
 	value = 40
 	if = { 
 		limit = { culture = { has_cultural_parameter = elder_culture } }
-		subtract = 10
+		subtract = 13
 	}
 }
 harm_event_random_list_high_odd_success_value = {

--- a/common/scripted_effects/20_health_effects.txt
+++ b/common/scripted_effects/20_health_effects.txt
@@ -1074,7 +1074,12 @@ increase_wounds_no_death_effect = {
 	}
 
 	if = { #Wounds from treatments give no infection and no additional treatment
-		limit = { NOT = { scope:treatment_type = flag:treatment } }
+		limit = { 
+			NOR = { 
+				scope:treatment_type = flag:treatment 
+				scope:treatment_type = flag:harm_reduction
+			} 
+		}
 
 		#CHANCE OF INFECTION
 		hidden_effect = {
@@ -4096,8 +4101,14 @@ upgrade_infirm_to_incapable_effect = {
 			remove_trait = infirm
 		}
 	}
-	# And add in capable.
-	add_trait = incapable
-	# Logging.
-	log_harm_event_incapability_as_variable_effect = yes
+	# Warcraft - add incapable ONLY IF your character is not lore important; otherwise just wound.
+	if = { 
+		limit = { has_character_modifier = important_lore_character }
+		increase_wounds_no_death_effect = { REASON = harm_reduction }
+	}
+	else  = { 
+		add_trait = incapable 
+		# Logging.
+		log_harm_event_incapability_as_variable_effect = yes
+	}
 }


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed `yearly_health_pulse` in `00_health_on_actions.txt` to be in line with vanilla.
- Bumped mitigation by 30% for LL3+ characters in the medium difficulty check for harm events in order to bring it in line with other mitigations.
- Made it so that lore important characters cannot be made incapable by harm events. 
- 
<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- run mod in observer mode, checking at 5, 10, and 20 years after start to ascertain that number of incapacitated characters doesn't exceed 20