### PR TITLE
Fix/code/repair undead scourge

### DIFF
--- a/common/epidemics/_epidemics.info
+++ b/common/epidemics/_epidemics.info
@@ -1,0 +1,159 @@
+#TESTING: Use spawn_epidemic smallpox 2595 apocalyptic to spawn an epidemic
+
+<key> = {
+	trait = <trait_key> # What trait is tied to this disease
+
+	color = <color> # What color this epidemic has on the map: takes color names defined in the script colors file, RGB, HSV, HSV360 and HEX
+	# color = red // color = { r g b } // color = hex { your_hex }
+
+	# Name of the epidemic
+	# defaults to epidemic_key
+	# root = the epidemic being created
+	name = {
+		<dynamic_description>
+	}
+
+	# Multiplier used against intensity level for how important an epidemic is 
+	# Used for picking which to show on the map
+	priority = <value>
+
+	# Data passed to the shader
+	shader_data = {
+		strength = 0-1 # Strength of the disease, unsigned normalized float
+		edge_fade = 0-1 # Edge fade out, unsigned normalized float
+		tile_multiplier = 0-1 # Multiplier for the tile wrapping
+		texture_index = 0 # Which tile texture in the shader to use
+		channel = red/green/blue/alpha # Which color channel to use in the texture
+	}
+
+	# Can a character be infected with this epidemic
+	# root = potential character to infect
+	# scope:epidemic = the epidemic
+	can_infect_character = {
+		<triggers>
+	}
+
+	# Monthly chance for an epidemic to infect a character in the province, ran once per character
+	# % from 0-100 inclusive
+	# root = potential character to infect
+	# scope:epidemic = the epidemic
+	character_infection_chance = {
+		<script value>
+	}
+
+	# Effect run when a character is infected with this epidemic
+	# root = character being infected
+	# scope:epidemic = the epidemic
+	on_character_infected = {
+		<effects>
+	}
+
+	# Effect run when a province is infected with this epidemic
+	# root = province being infected
+	# scope:epidemic = the epidemic
+	on_province_infected = {
+		<effects>
+	}
+
+	# Effect run when a province recovers from this epidemic
+	# root = province being infected
+	# scope:epidemic = the epidemic
+	on_province_recovered = {
+		<effects>
+	}
+
+	# Effect run when a province spawns an outbreak of this epidemic
+	# root = the epidemic
+	on_start = {
+		<effects>
+	}
+
+	# Effect run on rulers of the provinces affected by the epidemic on monthly 
+	# tick.
+	# root = the ruler being affected
+	# scope:epidemic = the epidemic
+	on_monthly = {
+		<effects>
+	}
+
+	# Effect run when an epidemic of this type ends
+	# root = the epidemic
+	on_end = {
+		<effects>
+	}
+
+	# Every province has an infection level from 0-100, the highest level there they are above the threshold of
+	# will have its modifiers applied
+	infection_levels = {
+		# Left hand side value can reference a named script value that has a constant value ie: no formulas
+		<value> = {
+			# Modifier applied to any province infected
+			province_modifier = {
+				<modifier>
+			}
+
+			# Modifier applied to the county if its county capital province is infected
+			county_modifier = {
+				<modifier>
+			}
+
+			# Modifier applied to every ruler that has this province as a part of their de facto realm hierarchy
+			# This means its effects will be stacked on a ruler for every infected province
+			realm_modifier = {
+				<modifier>
+			}
+		}
+	}
+
+	outbreak_intensities = {
+		# Intensity levels are minor, major and apocalytpic, each can be read in separately
+		# Higher intensity levels are kept when neighboring epidemics merge.
+
+		minor = {
+			# Should an outbreak of this intensity be considered a global event that notifies the player regardless
+			# of their proximity to the outbreak
+			# Defaults to no
+			global_notification = yes/no
+
+			# Chance for an outbreak of this intensity to spawn on a province per year
+			# % from 0-100 inclusive
+			# root = potential province
+			# scope:epidemic_type = this epidemic type
+			outbreak_chance = {
+				<script value>
+			}
+
+			# Chance for an epidemic of this intensity to spread to an adjacent province per month
+			# % from 0-100 inclusive
+			# root = potential province
+			# scope:epidemic = the epidemic
+			spread_chance = {
+				<script value>
+			}
+
+			# Maximum number of provinces an epidemic of this intensity can infect
+			max_provinces = <script_value>
+
+			# How long an infection in a province lasts for once it hits max infection
+			# root = infected province
+			# scope:epidemic = the epidemic
+			infection_duration = {
+				<scripted_duration>
+			}
+
+			# How many days it will take for a province to hit max infection
+			# root = infected province
+			# scope:epidemic = the epidemic
+			infection_progress_duration = {
+				<scripted_duration>
+			}
+
+			# How many days it will take for a province to recover from max infection after infection_duration has elapsed
+			# root = infected province
+			# scope:epidemic = the epidemic
+			infection_recovery_duration = {
+				<scripted_duration>
+			}
+		}
+	}
+}

--- a/common/epidemics/wc_epidemics.txt
+++ b/common/epidemics/wc_epidemics.txt
@@ -16,10 +16,6 @@
 	}
 	
 	on_start = {
-		set_global_variable = {
-			name = undead_scourge
-			value = root
-		}
 		if = {
 			limit = {
 				outbreak_province = {
@@ -44,7 +40,6 @@
 			remove_global_variable = scourge_of_lordaeron
 			set_global_variable = scourge_of_lordaeron_has_happened
 		}
-		remove_global_variable = undead_scourge
 	}
 	
 	on_monthly = {

--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -1984,6 +1984,6 @@ on_game_start_after_lobby = {
 
 		# Warcraft
 		wc_horde_invasion.0001 #Starts the Horde Invasion
-		WCCSC.0001 #Starts the Scourge events
+		#WCCSC.0001 #Starts the Scourge events
 	}
 }

--- a/common/scripted_effects/wc_scourge_invasion_effects.txt
+++ b/common/scripted_effects/wc_scourge_invasion_effects.txt
@@ -9,21 +9,12 @@
 	spawn_scourge_troops_effect = yes
 	spawn_scourge_troops_effect = yes
 	spawn_scourge_troops_effect = yes
-}
-scourge_603_pack_effect = {
-	add_gold = monumental_gold_max_value
-	add_prestige = monumental_prestige_gain
-	add_piety = massive_piety_gain
-	
-	add_dread = 100
-	
-	spawn_scourge_troops_effect = yes
-	spawn_scourge_troops_effect = yes
 	if = { 
 		limit = { NOT = { any_owned_story = story_scourge_invasion } }
 		create_story = story_scourge_invasion
 	}
 }
+
 spawn_scourge_troops_effect = {
 	if = {
 		limit = { exists = capital_province }
@@ -51,6 +42,7 @@ spawn_scourge_troops_effect = {
 		}
 	}
 }
+
 try_to_set_scourge_story_owner = {
 	if = {
 		limit = {
@@ -67,6 +59,7 @@ try_to_set_scourge_story_owner = {
 		end_scourge_effect = yes
 	}
 }
+
 scourge_offer_vassalization_effect = {
 	save_scope_as = actor
 	save_scope_value_as = {

--- a/common/scripted_effects/wc_scourge_invasion_effects.txt
+++ b/common/scripted_effects/wc_scourge_invasion_effects.txt
@@ -19,8 +19,10 @@ scourge_603_pack_effect = {
 	
 	spawn_scourge_troops_effect = yes
 	spawn_scourge_troops_effect = yes
-	
-	create_story = story_scourge_invasion
+	if = { 
+		limit = { NOT = { any_owned_story = story_scourge_invasion } }
+		create_story = story_scourge_invasion
+	}
 }
 spawn_scourge_troops_effect = {
 	if = {

--- a/common/scripted_triggers/wc_draenor_triggers.txt
+++ b/common/scripted_triggers/wc_draenor_triggers.txt
@@ -1,6 +1,7 @@
 ﻿can_destroy_dark_portal_trigger = {
 	has_draenor_culture_trigger = no
 	draenor_faith_trigger = no
+	NOT = { is_target_in_global_variable_list = { name = unavailable_unique_events target = flag:beyond_dark_portal } }
 	
 	dark_portal_is_opened_trigger = yes
 }

--- a/common/story_cycles/wc_story_cycle_scourge_invasion.txt
+++ b/common/story_cycles/wc_story_cycle_scourge_invasion.txt
@@ -7,7 +7,10 @@
 		remove_global_variable = wc_scourge_can_spawn
 		
 		story_owner = {
-			trigger_event = WCCSC.3
+			trigger_event =  { 
+				id = WCCSC.3
+				days = 3
+			}
 		}
 		
 		# Timeline setup

--- a/events/story_cycles/wc_story_cycle_scourge_invasion_events.txt
+++ b/events/story_cycles/wc_story_cycle_scourge_invasion_events.txt
@@ -12,6 +12,8 @@ WCCSC.01 = {
 	hidden = yes
 
 	immediate = {
+		debug_log = "The Scourge has appeared!"
+		debug_log_date = yes
 		if = {
 			limit = {
 				character:10014 = { 
@@ -30,6 +32,7 @@ WCCSC.01 = {
 				set_culture = culture:scourge
 				set_character_faith = faith:death_god
 				save_scope_as = nerzhul
+				create_story = story_scourge_invasion
 			}
 		}
 		else = {
@@ -39,6 +42,9 @@ WCCSC.01 = {
 				template = lich_nerzhul_character_template
 				
 				name = "Ner'zhul"
+				after_creation = { 
+					create_story = story_scourge_invasion
+				}
 			}
 		}
 		scope:nerzhul = {
@@ -81,8 +87,6 @@ WCCSC.01 = {
 				limit = { get_news_from_region_trigger = { REGION = world_northrend } }
 				trigger_event = WCCSC.5
 			}
-			
-			create_story = story_scourge_invasion
 		}
 	}
 }
@@ -117,13 +121,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = tichondrius_character_template
 				
 				name = "Tichondrius"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -137,13 +142,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = varimathras_character_template
 				
 				name = "Varimathras"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -157,13 +163,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = mephistroth_character_template
 				
 				name = "Mephistroth"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -177,13 +184,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = anetheron_character_template
 				
 				name = "Anetheron"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -197,13 +205,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = balnazzar_character_template
 				
 				name = "Balnazzar"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -217,13 +226,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = detheroc_character_template
 				
 				name = "Detheroc"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -237,13 +247,14 @@ WCCSC.3 = {
 		}
 		else = {
 			create_character = {
-				employer = scope:nerzhul
+				location = scope:nerzhul.location
 				template = malganis_character_template
 				
 				name = "Mal'Ganis"
 				
 				after_creation = {
 					scope:story = { add_to_variable_list = { name = nerzhul_jailors target = prev } }
+					set_employer = scope:nerzhul
 				}
 			}
 		}
@@ -354,7 +365,7 @@ WCCSC.20 = {
 	title = WCCSC_15_TITLE
 	desc = WCCSC_20_DESC
 	theme = war
-	orphan = yes #remove it if you return the event
+	# orphan = yes #remove it if you return the event
 	
 	override_background = {
 		reference = wc_background_northrend
@@ -448,33 +459,33 @@ WCCSC.30 = {
 		death = { death_reason = death_suicide }
 	}
 }
-WCCSC.0001 = {
-	scope = none
-	hidden = yes
+# WCCSC.0001 = {
+# 	scope = none
+# 	hidden = yes
 
-	trigger = {
-		current_date >= 603.1.1
-		exists = title:e_scourge
-	}
+# 	trigger = {
+# 		current_date >= 603.1.1
+# 		exists = title:e_scourge
+# 	}
 
-	immediate = {
-		debug_log = "The Scourge has appeared!"
-		debug_log_date = yes
+# 	immediate = {
+# 		debug_log = "The Scourge has appeared!"
+# 		debug_log_date = yes
 
-		every_ruler = {
-			limit = {
-				NOR = { 
-					this = title:e_scourge.holder
-					is_vassal_or_below_of = title:e_scourge.holder
-				}
-				OR = {
-					location = {
-						geographical_region = world_northrend
-						geographical_region = world_eastern_kingdoms
-					}
-				}
-			}
-			trigger_event = WCCSC.5
-		}
-	}
-}
+# 		every_ruler = {
+# 			limit = {
+# 				NOR = { 
+# 					this = title:e_scourge.holder
+# 					is_vassal_or_below_of = title:e_scourge.holder
+# 				}
+# 				OR = {
+# 					location = {
+# 						geographical_region = world_northrend
+# 						geographical_region = world_eastern_kingdoms
+# 					}
+# 				}
+# 			}
+# 			trigger_event = WCCSC.5
+# 		}
+# 	}
+# }

--- a/events/wc_events/wc_scourge_plague_events.txt
+++ b/events/wc_events/wc_scourge_plague_events.txt
@@ -333,6 +333,9 @@ wc_scourge_plague.0009 = {
 		is_available_healthy_adult = yes
 		is_travelling = no
 		is_landed = yes
+		any_owned_story = { 
+			story_type = story_cycle_scourge_plague
+		}
 	}
 
 	immediate = {
@@ -1065,6 +1068,9 @@ wc_scourge_plague.1005 = {
 		}
 		is_travelling = no
 		can_contract_disease_trigger = { DISEASE = undead_plague } # Plot armor give you immunity
+		any_owned_story = { 
+			story_type = story_cycle_scourge_plague
+		}
 	}
 	
 	immediate = {
@@ -1110,6 +1116,9 @@ wc_scourge_plague.1006 = {
 			has_trait = being_undead # You should be alive
 		}
 		is_travelling = no
+		any_owned_story = { 
+			story_type = story_cycle_scourge_plague
+		}
 	}
 
 	immediate = {

--- a/events/wc_events/wc_scourge_plague_events.txt
+++ b/events/wc_events/wc_scourge_plague_events.txt
@@ -580,6 +580,18 @@ wc_scourge_plague.1000 = { #Scourge plague story cycle pacing control
 	}
 }
 
+scripted_trigger scourge_plague_in_realm = { 
+	NOR = {
+		any_sub_realm_county = { #Undead Plague is already here, no need to talk about it closing in
+			any_county_province = {
+				any_province_epidemic = {
+					epidemic_type.epidemic_trait = trait:undead_scourge
+				}
+			}
+		}
+	}
+}
+
 # The Scourge Plague is closing in
 # Used to trigger Scourge Plague Story cycle
 wc_scourge_plague.1001 = {
@@ -593,7 +605,7 @@ wc_scourge_plague.1001 = {
 		character = root
 		animation = worry
 	}
-	cooldown = { years = 2 }
+	cooldown = { years = 5 }
 
 	trigger = {
 		is_ai = no

--- a/events/wc_events/wc_scourge_plague_events.txt
+++ b/events/wc_events/wc_scourge_plague_events.txt
@@ -600,7 +600,7 @@ wc_scourge_plague.1001 = {
 			any_sub_realm_county = { #Undead Plague is already here, no need to talk about it closing in
 				any_county_province = {
 					any_province_epidemic = {
-						this = global_var:undead_scourge
+						epidemic_type.epidemic_trait = trait:undead_scourge
 					}
 				}
 			}

--- a/events/wc_events/wc_scourge_plague_events.txt
+++ b/events/wc_events/wc_scourge_plague_events.txt
@@ -599,21 +599,18 @@ wc_scourge_plague.1001 = {
 		is_ai = no
 		is_available_adult = yes
 		is_travelling = no
-		NOR = {
-			any_sub_realm_county = { #Undead Plague is already here, no need to talk about it closing in
-				any_county_province = {
-					any_province_epidemic = {
-						epidemic_type.epidemic_trait = trait:undead_scourge
-					}
-				}
-			}
-		}
+		scourge_plague_in_realm = no
 	}
 
 	on_trigger_fail = {
-		trigger_event = {
-			id = wc_scourge_plague.1001
-			days = { 7 14 }
+		if = { 
+			limit = { 
+				scourge_plague_in_realm = no
+			}
+			trigger_event = {
+				id = wc_scourge_plague.1001
+				days = { 7 14 }
+			}
 		}
 	}
 
@@ -628,18 +625,6 @@ wc_scourge_plague.1001 = {
 				}
 			}
 			add_character_flag = scourge_plague_closer
-		}
-		
-		hidden_effect = {
-			every_sub_realm_county = {
-				limit = {
-					any_county_province = {
-						any_province_epidemic = {
-							this = scope:epidemic_scope
-						}
-					}
-				}
-			}
 		}
 	}
 

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -590,7 +590,7 @@ bleedinghollow7={ # someone's OC but i added more OCs to justify his existence b
 		trait = in_ice_prison
 		
 		effect = {
-			scourge_603_pack_effect = yes
+			scourge_start_pack_effect = yes
 			set_variable = { name = wc_death_magic_lifestyle_additional_perks_variable value = wc_perks_needed_for_level_5_magic_trait_value }
 		}
 	}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed an issue which caused scourge story to start twice
- Fixed sloppy undead plague event implementation clogging error log
- Removed unnecessary global variable which was probably causing some issues
- Stopped scourge from spawning at game start
- Fixed bugs involving scourge jailors not spawning in after BDP

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
