### PR TITLE
cant send or demand lore chars

### DIFF
--- a/common/character_interactions/00_marriage_interactions.txt
+++ b/common/character_interactions/00_marriage_interactions.txt
@@ -3270,6 +3270,12 @@ offer_concubine = {
 				}
 			}
 		}
+		# Warcraft
+		scope:secondary_actor = { 
+			NOT = { 
+				has_character_modifier = important_lore_character
+			}
+		}
 	}
 
 	auto_accept = no

--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1335,6 +1335,12 @@ offer_courtier_interaction = {
 				}
 			}
 		}
+		# Warcraft
+		scope:secondary_actor = { 
+			NOT = { 
+				has_character_modifier = important_lore_character
+			}
+		}
 	}
 
 	auto_accept = no
@@ -1785,6 +1791,12 @@ demand_courtier_interaction = {
 	}
 
 	can_send = {
+		# Warcraft
+		scope:secondary_actor = { 
+			NOT = { 
+				has_character_modifier = important_lore_character
+			}
+		}
 	}
 
 	auto_accept = no
@@ -2103,6 +2115,12 @@ demand_concubine_interaction = {
 	}
 
 	can_send = {
+		# Warcraft
+		scope:secondary_actor = { 
+			NOT = { 
+				has_character_modifier = important_lore_character
+			}
+		}
 	}
 
 	auto_accept = no


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- characters that are lore important are no longer able to be sent or demanded as court employees
- characters that are lore important are no longer able to be sent or demanded as concubines

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
