### PR TITLE
Fix Thunder King guaranteed spawn

### DIFF
--- a/common/on_action/wc_yearly_on_actions.txt
+++ b/common/on_action/wc_yearly_on_actions.txt
@@ -359,7 +359,7 @@ thunder_king_invasion_on_action = {
 				}
 			}
 		}
-		else = {
+		else_if = {
             limit = {
                 current_date > 650.1.1
                 current_date < 750.1.1
@@ -379,17 +379,28 @@ thunder_king_invasion_on_action = {
                     add = 10
                     current_date > 715.1.1
                 }
-                modifier = {
-                    add = 50
-                    current_date > 650.1.1
-                    has_game_rule = wc_thunder_king_crisis_guaranteed
-                }
                 debug_log = "Attempting to spawn Thunder King within 240 days"
                 trigger_event = {
                     id = pandaria_unification.0400
                     days = { 2 240 }
                 }
             }
+		}
+		else = {
+			limit = { has_game_rule = wc_thunder_king_crisis_guaranteed } 
+            debug_log = "Checking for chance of guaranteed spawning Thunder King after 650"			
+            random = {
+                chance = 1
+                modifier = {
+                    add = 50
+                    current_date > 650.1.1
+                }
+                debug_log = "Attempting to spawn Thunder King within 240 days"
+                trigger_event = {
+                    id = pandaria_unification.0400
+                    days = { 2 240 }
+                }
+            }			
 		}
     }
 }

--- a/common/on_action/wc_yearly_on_actions.txt
+++ b/common/on_action/wc_yearly_on_actions.txt
@@ -359,11 +359,24 @@ thunder_king_invasion_on_action = {
 				}
 			}
 		}
-		else_if = {
-            limit = {
-                current_date > 650.1.1
-                current_date < 750.1.1
-            }
+		else_if = {	
+			limit = { has_game_rule = wc_thunder_king_crisis_guaranteed } 
+            debug_log = "Checking for chance of guaranteed spawning Thunder King in 650"			
+            random = {
+                chance = 0
+                modifier = {
+					has_game_rule = wc_thunder_king_crisis_guaranteed 
+                    add = 100
+                    current_date > 650.1.1
+                }
+                debug_log = "Attempting to spawn Thunder King within 240 days"
+                trigger_event = {
+                    id = pandaria_unification.0400
+                    days = { 2 240 }
+                }
+            }			
+		}
+		else = {
             debug_log = "Checking for chance of spawning Thunder King after 650"
             random = {
                 chance = 1
@@ -385,22 +398,6 @@ thunder_king_invasion_on_action = {
                     days = { 2 240 }
                 }
             }
-		}
-		else = {
-			limit = { has_game_rule = wc_thunder_king_crisis_guaranteed } 
-            debug_log = "Checking for chance of guaranteed spawning Thunder King after 650"			
-            random = {
-                chance = 1
-                modifier = {
-                    add = 50
-                    current_date > 650.1.1
-                }
-                debug_log = "Attempting to spawn Thunder King within 240 days"
-                trigger_event = {
-                    id = pandaria_unification.0400
-                    days = { 2 240 }
-                }
-            }			
 		}
     }
 }


### PR DESCRIPTION

## Changelog:
- Fixed the chance of spawning AI Thunder King after 650 KC with guaranteed spawn gamerule.

## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

# How to test:
- Set date to 650.1.1 with guaranteed spawn gamerule and verify if Thunder King event fires properly.