### PR TITLE
More Coalition and Union rework

### DIFF
--- a/common/character_interactions/wc_crisis_interactions.txt
+++ b/common/character_interactions/wc_crisis_interactions.txt
@@ -16,10 +16,6 @@
 	
 	is_valid_showing_failures_only = {
 		scope:actor = {
-			custom_tooltip = {
-				text = cannot_into_coalition_if_you_dont_border_crisis
-				any_neighboring_top_liege_realm_owner = { this = scope:recipient }
-			}
 			is_confederation_member = no # Already in a defensive Confederation
 			NOT = { is_isolated_from_trigger = { target = scope:recipient } } # Your lands are in Isolation
 			custom_tooltip = {

--- a/common/character_interactions/wc_crisis_interactions.txt
+++ b/common/character_interactions/wc_crisis_interactions.txt
@@ -26,6 +26,10 @@
 			has_crisis_coalition_cooldown_trigger = no
 			can_be_in_coalition_trigger = yes
 			can_be_in_coalition_against_trigger = { CRISIS_HOLDER = scope:recipient }
+			custom_tooltip = {
+				text = can_into_coalition_since_crisis_on_continent
+				has_crisis_on_same_continent_trigger = yes
+			}
 		}
 	}
 	

--- a/common/scripted_triggers/wc_pol_faction_triggers.txt
+++ b/common/scripted_triggers/wc_pol_faction_triggers.txt
@@ -959,6 +959,7 @@ has_illidari_culture_trigger = {
 			is_culture_or_parent_culture_trigger = { CULTURE = culture:blood_elf }
 			has_cultural_pillar = heritage_darnassian
 			has_cultural_pillar = heritage_azsharic
+			has_cultural_pillar = heritage_argussian
 		}
 	}
 }
@@ -969,10 +970,15 @@ has_illidari_race_trigger = {
 		has_trait = creature_naga
 		has_trait = creature_draenei
 		has_trait = creature_broken
+		has_trait = creature_lost_one
 	}
 	AND = { # Blood Elf
 		has_trait = creature_high_elf
 		culture = { is_culture_or_parent_culture_trigger = { CULTURE = culture:blood_elf } }
+	}
+	AND = { # Fel Orc
+		has_trait = creature_orc
+		has_trait = being_demon
 	}
 	NOR = { # Fairly isolationist compared to other factions
 		has_trait = being_undead

--- a/common/scripted_triggers/wc_pol_faction_triggers.txt
+++ b/common/scripted_triggers/wc_pol_faction_triggers.txt
@@ -694,19 +694,19 @@ union_overcrowded_trigger = {
 		limit = { has_crisis_on_same_continent_trigger = yes }
 		trigger_if = {
 			limit = { OR = { has_culture = culture:forsaken has_culture = culture:night_elf } }
-			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 8 } }
+			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 12 } }
 		}
 		trigger_else = {
-			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 7 } }
+			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 10 } }
 		}
 	}
 	trigger_else = {
 		trigger_if = {
 			limit = { OR = { has_culture = culture:forsaken has_culture = culture:night_elf } }
-			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 4 } }
+			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 6 } }
 		}
 		trigger_else = {
-			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 3 } }
+			scope:crowd_union ?= { variable_list_size = { name = union_members value >= 4 } }
 		}
 	}
 }
@@ -719,10 +719,10 @@ union_overcrowded_of_trigger = {
 	}
 	trigger_if = {
 		limit = { has_crisis_on_same_continent_trigger = yes }
-		scope:crowd_union ?= { variable_list_size = { name = union_members value >= 8 } }
+		scope:crowd_union ?= { variable_list_size = { name = union_members value >= 12 } }
 	}
 	trigger_else = {
-		scope:crowd_union ?= { variable_list_size = { name = union_members value >= 4 } }
+		scope:crowd_union ?= { variable_list_size = { name = union_members value >= 6 } }
 	}
 }
 

--- a/localization/english/wc_important_actions_l_english.yml
+++ b/localization/english/wc_important_actions_l_english.yml
@@ -20,3 +20,4 @@
  action_join_coalition_combined_label:0 "[recipient.GetPrimaryTitle.Custom('GetTierIcon')] [recipient.GetUINameNoTooltip], #low @soldier_icon![recipient.GetMilitaryStrengthText]#!"
  action_join_coalition_click:0 "#I Click to join [coalition|E]#!"
  cannot_into_coalition_since_already_in_union:0 "You cannot join this [coalition|E] since you already belong to a [union|E]"
+ can_into_coalition_since_crisis_on_continent:0 "The [crisis|E] needs to be on your continent to join this [coalition|E]"

--- a/localization/english/wc_important_actions_l_english.yml
+++ b/localization/english/wc_important_actions_l_english.yml
@@ -19,5 +19,4 @@
  action_join_coalition_label:0 "You can join a [coalition|E] against [recipient.GetPrimaryTitle.Custom('GetTierIcon')][recipient.GetUINameNoTooltip], #low @soldier_icon![recipient.GetMilitaryStrengthText]#!"
  action_join_coalition_combined_label:0 "[recipient.GetPrimaryTitle.Custom('GetTierIcon')] [recipient.GetUINameNoTooltip], #low @soldier_icon![recipient.GetMilitaryStrengthText]#!"
  action_join_coalition_click:0 "#I Click to join [coalition|E]#!"
- cannot_into_coalition_if_you_dont_border_crisis:0 "You cannot join this [coalition|E] since you do not directly border the [crisis|E]"
  cannot_into_coalition_since_already_in_union:0 "You cannot join this [coalition|E] since you already belong to a [union|E]"

--- a/localization/english/wc_pol_faction_l_english.yml
+++ b/localization/english/wc_pol_faction_l_english.yml
@@ -85,7 +85,7 @@
  do_you_have_horde_culture:0 "Your culture has one of these heritages: #V Hozen#!, #V Gorian#!, #V Orcish#!, #V Zulite#!, #V Forsaken#!, #V Sin'dorei#!, #V Nightborne#!, #V Goblin#!, #V Gilblin#!, #V Yuangolic#!, #V Tauren#!, #V Taunka#!"
  do_you_have_horde_religion:0 "Your faiths is one of these: #V Fortunism#!, #V Belorism#!, #V Ancestrism#!, #V Mashani#!, #V Roanaki#!, #V Shal'danalism#!, #V Corruptism#! or you have any religion under: #V Grondism#!, #V Shadow#!, #V Loa#!, #V Apism#!"
 
- do_you_have_illidari_culture:0 "Your culture has one of these heritages: #V Darnassian#!, #V Azsharic#! or you belong to the cultures: #V Sin'dorei#!"
+ do_you_have_illidari_culture:0 "Your culture has one of these heritages: #V Darnassian#!, #V Azsharic#!, #V Argussian#! or you belong to the cultures: #V Sin'dorei#!"
  do_you_have_illidari_religion:0 "Your religion is one of these: #V Fel#!, #V Energism#!"
 
  do_you_have_draconic_culture:0 "Your culture has one of these heritages: #V Draconic#!"


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- You can now join a Coalition even if you don't directly border a crisis
- Increased the number of Union members that will stay in a Union from 10-12 to approximately 15~ members
- Fixed an issue where people where joining in a coalition when they didn't even have the crisis on their continent
- Added Draenei's cultural heritage (Argussian) in the list of cultures who can join the Illidari Union 

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Some of you think that there is a hard limit that disables a way to join a union if it becomes overcrowded, there isn't any such hard limit, any AI/player character can join a Union even if it is overcrowded. I just worded it in a bad way in the changelog for 1.17.1. And the players who were complaining about the limitations hadn't even played the update to see how unions work now. Nonetheless, Unions work as intended.
- How `union_overcrowded_of_trigger` and `union_overcrowded_trigger` works is that the AI has more chances to *leave your union* if they don't like how overcrowded the union has become

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
