### PR TITLE
Illidan's Story

### DIFF
--- a/common/casus_belli_types/00_invasion_war.txt
+++ b/common/casus_belli_types/00_invasion_war.txt
@@ -649,7 +649,7 @@ mongol_invasion_war = {
 		if = {
 			limit = { scope:attacker = { has_title = title:h_burning_legion } }
 			hidden_effect = {
-				spawn_future_burning_legion_vassals_as_courtiers_effect = yes
+				spawn_future_burning_legion_courtiers_effect = yes
 			}
 		}
 

--- a/common/character_interactions/00_prison_interactions.txt
+++ b/common/character_interactions/00_prison_interactions.txt
@@ -7284,6 +7284,13 @@ castrate_interaction = {
 		# 	}
 		# 	add = 30
 		# }
+		# Warcraft
+		# Maiev will not castrate Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 
 	ai_frequency_by_tier = {
@@ -7486,6 +7493,13 @@ blind_interaction = {
 		# 	}
 		# 	add = 30
 		# }
+		# Warcraft
+		# Maiev will not blind Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
+		}
 	}
 
 	ai_frequency_by_tier = {
@@ -7902,6 +7916,13 @@ systematically_maim_character_interaction = {
 				}
 			}
 			add = 25
+		}
+		# Warcraft
+		# Maiev will not maim Illidan
+		modifier = { 
+			factor = 0
+			scope:actor = character:340021
+			scope:recipient = character:340009
 		}
 	}
 

--- a/common/modifiers/wc_event_modifiers.txt
+++ b/common/modifiers/wc_event_modifiers.txt
@@ -679,3 +679,9 @@ dryad_and_keeper_blessed_by_restored_nordrassil = {
 
 	life_expectancy = 750
 }
+
+weakened_burning_legion = {
+	icon = martial_negative
+
+	army_toughness_mult = -1
+}

--- a/common/on_action/wc_yearly_on_actions.txt
+++ b/common/on_action/wc_yearly_on_actions.txt
@@ -30,6 +30,7 @@ yearly_global_pulse = {
 		theramore_survivors_story_on_action # Happens between 605 - 610
 		burning_legion_invasion_on_action # Happens between 604 - 624
 		eternitysend_on_action # Happens a few months after Burning Legion has spawned
+		illidan_stormrage_on_action # Happens when Cenarius dies
         thunder_king_invasion_on_action # Happens between 600 - 650 or after 650 depending on game rules
 
 		# Warcraft
@@ -257,6 +258,32 @@ eternitysend_on_action = {
 			debug_log = "Schemes against cenarius will soon take place"
 			trigger_event = { # This starts the content for Burning Legion's attempt to kill Cenarius and invade Kaldorei
 				id = eternitysend.0001
+				days = { 2 240 } # keep this smaller than 1 year since they might trigger twice if set to 1 year
+			}
+		}
+	}
+}
+
+illidan_stormrage_on_action = {
+	trigger = {
+		game_start_date < 605.6.6
+		NOT = {
+			is_target_in_global_variable_list = {
+				name = warcraft_invaders_story
+				target = flag:illidan_stormrage_story_started
+			}
+		}
+	}
+	effect = {
+		random = {
+			chance = 0
+			modifier = { # Cenarius is dead?
+				add = 100
+				character:410002 = { is_alive = no }
+			}
+			debug_log = "Illidan will soon be freed from his prison"
+			trigger_event = {
+				id = illidansbeginnings.0001
 				days = { 2 240 } # keep this smaller than 1 year since they might trigger twice if set to 1 year
 			}
 		}

--- a/common/on_action/yearly_on_actions.txt
+++ b/common/on_action/yearly_on_actions.txt
@@ -1476,13 +1476,14 @@ five_year_playable_pulse = {
 				}
 			}
 		}
-
 	}
 	events = {
 		courtier_guest_management.3001 	# Courtiers and guests getting relationships & secrets
 		game_rule.1 					# De Jure Requirement Game Rule
 		game_rule.4 					# Empire Obscurity Game Rule
 		culture_tradition_events.3000	# Bear Sightings
+
+		illidansbeginnings.0200         # Warcraft, starts spawning Demon Hunter adventurers every five years
 	}
 	on_actions = {
 		delay = { days = { 45 75 } }

--- a/common/scripted_effects/wc_burning_legion_effects.txt
+++ b/common/scripted_effects/wc_burning_legion_effects.txt
@@ -212,7 +212,7 @@ spawn_burning_legion_troops_effect = {
 	}
 }
 
-spawn_future_burning_legion_vassals_as_courtiers_effect = {
+spawn_future_burning_legion_courtiers_effect = {
 	create_character = {
 		employer = scope:attacker
 		culture = culture:annihilan

--- a/events/wc_events/wc_central_kalimdor_events.txt
+++ b/events/wc_events/wc_central_kalimdor_events.txt
@@ -462,7 +462,7 @@ cen_kal.1003 = {
 	
 	left_portrait = {
  		character = root
-		animation = angry
+		animation = anger
 	}
 	right_portrait = {
 		character = var:goblin_prospector
@@ -532,7 +532,7 @@ cen_kal.1004 = {
 	
 	left_portrait = {
  		character = root
-		animation = angry
+		animation = anger
 	}
 	right_portrait = {
 		character = scope:steward

--- a/events/wc_events/wc_eternitysend_events.txt
+++ b/events/wc_events/wc_eternitysend_events.txt
@@ -741,7 +741,7 @@ eternitysend.0221 = { # Warsong loses
     }
     right_portrait = {
         character = scope:attacker
-        animation = angry
+        animation = anger
     }
 
     option = {

--- a/events/wc_events/wc_illidansbeginnings_events.txt
+++ b/events/wc_events/wc_illidansbeginnings_events.txt
@@ -5,7 +5,7 @@
 
 #### illidansbeginnings.0100 -> Begin the event chain: Tyrande/Kaldorei ruler frees Illidan because Cenarius is dead
 
-scripted_effect illidan_becomes_an_adventurer = {
+scripted_effect become_an_adventurer = {
     save_scope_as = adventurer
     if = {
         limit = {
@@ -58,6 +58,28 @@ scripted_effect illidan_becomes_an_adventurer = {
         }
     }
     trigger_event = { id = ep3_laamps.0030 }
+    # Debug tracking
+    if = {
+        limit = {
+            is_ai = yes
+            debug_only = yes
+        }
+        if = {
+            limit = { exists = global_var:ai_voluntary_laamp_count }
+            change_global_variable = {
+                name = ai_voluntary_laamp_count
+                add = 1
+            }
+        }
+        else = {
+            set_global_variable = {
+                name = ai_voluntary_laamp_count
+                value = 1
+            }
+        }
+        debug_log = "Demon Hunter AI was granted an adventurer camp"
+        debug_log_scopes = yes
+    }
 }
 
 illidansbeginnings.0001 = {
@@ -82,7 +104,7 @@ illidansbeginnings.0001 = {
                     release_from_prison = yes
                 }
 
-                illidan_becomes_an_adventurer = yes
+                become_an_adventurer = yes
 
                 set_character_faith = faith:illidari
             }
@@ -331,6 +353,131 @@ illidansbeginnings.0104 = {
         title:h_burning_legion.holder = {
             add_character_modifier = {
                 modifier = weakened_burning_legion
+            }
+        }
+
+        set_global_variable = { name = era_of_demon_hunters value = yes } # every 5 years, rando demon hunters will spawn
+    }
+}
+
+illidansbeginnings.0200 = {
+    scope = none
+    hidden = yes
+
+    trigger = {
+        exists = global_var:era_of_demon_hunters
+        NOT = { exists = global_var:stop_DH_spawn_for_5_years }
+    }
+
+    immediate = {
+        hidden_effect = {
+            create_character = {
+                location = title:c_astranaar.title_province
+                faith = faith:illidari
+                culture = culture:night_elf
+                age = { 20 200 }
+                gender_female_chance = 50
+                save_scope_as = new_demon_hunter
+                after_creation = {
+                    trigger_race_giving_no_gene_effect = yes # Assigns race trait
+
+                    add_trait = demon_hunter
+
+                    random_list = { # Just to give them a little head start
+                        33 = {
+                            add_trait_xp = {
+                                trait = demon_hunter
+                                track = spectral_assassin
+                                value = 33
+                            }
+                        }
+                        34 = {
+                            add_trait_xp = {
+                                trait = demon_hunter
+                                track = slayer
+                                value = 33
+                            }
+                        }
+                        33 = {
+                            add_trait_xp = {
+                                trait = demon_hunter
+                                track = fury
+                                value = 33
+                            }
+                        }
+                    }
+                }
+            }
+
+            set_global_variable = {
+                name = stop_DH_spawn_for_5_years
+                value = yes
+                years = 5
+            }
+
+            scope:new_demon_hunter = {
+                trigger_event = {
+                    id = illidansbeginnings.0201
+                    days = 1
+                }
+            }
+        }
+    }
+}
+illidansbeginnings.0201 = {
+    hidden = yes
+
+    immediate = {
+        hidden_effect = {
+            save_scope_as = adventurer
+            if = {
+                limit = {
+                    NOT = { exists = scope:laamp_inheritor }
+                }
+                hidden_effect_new_object = {
+                    create_character = {
+                        template = laamp_inheritor_template
+                        culture = scope:new_demon_hunter.culture
+                        faith = scope:new_demon_hunter.faith
+                        dynasty = generate
+                        location = root.capital_province
+                        after_creation = {
+                            save_scope_as = laamp_inheritor
+                            add_character_flag = new_laamp_inheritor
+                        }
+                    }
+                }
+            }
+            create_landless_adventurer_title_tooltip_effect = yes
+            show_as_tooltip = {
+                add_prestige = medium_prestige_gain
+                add_character_modifier = {
+                    modifier = ep3_voluntary_laamp_character_modifier
+                    years = 5
+                }
+            }
+            trigger_event = { id = ep3_laamps.0030 }
+            # Debug tracking
+            if = {
+                limit = {
+                    is_ai = yes
+                    debug_only = yes
+                }
+                if = {
+                    limit = { exists = global_var:ai_voluntary_laamp_count }
+                    change_global_variable = {
+                        name = ai_voluntary_laamp_count
+                        add = 1
+                    }
+                }
+                else = {
+                    set_global_variable = {
+                        name = ai_voluntary_laamp_count
+                        value = 1
+                    }
+                }
+                debug_log = "Demon Hunter AI was granted an adventurer camp"
+                debug_log_scopes = yes
             }
         }
     }

--- a/events/wc_events/wc_illidansbeginnings_events.txt
+++ b/events/wc_events/wc_illidansbeginnings_events.txt
@@ -1,0 +1,331 @@
+﻿namespace = illidansbeginnings
+
+#### illidansbeginnings.0001 -> Scope out illidan and free him and then make him an adventurer
+#### illidansbeginnings.0002 -> Ask the player if they wanna play as illidan
+
+#### illidansbeginnings.0100 -> Begin the event chain: Tyrande/Kaldorei ruler frees Illidan because Cenarius is dead
+
+scripted_effect illidan_becomes_an_adventurer = {
+    save_scope_as = adventurer
+    if = {
+        limit = {
+            player_heir ?= {
+                this != root
+                is_adult = yes
+            }
+        }
+        player_heir = {
+            save_scope_as = laamp_heir
+            save_scope_as = laamp_inheritor
+            custom_tooltip = become_landless_adventurer_decision_title_scope_tt
+        }
+    }
+    else_if = {
+        limit = { top_liege != this }
+        liege = {
+            save_scope_as = laamp_liege
+            save_scope_as = laamp_inheritor
+            custom_tooltip = become_landless_adventurer_decision_title_scope_tt
+        }
+    }
+    else = {
+        custom_tooltip = become_landless_adventurer_decision_title_created_tt
+        if = {
+            limit = {
+                NOT = { exists = scope:laamp_inheritor }
+            }
+            hidden_effect_new_object = {
+                create_character = {
+                    template = laamp_inheritor_template
+                    culture = root.capital_county.culture
+                    faith = root.capital_county.faith
+                    dynasty = generate
+                    location = root.capital_province
+                    after_creation = {
+                        save_scope_as = laamp_inheritor
+                        add_character_flag = new_laamp_inheritor
+                    }
+                }
+            }
+        }
+    }
+    create_landless_adventurer_title_tooltip_effect = yes
+    show_as_tooltip = {
+        add_prestige = medium_prestige_gain
+        add_character_modifier = {
+            modifier = ep3_voluntary_laamp_character_modifier
+            years = 5
+        }
+    }
+    trigger_event = { id = ep3_laamps.0030 }
+}
+
+illidansbeginnings.0001 = {
+    scope = none
+    hidden = yes
+
+    immediate = {
+        hidden_effect = {
+            add_to_global_variable_list = {
+                name = warcraft_invaders_story
+                target = flag:illidan_stormrage_story_started
+            }
+
+            if = {
+                limit = { any_living_character = { is_illidan_trigger = yes } }
+                character:340009 = { save_scope_as = illidan }
+            }
+
+            scope:illidan = {
+                if = {
+                    limit = { is_imprisoned = yes }
+                    release_from_prison = yes
+                }
+
+                illidan_becomes_an_adventurer = yes
+
+                set_character_faith = faith:illidari
+            }
+
+            every_player = { trigger_event = { id = illidansbeginnings.0002 } }
+        }
+    }
+}
+
+illidansbeginnings.0002 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0002_title
+    desc = illidansbeginnings_0002_desc
+    theme = realm
+    override_background = { reference = terrain }
+
+    trigger = { is_ai = no }
+
+    on_trigger_fail = {
+        scope:illidan = {
+            trigger_event = {
+                id = illidansbeginnings.0100
+                days = 1
+            }
+        }
+    }
+
+    left_portrait = {
+        character = scope:illidan
+        animation = scheme
+    }
+
+    option = {
+        name = illidansbeginnings_0002_a
+        add_internal_flag = dangerous
+        set_player_character = scope:illidan
+
+        custom_tooltip = illidansbeginnings_0002_a_tt
+
+        scope:illidan = {
+            trigger_event = {
+                id = illidansbeginnings.0100
+                days = 1
+            }
+        }
+    }
+    option = {
+        name = illidansbeginnings_0002_b
+
+        scope:illidan = {
+            trigger_event = {
+                id = illidansbeginnings.0100
+                days = 1
+            }
+        }
+    }
+}
+
+illidansbeginnings.0100 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0100_title
+    desc = illidansbeginnings_0100_desc
+    theme = murder_feast_activity
+    override_background = { reference = terrain }
+
+    immediate = {
+        if = {
+            limit = { any_living_character = { is_tyrande_trigger = yes } }
+            character:340003 = { save_scope_as = tyrande }
+        }
+        else = {
+            title:e_kaldorei.holder = { save_scope_as = tyrande }
+        }
+    }
+
+    left_portrait = {
+        character = scope:illidan
+        animation = dismissal
+    }
+    right_portrait = {
+        character = scope:tyrande
+        animation = interested
+    }
+
+    option = {
+        name = illidansbeginnings_0100_a
+
+        scope:illidan = {
+            trigger_event = { id = illidansbeginnings.0101 }
+        }
+    }
+}
+
+illidansbeginnings.0101 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0101_title
+    desc = illidansbeginnings_0101_desc
+    theme = murder_feast_activity
+    override_background = { reference = terrain }
+
+    immediate = {
+        if = {
+            limit = { exists = character:430000 }
+            character:430000 = {
+                save_scope_as = tichondrius
+            }
+        }
+        else = {
+            create_character = {
+                employer = title:h_burning_legion.holder
+                template = tichondrius_character_template
+                name = "Tichondrius"
+                save_scope_as = tichondrius
+            }
+        }
+    }
+
+    left_portrait = {
+        character = scope:illidan
+        animation = thinking
+    }
+    right_portrait = {
+        character = character:60003 # Arthas
+        animation = schadenfreude
+    }
+
+    option = {
+        name = illidansbeginnings_0101_a
+
+        custom_tooltip = illidansbeginnings_0101_a_tt
+
+        scope:illidan = {
+            trigger_event = {
+                id = illidansbeginnings.0102
+                days = 31
+            }
+        }
+    }
+}
+
+illidansbeginnings.0102 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0102_title
+    desc = illidansbeginnings_0102_desc
+    theme = murder_feast_activity
+    override_background = { reference = wc_background_tomb_of_sargeras }
+
+    right_portrait = {
+        character = scope:illidan
+        animation = manic
+    }
+
+    option = {
+        name = illidansbeginnings_0102_a
+
+        add_trait = demon_hunter
+
+        add_trait_xp = {
+            trait = demon_hunter
+            track = spectral_assassin
+            value = 33
+        }
+        add_trait_xp = {
+            trait = demon_hunter
+            track = slayer
+            value = 33
+        }
+        add_trait_xp = {
+            trait = demon_hunter
+            track = fury
+            value = 33
+        }
+
+        scope:illidan = {
+            trigger_event = { id = illidansbeginnings.0103 }
+        }
+    }
+}
+
+illidansbeginnings.0103 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0103_title
+    desc = illidansbeginnings_0103_desc
+    theme = murder_feast_activity
+    override_background = { reference = wc_background_tomb_of_sargeras }
+
+    left_portrait = {
+        character = scope:illidan
+        animation = war_attacker
+    }
+    right_portrait = {
+        character = scope:tichondrius
+        animation = war_defender
+    }
+
+    option = {
+        name = illidansbeginnings_0103_a
+
+        configure_start_single_combat_effect = {
+            SC_INITIATOR = scope:illidan
+			SC_ATTACKER = scope:illidan
+			SC_DEFENDER = scope:tichondrius
+			FATALITY = always
+			FIXED = sc_attacker
+			LOCALE = battlefield
+			OUTPUT_EVENT = perk_interaction.0101
+			INVALIDATION_EVENT = perk_interaction.0102
+        }
+
+        custom_tooltip = illidansbeginnings_0103_a_tt
+
+        scope:illidan = {
+            trigger_event = {
+                id = illidansbeginnings.0104
+                days = 2
+            }
+        }
+    }
+}
+
+illidansbeginnings.0104 = {
+    type = character_event
+    content_source = dlc_GOA
+    title = illidansbeginnings_0104_title
+    desc = illidansbeginnings_0104_desc
+    theme = murder_feast_activity
+    override_background = { reference = terrain }
+
+    left_portrait = {
+        character = scope:illidan
+        animation = dismissal
+    }
+    right_portrait = {
+        character = scope:tyrande
+        animation = anger
+    }
+
+    option = {
+        name = illidansbeginnings_0104_a
+    }
+}

--- a/events/wc_events/wc_illidansbeginnings_events.txt
+++ b/events/wc_events/wc_illidansbeginnings_events.txt
@@ -327,5 +327,11 @@ illidansbeginnings.0104 = {
 
     option = {
         name = illidansbeginnings_0104_a
+
+        title:h_burning_legion.holder = {
+            add_character_modifier = {
+                modifier = weakened_burning_legion
+            }
+        }
     }
 }

--- a/localization/english/event_localization/wc_illidansbeginnings_events_l_english.yml
+++ b/localization/english/event_localization/wc_illidansbeginnings_events_l_english.yml
@@ -1,0 +1,29 @@
+﻿l_english:
+
+ illidansbeginnings_0002_title: "A Fated Saviour?"
+ illidansbeginnings_0002_desc: "#help This is just a notification event for the player. Illidan Stromrage is about to start his crusade against the burning legion and its servants. Do you wish to play as him?#!"
+ illidansbeginnings_0002_a: "A Sorrowful Fate?"
+ illidansbeginnings_0002_a_tt: "#XB You will not be able to play as your previous character after starting as Illidan#!"
+ illidansbeginnings_0002_b: "I would rather walk my own path!"
+
+ illidansbeginnings_0100_title: "Bound by Blood"
+ illidansbeginnings_0100_desc: "The gates that barred even the light from entering my prison have been broken. I sense a familiar presence lingering around, one that I haven't felt since thousands of years.\n\n"[illidan.GetFirstName]! Is that you?"\n\nI turn around to face the voice and the being who has approached me. "[tyrande.GetFirstName]... it is your voice! After all these ages spent in darkness, your voice is like the pure light of the moon upon my mind..."\n\n"The Legion has returned, [illidan.GetFirstName]. Your people have need of you once more." [tyrande.GetFirstName] says seriously without a hint of any lie on [tyrande.GetHerHis] face.\n\nI turn around consider the opportunity to not only escape my bindings, but also prove everyone from the past wrong.\n\nI easily smash away the bars that held me in my prison. "Because I once cared for you, [tyrande.GetFirstName], I will hunt down the demons. But I will never owe our people anything!"\n\n[tyrande.GetFirstName] seems satisfied with my response "Then let us hurry back to the surface! The demons' corruption spreads wth every second we waste!""
+ illidansbeginnings_0100_a: "Time for a Hunt!"
+
+ illidansbeginnings_0101_title: "A Destiny of Flame and Sorrow"
+ illidansbeginnings_0101_desc: ""I am free... after ten thousand years... yet my own people still think of me as a villain! I'll show them my true power! I'll show them that the demons have no hold over me!"\n\n"Are you certain of that, hunter? Are you certain your will is your own?" I turn around to see a Human, but it is not one of those outlanders... this one reeks of death.\n\n"You'll regret approaching me, Human..." I give a final warning to him. Nonetheless, the Human lunges at me. But as we duel, I realize that we are evenly matched with neither of us gaining the upper hand.\n\n"We could go on like this forever, what is it you truly want, Human?" I ask the Human as we the duel comes to a pause.\n\nThe Human smirks and continues "The Dreadlord who commands the Undead forces of the Legion is called [tichondrius.GetFirstName]. He controls a powerful warlock artifact called the #italic Skull of Gul'dan#!. It is reponsible for corrupting the forests across Kalimdor and weaken the Night Elves."\n\nI am not convinced of the Human's sudden advices which could help me "And you wish for me to steal it? Why? What do you gain from it, Human?"\n\n"Let's just say that I have no love for [tichondrius.GetFirstName], and the Lord I serve would... benefit from the Legion's downfall." I could trace no lie on the deathly Human's face. Even if the Human has no reason to help me, there seems a desperation of his face, he wants [tichondrius.GetFirstName] gone for good.\n\n"Hmm... consider it your lucky day, Human... now... begone!""
+ illidansbeginnings_0101_a: "Time to search for this artifact..."
+ illidansbeginnings_0101_a_tt: "It will take some time to find #italic Skull of Gul'dan#!"
+
+ illidansbeginnings_0102_title: "A Destiny of Flame and Sorrow"
+ illidansbeginnings_0102_desc: "We have found it... the #italic Skull of Gul'dan#!... Now at least the demons will no longer corrupt the forests. But... if I destroy the skull and claim its power as my own, I will become stronger than any of [burning_legion|E]'s lieutenants! Yes... this power should be mine!\n\nI destroy the #italic Skull of Gul'dan#! with my bare hands and start absorbing its powers. Now I am complete!"
+ illidansbeginnings_0102_a: "Time to find [tichondrius.GetFirstName]..."
+
+ illidansbeginnings_0103_title: "A Destiny of Flame and Sorrow"
+ illidansbeginnings_0103_desc: "I approach [tichondrius.GetFirstName] with my newfound powers and form.\n\n[tichondrius.GetFirstName] prepares for a battle with me "What? Who are... you?"\n\n"Hehe... let's see how confident you are against one of your own kind, dreadlord!""
+ illidansbeginnings_0103_a: "I will banish you, [tichondrius.GetFirstName]!"
+ illidansbeginnings_0103_a_tt: "You will duel [tichondrius.GetFirstName] to death!"
+
+ illidansbeginnings_0104_title: "A Destiny of Flame and Sorrow"
+ illidansbeginnings_0104_desc: "A few days of wiping out the Demons still lurking in the forests, [tyrande.GetFirstName] approaches me. "Foul Demon! What have you done to [illidan.GetFirstName]?"\n\nI smile slightly and answer "It is I, [tyrande.GetFirstName]... this is what I've become..."\n[tyrande.GetFirstName] is shocked "What? [illidan.GetFirstName], how could you?"\nI present the forest empty from the corrupting forces and free of any Demons "The leader of those Undead legions has been destroyed, the forests will heal in time."\n\n[tyrande.GetFirstName] walks towards me with a disappointed face "At the cost of your soul? Begone from this place and our ancient lands... and never set foot in this place ever again!""
+ illidansbeginnings_0104_a: "So be it... [tyrande.GetFirstName]..."

--- a/localization/english/modifiers/wc_modifiers_l_english.yml
+++ b/localization/english/modifiers/wc_modifiers_l_english.yml
@@ -409,3 +409,6 @@
 
  dryad_and_keeper_blessed_by_restored_nordrassil: "Empowered by a Restored Nordrassil"
  dryad_and_keeper_blessed_by_restored_nordrassil_desc: "This Dryad is touched by the renewed powers of [GetBuilding('nordrassil_restored').GetName]. Though diminished from its ancient height, the World Tree once again grants a fragment of its former grace."
+
+ weakened_burning_legion: "Weakened Legions"
+ weakened_burning_legion_desc: "The [burning_legion|E] has been weakened after the #italic Skull of Gul'dan#! was destroyed by Illidan Stormrage."


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Iliidan will not be castrated, blinded or maimed by Maiev Shadowsong's AI
- Added a linear event chain for Illidan Stormrage which triggers after Cenarius is dead
- Completing the storyline will give a debuff to Archimonde
- After Illidan Stormrage becomes a Demon Hunter, the game will spawn random Demon Hunter adventurers every 5 years

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Just adding a small storyline for Illidan and to make him a demon hunter

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
