### PR TITLE
Renown and vassal's Opinion Modifiers rework for Dark Governments

### DIFF
--- a/common/laws/wc_realm_laws.txt
+++ b/common/laws/wc_realm_laws.txt
@@ -7,10 +7,12 @@
 	necro_authority_0 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = 20
-			glory_hound_opinion = 10
-			parochial_opinion = 10
-			courtly_opinion = 5
+			barons_and_minor_landholders_opinion = -30
+			glory_hound_opinion = -25
+			parochial_opinion = -25
+			courtly_opinion = -10
+			zealot_opinion = -20
+			minority_opinion = -30
 			
 			levy_size = -0.25
 			levy_reinforcement_rate = -1.5
@@ -23,16 +25,19 @@
 	
 	necro_authority_1 = {
 		modifier = {
-			# Crown-like	
-			barons_and_minor_landholders_opinion = -30
-			glory_hound_opinion = -15
-			parochial_opinion = -15
-			courtly_opinion = -5
-			minority_opinion = -10
+			# Crown-like
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 15
+			parochial_opinion = 15
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
 			
 			levy_size = 0.15
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
+
+			monthly_dynasty_prestige = 1
 		}
 		flag = title_revocation_allowed
 		flag = vassal_retraction_allowed
@@ -44,19 +49,22 @@
 	
 	necro_authority_2 = {
 		modifier = {
-			# Crown-like
-			barons_and_minor_landholders_opinion = -10
-			glory_hound_opinion = -10
-			parochial_opinion = -10
-			courtly_opinion = -5
-			zealot_opinion = -10
-			minority_opinion = -10
+			# Crown-like	
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.1
 			vassal_levy_contribution_mult = 0.1
 			
 			levy_size = 0.15
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
+
+			monthly_dynasty_prestige = 2
 		}
 		flag = vassal_refusal_is_treason
 		flag = titles_cannot_leave_realm_on_succession # Hardcoded flag
@@ -68,18 +76,21 @@
 	necro_authority_3 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = -20
-			glory_hound_opinion = -25
-			parochial_opinion = -25
-			courtly_opinion = -10
-			zealot_opinion = -20
-			minority_opinion = -30
+			barons_and_minor_landholders_opinion = 20
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.25
 			vassal_levy_contribution_mult = 0.25
 			
 			levy_size = 0.15
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
+
+			monthly_dynasty_prestige = 5
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level
@@ -97,10 +108,12 @@ demonic_authority = {
 	demonic_authority_0 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = 20
-			glory_hound_opinion = 10
-			parochial_opinion = 10
-			courtly_opinion = 5
+			barons_and_minor_landholders_opinion = -30
+			glory_hound_opinion = -25
+			parochial_opinion = -25
+			courtly_opinion = -10
+			zealot_opinion = -20
+			minority_opinion = -30
 			
 			enemy_hard_casualty_modifier = -0.25
 			movement_speed = -0.15
@@ -113,16 +126,19 @@ demonic_authority = {
 	
 	demonic_authority_1 = {
 		modifier = {
-			# Crown-like	
-			barons_and_minor_landholders_opinion = -30
-			glory_hound_opinion = -15
-			parochial_opinion = -15
-			courtly_opinion = -5
-			minority_opinion = -10
+			# Crown-like
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 15
+			parochial_opinion = 15
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
 			dread_decay_mult = -0.35
+
+			monthly_dynasty_prestige = 1
 		}
 		flag = title_revocation_allowed
 		flag = vassal_retraction_allowed
@@ -134,19 +150,22 @@ demonic_authority = {
 	
 	demonic_authority_2 = {
 		modifier = {
-			# Crown-like
-			barons_and_minor_landholders_opinion = -10
-			glory_hound_opinion = -10
-			parochial_opinion = -10
-			courtly_opinion = -5
-			zealot_opinion = -10
-			minority_opinion = -10
+			# Crown-like	
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.1
 			vassal_levy_contribution_mult = 0.1
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
 			dread_decay_mult = -0.35
+
+			monthly_dynasty_prestige = 2
 		}
 		flag = vassal_refusal_is_treason
 		flag = titles_cannot_leave_realm_on_succession # Hardcoded flag
@@ -158,18 +177,21 @@ demonic_authority = {
 	demonic_authority_3 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = -20
-			glory_hound_opinion = -25
-			parochial_opinion = -25
-			courtly_opinion = -10
-			zealot_opinion = -20
-			minority_opinion = -30
+			barons_and_minor_landholders_opinion = 20
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.25
 			vassal_levy_contribution_mult = 0.25
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
 			dread_decay_mult = -0.35
+
+			monthly_dynasty_prestige = 5
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level
@@ -187,10 +209,12 @@ eldritch_authority = {
 	eldritch_authority_0 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = 20
-			glory_hound_opinion = 10
-			parochial_opinion = 10
-			courtly_opinion = 5
+			barons_and_minor_landholders_opinion = -30
+			glory_hound_opinion = -25
+			parochial_opinion = -25
+			courtly_opinion = -10
+			zealot_opinion = -20
+			minority_opinion = -30
 			
 			diplomacy_per_stress_level = -2
 			martial_per_stress_level = -2
@@ -207,12 +231,13 @@ eldritch_authority = {
 	
 	eldritch_authority_1 = {
 		modifier = {
-			# Crown-like	
-			barons_and_minor_landholders_opinion = -30
-			glory_hound_opinion = -15
-			parochial_opinion = -15
-			courtly_opinion = -5
-			minority_opinion = -10
+			# Crown-like
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 15
+			parochial_opinion = 15
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
 			
 			diplomacy_per_stress_level = 1
 			martial_per_stress_level = 1
@@ -221,6 +246,8 @@ eldritch_authority = {
 			learning_per_stress_level = 1
 			prowess_per_stress_level = 1
 			development_growth_factor = 1.15
+
+			monthly_dynasty_prestige = 1
 		}
 		flag = title_revocation_allowed
 		flag = vassal_retraction_allowed
@@ -232,13 +259,14 @@ eldritch_authority = {
 	
 	eldritch_authority_2 = {
 		modifier = {
-			# Crown-like
-			barons_and_minor_landholders_opinion = -10
-			glory_hound_opinion = -10
-			parochial_opinion = -10
-			courtly_opinion = -5
-			zealot_opinion = -10
-			minority_opinion = -10
+			# Crown-like	
+			barons_and_minor_landholders_opinion = 15
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.1
 			vassal_levy_contribution_mult = 0.1
 			
@@ -249,6 +277,8 @@ eldritch_authority = {
 			learning_per_stress_level = 1
 			prowess_per_stress_level = 1
 			development_growth_factor = 1.15
+
+			monthly_dynasty_prestige = 2
 		}
 		flag = vassal_refusal_is_treason
 		flag = titles_cannot_leave_realm_on_succession # Hardcoded flag
@@ -260,12 +290,13 @@ eldritch_authority = {
 	eldritch_authority_3 = {
 		modifier = {
 			# Crown-like
-			barons_and_minor_landholders_opinion = -20
-			glory_hound_opinion = -25
-			parochial_opinion = -25
-			courtly_opinion = -10
-			zealot_opinion = -20
-			minority_opinion = -30
+			barons_and_minor_landholders_opinion = 20
+			glory_hound_opinion = 10
+			parochial_opinion = 10
+			courtly_opinion = 5
+			zealot_opinion = 10
+			minority_opinion = 10
+
 			vassal_tax_mult = 0.25
 			vassal_levy_contribution_mult = 0.25
 			
@@ -276,6 +307,8 @@ eldritch_authority = {
 			learning_per_stress_level = 1
 			prowess_per_stress_level = 1
 			development_growth_factor = 1.15
+
+			monthly_dynasty_prestige = 5
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level

--- a/common/laws/wc_realm_laws.txt
+++ b/common/laws/wc_realm_laws.txt
@@ -90,7 +90,7 @@
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
 
-			monthly_dynasty_prestige = 5
+			monthly_dynasty_prestige = 2
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level
@@ -191,7 +191,7 @@ demonic_authority = {
 			movement_speed = 0.1
 			dread_decay_mult = -0.35
 
-			monthly_dynasty_prestige = 5
+			monthly_dynasty_prestige = 2
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level
@@ -308,7 +308,7 @@ eldritch_authority = {
 			prowess_per_stress_level = 1
 			development_growth_factor = 1.15
 
-			monthly_dynasty_prestige = 5
+			monthly_dynasty_prestige = 2
 		}
 		flag = can_designate_heirs
 		flag = max_authority_level

--- a/common/laws/wc_realm_laws.txt
+++ b/common/laws/wc_realm_laws.txt
@@ -14,7 +14,7 @@
 			zealot_opinion = -20
 			minority_opinion = -30
 			
-			levy_size = -0.25
+			levy_size = -0.20
 			levy_reinforcement_rate = -1.5
 			men_at_arms_maintenance = 0.3
 		}
@@ -32,8 +32,11 @@
 			courtly_opinion = 5
 			zealot_opinion = 10
 			minority_opinion = 10
+
+			vassal_tax_mult = 0.02
+			vassal_levy_contribution_mult = 0.05
 			
-			levy_size = 0.15
+			levy_size = 0.10
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
 
@@ -57,10 +60,10 @@
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.1
+			vassal_tax_mult = 0.03
 			vassal_levy_contribution_mult = 0.1
 			
-			levy_size = 0.15
+			levy_size = 0.20
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
 
@@ -83,10 +86,10 @@
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.25
-			vassal_levy_contribution_mult = 0.25
+			vassal_tax_mult = 0.05
+			vassal_levy_contribution_mult = 0.1
 			
-			levy_size = 0.15
+			levy_size = 0.10
 			levy_reinforcement_rate = 1
 			men_at_arms_maintenance = -0.2
 
@@ -133,6 +136,9 @@ demonic_authority = {
 			courtly_opinion = 5
 			zealot_opinion = 10
 			minority_opinion = 10
+
+			vassal_tax_mult = 0.02
+			vassal_levy_contribution_mult = 0.05
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
@@ -158,12 +164,12 @@ demonic_authority = {
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.1
+			vassal_tax_mult = 0.03
 			vassal_levy_contribution_mult = 0.1
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
-			dread_decay_mult = -0.35
+			dread_decay_mult = -0.3
 
 			monthly_dynasty_prestige = 2
 		}
@@ -184,8 +190,8 @@ demonic_authority = {
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.25
-			vassal_levy_contribution_mult = 0.25
+			vassal_tax_mult = 0.05
+			vassal_levy_contribution_mult = 0.1
 			
 			enemy_hard_casualty_modifier = 0.15
 			movement_speed = 0.1
@@ -238,6 +244,9 @@ eldritch_authority = {
 			courtly_opinion = 5
 			zealot_opinion = 10
 			minority_opinion = 10
+
+			vassal_tax_mult = 0.02
+			vassal_levy_contribution_mult = 0.05
 			
 			diplomacy_per_stress_level = 1
 			martial_per_stress_level = 1
@@ -267,7 +276,7 @@ eldritch_authority = {
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.1
+			vassal_tax_mult = 0.03
 			vassal_levy_contribution_mult = 0.1
 			
 			diplomacy_per_stress_level = 1
@@ -276,7 +285,7 @@ eldritch_authority = {
 			intrigue_per_stress_level = 1
 			learning_per_stress_level = 1
 			prowess_per_stress_level = 1
-			development_growth_factor = 1.15
+			development_growth_factor = 1.2
 
 			monthly_dynasty_prestige = 2
 		}
@@ -297,8 +306,8 @@ eldritch_authority = {
 			zealot_opinion = 10
 			minority_opinion = 10
 
-			vassal_tax_mult = 0.25
-			vassal_levy_contribution_mult = 0.25
+			vassal_tax_mult = 0.05
+			vassal_levy_contribution_mult = 0.1
 			
 			diplomacy_per_stress_level = 1
 			martial_per_stress_level = 1


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- **Added Renown advantage if Dark Government Authority is higher.**
- Renown for Dark Authority 2: 1/per month
- Renown for Dark Authority 3: 3/per month
- Renown for Dark Authority 4: 5/per month

- **Changed the opinion modifiers for Dark Governments.**
- Lowest Dark Authority now causes your vassals to have worse opinion of you
- As Dark Authority increases, your vassals will like you more
- At Dark Authority 1 & 2: the Opinion Modifiers are all in the negatives
- At Dark Authority 3: the Opinion Modifiers are all basically nullified to 0
- At Dark Authority 4: the Opinion Modifiers are all in the positives

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Since Dark Governments cannot use Royal Courts, they are heavily disadvantaged in terms of renown which a normal government gets by having court artifacts that provide a tonne of renown very easily even as a new Kingdom level entity. This issue is now solved.
- It does not make any sense for Dark Governments vassals hating their liege the more Dark Authority they have. In warcraft, characters of evil govs are more obedient to their overlord the more powerful they are. At maximum Dark Authority, your vassals should rather respect you and hold you in high regards

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
