### PR TITLE
add exception to crisis_events.0210

### DIFF
--- a/events/wc_events/wc_crisis_events.txt
+++ b/events/wc_events/wc_crisis_events.txt
@@ -500,6 +500,10 @@ wc_crisis_events.0210 = {
             has_character_flag = wc_betrayal_success
             has_character_flag = crisis_events_cd
         }
+        NOT = { # prevent stormwind from submitting without a fight
+            root = title:e_horde.holder
+            scope:target = title:k_stormwind.holder 
+        }
     }
 
     immediate = {

--- a/events/wc_events/wc_crisis_events.txt
+++ b/events/wc_events/wc_crisis_events.txt
@@ -501,6 +501,7 @@ wc_crisis_events.0210 = {
             has_character_flag = crisis_events_cd
         }
         NOT = { # prevent stormwind from submitting without a fight
+            game_start_date <= 583.1.1
             root = title:e_horde.holder
             scope:target = title:k_stormwind.holder 
         }


### PR DESCRIPTION

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added an exception to crisis_events.0210 that should prevent Stormwind from submitting to the horde without a fight and bugging the horde invasion story

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
