### PR TITLE
Perk Reset Effect Fix

### DIFF
--- a/events/magic_events/wc_magic_perk_event.txt
+++ b/events/magic_events/wc_magic_perk_event.txt
@@ -1,10 +1,45 @@
 ﻿namespace = magic_perk
 
+scripted_effect switch_arcane_intellect_skill = { 
+    if = { 
+        limit = { 
+            has_variable = arcane_intellect_skill
+            var:arcane_intellect_skill != flag:$SKILL$
+        }
+        switch = {
+            trigger = var:arcane_intellect_skill
+            flag:diplomacy = { add_diplomacy_skill = -2 }
+            flag:martial = { add_martial_skill = -2 }
+            flag:stewardship = { add_stewardship_skill = -2 } 
+            flag:intrigue = { add_intrigue_skill = -2 }
+            flag:learning = { add_learning_skill = -2 }
+        }
+        add_$SKILL$_skill = 2
+    }
+    if = {
+        limit = { NOT = { has_variable = arcane_intellect_skill } }
+        add_$SKILL$_skill = 2
+    }
+    set_variable = { 
+        name = arcane_intellect_skill
+        value = flag:$SKILL$
+    }
+}
+
 # Arcane Intellect by Robmart
 magic_perk.0001 = {
     content_source = dlc_GOA
     title = magic_perk.0001.title
-    desc = magic_perk.0001.desc
+    desc = { 
+        desc = magic_perk.0001.desc
+        first_valid = { 
+            triggered_desc = {
+                trigger = { has_variable = arcane_intellect_skill }
+                desc = magic_perk.0001.again
+            }
+            desc = magic_perk.0001.first
+        }
+    }
     theme = order
 
     left_portrait = {
@@ -14,33 +49,28 @@ magic_perk.0001 = {
 
     option = {
         name = magic_perk.0001.a
-        add_diplomacy_skill = 2
+        switch_arcane_intellect_skill = { SKILL = diplomacy }
     }
 
     option = {
         name = magic_perk.0001.b
-        add_martial_skill = 2
+        switch_arcane_intellect_skill = { SKILL = martial }
     }
 
     option = {
         name = magic_perk.0001.c
-        add_stewardship_skill = 2
+        switch_arcane_intellect_skill = { SKILL = stewardship }
     }
 
     option = {
         name = magic_perk.0001.d
-        add_intrigue_skill = 2
+        switch_arcane_intellect_skill = { SKILL = intrigue }
     }
 
     option = {
         name = magic_perk.0001.e
-        add_learning_skill = 2
+        switch_arcane_intellect_skill = { SKILL = learning }
     }
-
-    # option = {
-    #     name = magic_perk.0001.f
-    #     add_prowess_skill = 2
-    # }
 }
 
 # Holy Aura by Dione

--- a/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
+++ b/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
@@ -1,11 +1,14 @@
 ﻿l_english:
  magic_perk.0001.title:0 "Arcane Intellect"
- magic_perk.0001.desc:0 "As you channel the arcane energy, your mind sharpens, and possibilities unfold before you.\n\nWhich path will you enhance—your ability to sway others, command with authority, manage resources, unravel secrets, or deepen your knowledge? The magic hums in your veins, ready to amplify your chosen skill.\n\nThe decision is yours."
+ magic_perk.0001.desc:0 "As you channel the arcane energy, your mind sharpens, and possibilities unfold before you.\n\nWhich path will you enhance—your ability to sway others, command with authority, manage resources, unravel secrets, or deepen your knowledge? The magic hums in your veins, ready to amplify your chosen skill."
+ magic_perk.0001.first:0 "\n\nThe decision is yours."
+ magic_perk.0001.again:0 "\n\nThe decision is yours once more."
  magic_perk.0001.a:0 "Diplomacy"
  magic_perk.0001.b:0 "Martial"
  magic_perk.0001.c:0 "Stewardship"
  magic_perk.0001.d:0 "Intrigue"
  magic_perk.0001.e:0 "Learning"
+ magic_perk.0001.f:0 "Keep my previous selection"
 
  magic_perk.0002.title:0 "Holy Aura"
  magic_perk.0002.desc:0 "Your work as an agent of the light has not gone unnoticed. The divine energy that flows through you has grown stronger, and you can feel it radiating from your very being.\n\nWhich aspect of your faith will you enhance—your ability to heal, smite the wicked, protect the innocent, inspire the faithful, or deepen your understanding of the divine? The power of the light is yours to command.\n\nWill you use the power of holy magic for..."


### PR DESCRIPTION
One of our testers reported that repeatedly resetting perks caused certain perks to repeatedly grant buffs or events or other goodies that were only supposed to happen once. This PR aims to fix those issues.

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed the Arcane Intellect perk to allow the player to change their arcane intellect buff after resetting perks without stacking the buff. Also improved loc.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added a scripted effect that I'm pretty proud of to `magic_perks.0001` as well as additional loc

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
