### PR TITLE
Fix Bless applying multiple modifiers

### DIFF
--- a/common/scripted_effects/wc_magic_light_effects.txt
+++ b/common/scripted_effects/wc_magic_light_effects.txt
@@ -494,7 +494,20 @@ cast_bless_effect = {
             }
         }
         custom_tooltip = wc_bless_effect
-        every_spell_modifier_effect = { EFFECT = bless_apply_modifier_effect }
+        if = {
+            limit = { has_variable_list = bless_eligible_modifiers }
+            clear_variable_list = bless_eligible_modifiers
+        }
+        every_spell_modifier_effect = { EFFECT = bless_add_modifier_to_list_effect }
+        if = {
+            limit = { has_variable_list = bless_eligible_modifiers }
+            random_in_list = {
+                variable = bless_eligible_modifiers
+                save_scope_as = bless_modifier
+            }
+            every_spell_modifier_effect = { EFFECT = bless_apply_selected_modifier_effect }
+            clear_variable_list = bless_eligible_modifiers
+        }
         add_character_flag = {
             flag = wc_recently_blessed
             years = 1
@@ -502,7 +515,7 @@ cast_bless_effect = {
     }
 }
 
-bless_apply_modifier_effect = {
+bless_add_modifier_to_list_effect = {
     if = {
         limit = {
             NOT = { has_character_modifier = $MODIFIER$_modifier }
@@ -510,6 +523,24 @@ bless_apply_modifier_effect = {
             NOT = {
                 flag:$SPELL$ = flag:none
             }
+        }
+        add_to_variable_list = {
+            name = bless_eligible_modifiers
+            target = flag:$MODIFIER$
+        }
+    }
+
+    if = { # Error prevention
+        limit = { flag:$TYPE$ = flag:error }
+        limit = { flag:$SPELL$ = flag:error }
+    }
+}
+
+bless_apply_selected_modifier_effect = {
+    if = {
+        limit = {
+            exists = scope:bless_modifier
+            flag:$MODIFIER$ = scope:bless_modifier
         }
         send_interface_toast = {
             title = wc_bless_successful

--- a/common/scripted_triggers/wc_magic_spells_triggers.txt
+++ b/common/scripted_triggers/wc_magic_spells_triggers.txt
@@ -2703,6 +2703,14 @@ satisfy_spell_triggers_character = {
 			}
 		}
 	}
+	trigger_else_if = { # AI target selection does not use target_has_max_stacks_trigger.
+		limit = {
+			$SPELL$ = flag:bless
+		}
+		$TARGET$ = {
+			NOT = { has_character_flag = wc_recently_blessed }
+		}
+	}
 	trigger_else_if = { # Target must have some kind of physical injury
         limit = {
             #OR = {


### PR DESCRIPTION
## Changelog:
- Fixed Bless applying multiple positive spell modifiers from a single cast.
## Developer changelog:
- Bless now collects eligible positive spell modifiers and applies exactly one random modifier per cast.
- AI Bless targeting now respects the existing `wc_recently_blessed` target cooldown.
- Manual Bless and AI casting behavior remain enabled.
## Tests:
- [x] `git diff --check` passes.
- [x] No unresolved conflict markers.
- [x] Script braces are balanced.
- [ ] Runtime-tested in CK3 after rebasing/cherry-picking onto current `dev`.
# How to test:
1. Have an AI character cast Bless on the player or another valid target.
2. Confirm the target receives exactly one Bless-derived positive modifier, not dozens.
3. Confirm the target receives `wc_recently_blessed`.
4. Confirm another AI caster does not immediately Bless the same target again.