### PR TITLE
Reset Perk Effects Fix

### DIFF
--- a/common/on_action/lifestyles/general_lifestyle_on_actions.txt
+++ b/common/on_action/lifestyles/general_lifestyle_on_actions.txt
@@ -11,6 +11,7 @@ on_perks_refunded = {
 
 		# Warcraft
 		wc_remove_all_wc_lifestyle_traits_effect = yes
+		wc_remove_perk_special_effects = yes
 		clear_variable_list = known_spells
 		set_variable = {
 			name = known_spells_count value = 0

--- a/common/scripted_effects/wc_magic_effects.txt
+++ b/common/scripted_effects/wc_magic_effects.txt
@@ -2056,13 +2056,16 @@ spell_execute = {
 }
 
 magic_buff_maintenance_effect = { # Monthly Maint
-    if = { # referesh modifier
+    if = { # refresh modifier (or don't if you dont have the perk anymore
         limit = {
             has_character_modifier = wc_hearth_blessing_modifier
         }
         remove_character_modifier = wc_hearth_blessing_modifier
-        add_character_modifier = {
-            modifier = wc_hearth_blessing_modifier
+        if = { 
+            limit = { has_perk = elemental_fire_magic_tree_1_perk_3 }
+            add_character_modifier = {
+                modifier = wc_hearth_blessing_modifier
+            }
         }
     }
     if = {

--- a/common/scripted_effects/wc_perk_effects.txt
+++ b/common/scripted_effects/wc_perk_effects.txt
@@ -9,3 +9,39 @@
         fallback = { hidden_effect = { make_trait_inactive = eternal_suffering_1 } }
     }
 }
+
+wc_remove_perk_special_effects = {
+    # arcane intellect
+    if = { 
+        limit = { has_variable = arcane_intellect_skill }
+        arcane_intellect_reset_effect = yes
+        remove_variable = arcane_intellect_skill
+    }
+    # spell hack
+    remove_variable = wc_spell_hack_available
+    remove_variable = wc_spell_hack_activated 
+    # presence of mind
+    remove_variable = wc_presence_of_mind_available
+    remove_variable = wc_presence_of_mind_activated 
+    # reverse causality
+    remove_variable = wc_reverse_causality_available
+    remove_variable = wc_reverse_causality_mult
+    # other order perks
+    # holy aura
+    remove_character_modifier = wc_devotion_aura_modifier
+    remove_character_modifier = wc_retribution_aura_modifier
+    remove_character_modifier = wc_concentration_aura_modifier
+    remove_character_modifier = wc_vengeance_aura_modifier
+    
+}
+
+arcane_intellect_reset_effect = {
+    switch = {
+        trigger = var:arcane_intellect_skill
+        flag:diplomacy = { add_diplomacy_skill = -2 }
+        flag:martial = { add_martial_skill = -2 }
+        flag:stewardship = { add_stewardship_skill = -2 } 
+        flag:intrigue = { add_intrigue_skill = -2 }
+        flag:learning = { add_learning_skill = -2 }
+    }
+}

--- a/common/scripted_effects/wc_perk_effects.txt
+++ b/common/scripted_effects/wc_perk_effects.txt
@@ -26,13 +26,15 @@ wc_remove_perk_special_effects = {
     # reverse causality
     remove_variable = wc_reverse_causality_available
     remove_variable = wc_reverse_causality_mult
-    # other order perks
     # holy aura
     remove_character_modifier = wc_devotion_aura_modifier
     remove_character_modifier = wc_retribution_aura_modifier
     remove_character_modifier = wc_concentration_aura_modifier
     remove_character_modifier = wc_vengeance_aura_modifier
-    
+    # aquatic bounty
+    remove_character_flag = aquatic_bounty_coastal
+    remove_character_flag = aquatic_bounty_river
+    remove_character_flag = aquatic_bounty_other
 }
 
 arcane_intellect_reset_effect = {

--- a/common/scripted_effects/wc_perk_effects.txt
+++ b/common/scripted_effects/wc_perk_effects.txt
@@ -35,6 +35,9 @@ wc_remove_perk_special_effects = {
     remove_character_flag = aquatic_bounty_coastal
     remove_character_flag = aquatic_bounty_river
     remove_character_flag = aquatic_bounty_other
+    # biome attunement
+    biome_attunement_removal_effect = yes
+    
 }
 
 arcane_intellect_reset_effect = {
@@ -46,4 +49,27 @@ arcane_intellect_reset_effect = {
         flag:intrigue = { add_intrigue_skill = -2 }
         flag:learning = { add_learning_skill = -2 }
     }
+}
+
+biome_attunement_removal_effect = {
+    biome_attunement_terrain_removal_effect = { TERRAIN = plains }
+    biome_attunement_terrain_removal_effect = { TERRAIN = farmlands }
+    biome_attunement_terrain_removal_effect = { TERRAIN = hills }
+    biome_attunement_terrain_removal_effect = { TERRAIN = mountains }
+    biome_attunement_terrain_removal_effect = { TERRAIN = desert }
+    biome_attunement_terrain_removal_effect = { TERRAIN = desert_mountains }
+    biome_attunement_terrain_removal_effect = { TERRAIN = oasis }
+    biome_attunement_terrain_removal_effect = { TERRAIN = jungle }
+    biome_attunement_terrain_removal_effect = { TERRAIN = forest }
+    biome_attunement_terrain_removal_effect = { TERRAIN = taiga }
+    biome_attunement_terrain_removal_effect = { TERRAIN = wetlands }
+    biome_attunement_terrain_removal_effect = { TERRAIN = steppe }
+    biome_attunement_terrain_removal_effect = { TERRAIN = floodplains }
+    biome_attunement_terrain_removal_effect = { TERRAIN = drylands }
+    remove_variable = biome_attunement_stacks
+}
+
+biome_attunement_terrain_removal_effect = { 
+    remove_character_modifier = wc_biome_attunement_$TERRAIN$
+    remove_character_modifier = wc_biome_attunement_final_$TERRAIN$
 }

--- a/events/magic_events/wc_magic_perk_event.txt
+++ b/events/magic_events/wc_magic_perk_event.txt
@@ -6,14 +6,7 @@ scripted_effect switch_arcane_intellect_skill = {
             has_variable = arcane_intellect_skill
             var:arcane_intellect_skill != flag:$SKILL$
         }
-        switch = {
-            trigger = var:arcane_intellect_skill
-            flag:diplomacy = { add_diplomacy_skill = -2 }
-            flag:martial = { add_martial_skill = -2 }
-            flag:stewardship = { add_stewardship_skill = -2 } 
-            flag:intrigue = { add_intrigue_skill = -2 }
-            flag:learning = { add_learning_skill = -2 }
-        }
+        arcane_intellect_reset_effect = yes
         add_$SKILL$_skill = 2
     }
     if = {

--- a/events/magic_events/wc_magic_perk_event.txt
+++ b/events/magic_events/wc_magic_perk_event.txt
@@ -1,10 +1,45 @@
 ﻿namespace = magic_perk
 
+scripted_effect switch_arcane_intellect_skill = { 
+    if = { 
+        limit = { 
+            has_variable = arcane_intellect_skill
+            var:arcane_intellect_skill != flag:$SKILL$
+        }
+        switch = {
+            trigger = var:arcane_intellect_skill
+            flag:diplomacy = { add_diplomacy_skill = -2 }
+            flag:martial = { add_martial_skill = -2 }
+            flag:stewardship = { add_stewardship_skill = -2 } 
+            flag:intrigue = { add_intrigue_skill = -2 }
+            flag:learning = { add_learning_skill = -2 }
+        }
+        add_$SKILL$_skill = 2
+    }
+    if = {
+        limit = { NOT = { has_variable = arcane_intellect_skill } }
+        add_$SKILL$_skill = 2
+    }
+    set_variable = { 
+        name = arcane_intellect_skill
+        value = flag:$SKILL$
+    }
+}
+
 # Arcane Intellect by Robmart
 magic_perk.0001 = {
     content_source = dlc_GOA
     title = magic_perk.0001.title
-    desc = magic_perk.0001.desc
+    desc = { 
+        desc = magic_perk.0001.desc
+        first_valid = { 
+            triggered_desc = {
+                trigger = { has_variable = arcane_intellect_skill }
+                desc = magic_perk.0001.again
+            }
+            desc = magic_perk.0001.first
+        }
+    }
     theme = order
 
     left_portrait = {
@@ -14,33 +49,28 @@ magic_perk.0001 = {
 
     option = {
         name = magic_perk.0001.a
-        add_diplomacy_skill = 2
+        switch_arcane_intellect_skill = { SKILL = diplomacy }
     }
 
     option = {
         name = magic_perk.0001.b
-        add_martial_skill = 2
+        switch_arcane_intellect_skill = { SKILL = martial }
     }
 
     option = {
         name = magic_perk.0001.c
-        add_stewardship_skill = 2
+        switch_arcane_intellect_skill = { SKILL = stewardship }
     }
 
     option = {
         name = magic_perk.0001.d
-        add_intrigue_skill = 2
+        switch_arcane_intellect_skill = { SKILL = intrigue }
     }
 
     option = {
         name = magic_perk.0001.e
-        add_learning_skill = 2
+        switch_arcane_intellect_skill = { SKILL = learning }
     }
-
-    # option = {
-    #     name = magic_perk.0001.f
-    #     add_prowess_skill = 2
-    # }
 }
 
 # Holy Aura by Dione

--- a/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
+++ b/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
@@ -8,7 +8,6 @@
  magic_perk.0001.c:0 "Stewardship"
  magic_perk.0001.d:0 "Intrigue"
  magic_perk.0001.e:0 "Learning"
- magic_perk.0001.f:0 "Keep my previous selection"
 
  magic_perk.0002.title:0 "Holy Aura"
  magic_perk.0002.desc:0 "Your work as an agent of the light has not gone unnoticed. The divine energy that flows through you has grown stronger, and you can feel it radiating from your very being.\n\nWhich aspect of your faith will you enhance—your ability to heal, smite the wicked, protect the innocent, inspire the faithful, or deepen your understanding of the divine? The power of the light is yours to command.\n\nWill you use the power of holy magic for..."

--- a/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
+++ b/localization/english/event_localization/magic_events/wc_magic_perk_events_l_english.yml
@@ -1,11 +1,14 @@
 ﻿l_english:
  magic_perk.0001.title:0 "Arcane Intellect"
- magic_perk.0001.desc:0 "As you channel the arcane energy, your mind sharpens, and possibilities unfold before you.\n\nWhich path will you enhance—your ability to sway others, command with authority, manage resources, unravel secrets, or deepen your knowledge? The magic hums in your veins, ready to amplify your chosen skill.\n\nThe decision is yours."
+ magic_perk.0001.desc:0 "As you channel the arcane energy, your mind sharpens, and possibilities unfold before you.\n\nWhich path will you enhance—your ability to sway others, command with authority, manage resources, unravel secrets, or deepen your knowledge? The magic hums in your veins, ready to amplify your chosen skill."
+ magic_perk.0001.first:0 "\n\nThe decision is yours."
+ magic_perk.0001.again:0 "\n\nThe decision is yours once more."
  magic_perk.0001.a:0 "Diplomacy"
  magic_perk.0001.b:0 "Martial"
  magic_perk.0001.c:0 "Stewardship"
  magic_perk.0001.d:0 "Intrigue"
  magic_perk.0001.e:0 "Learning"
+ magic_perk.0001.f:0 "Keep my previous selection"
 
  magic_perk.0002.title:0 "Holy Aura"
  magic_perk.0002.desc:0 "Your work as an agent of the light has not gone unnoticed. The divine energy that flows through you has grown stronger, and you can feel it radiating from your very being.\n\nWhich aspect of your faith will you enhance—your ability to heal, smite the wicked, protect the innocent, inspire the faithful, or deepen your understanding of the divine? The power of the light is yours to command.\n\nWill you use the power of holy magic for..."


### PR DESCRIPTION
One of our testers reported that repeatedly resetting perks caused certain perks to repeatedly grant buffs or events or other goodies that were only supposed to happen once. This PR aims to fix those issues.

<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed the Arcane Intellect perk to allow the player to change their arcane intellect buff after resetting perks without stacking the buff. Also improved loc.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Added a scripted effect that I'm pretty proud of to `magic_perks.0001` as well as additional loc

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
