### PR TITLE
Add missing Russian Order magic localization aliases

### DIFF
--- a/localization/russian/wc_game_concepts_lifestyles_l_russian.yml
+++ b/localization/russian/wc_game_concepts_lifestyles_l_russian.yml
@@ -12,6 +12,8 @@
  game_concept_wc_disorder_magic_lifestyle_desc: "$game_concept_wc_disorder_magic_lifestyle$ подходит персонажам, желающим $disorder_magic_lifestyle_desc$"
  game_concept_wc_order_magic_lifestyle: "Тайная Магия: $game_concept_lifestyle$"
  game_concept_wc_order_magic_lifestyle_desc: "$game_concept_wc_order_magic_lifestyle$ подходит персонажам, желающим $order_magic_lifestyle_desc$"
+ game_concept_wc_Order_magic_lifestyle: "Тайная Магия: $game_concept_lifestyle$"
+ game_concept_wc_Order_magic_lifestyle_desc: "$game_concept_wc_Order_magic_lifestyle$ подходит персонажам, желающим $order_magic_lifestyle_desc$"
  game_concept_wc_life_magic_lifestyle: "Магия Природы: $game_concept_lifestyle$"
  game_concept_wc_life_magic_lifestyle_desc: "$game_concept_wc_life_magic_lifestyle$ подходит персонажам, желающим $life_magic_lifestyle_desc$"
  game_concept_wc_death_magic_lifestyle: "Магия Смерти: $game_concept_lifestyle$"

--- a/localization/russian/wc_game_concepts_magic_l_russian.yml
+++ b/localization/russian/wc_game_concepts_magic_l_russian.yml
@@ -123,6 +123,7 @@
  wc_life_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_life', 'магии Природы')|E]:"
  wc_death_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_death', 'магии Смерти')|E]:"
  wc_order_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_order', 'тайной магии')|E]:"
+ wc_Order_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_order', 'тайной магии')|E]:"
  wc_elemental_fire_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_elemental_fire', 'магии Огня')|E]:"
  wc_elemental_water_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_elemental_water', 'магии Воды')|E]:"
  wc_elemental_earth_magic_resistance: "[wc_magic_resistance|E] к [Concept('wc_spell_school_elemental_earth', 'магии Земли')|E]:"


### PR DESCRIPTION
## Changelog:
- Fixed missing Russian localization for Order magic.

## Developer changelog:
- Added Russian localization aliases for legacy Order magic keys.

## Tests:
- [ ] No unexpected `wc` errors in `error.log`
- [ ] Memory usage stays below 5.5 GB

# How to test:
Launch the game in Russian and check Order magic localization.