### PR TITLE
Arthas expedition non dlc fixes

### DIFF
--- a/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
+++ b/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
@@ -343,8 +343,9 @@
 			ai_will_do = { value = 100 }
 			location_source = scripted
 			select_scripted_location = {
+				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
-					limit = { exists = global_var:plague_center } # TODO: Change to plague story cycle
+					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
 				}
 				else = { title:b_andorhal = { save_scope_as = province } }
@@ -379,11 +380,12 @@
 
 			location_source = scripted
 			select_scripted_location = {
+				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
-					limit = { exists = global_var:big_city_1 } # TODO: Change to plague story cycle
-					global_var:big_city_1.title_province = { save_scope_as = province }
+					limit = { exists = global_var:plague_center }
+					global_var:plague_center = { save_scope_as = province }
 				}
-				else = { title:b_hearthglen = { save_scope_as = province } }
+				else = { title:b_andorhal = { save_scope_as = province } }
 			}
 
 			on_enter_phase = {
@@ -416,11 +418,12 @@
 
 			location_source = scripted
 			select_scripted_location = {
+				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
-					limit = { exists = global_var:big_city_2 } # TODO: Change to plague story cycle
-					global_var:big_city_2.title_province = { save_scope_as = province }
+					limit = { exists = global_var:plague_center }
+					global_var:plague_center = { save_scope_as = province }
 				}
-				else = { title:b_stratholme = { save_scope_as = province } }
+				else = { title:b_andorhal = { save_scope_as = province } }
 			}
 
 			on_enter_phase = {
@@ -451,7 +454,12 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				title:b_tushma.title_province = { save_scope_as = province }
+				# is_single_location = yes requires every phase to resolve to the same province
+				if = {
+					limit = { exists = global_var:plague_center }
+					global_var:plague_center = { save_scope_as = province }
+				}
+				else = { title:b_andorhal = { save_scope_as = province } }
 			}
 
 			is_valid = {
@@ -492,7 +500,12 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				title:c_frostfate.title_province = { save_scope_as = province }
+				# is_single_location = yes requires every phase to resolve to the same province
+				if = {
+					limit = { exists = global_var:plague_center }
+					global_var:plague_center = { save_scope_as = province }
+				}
+				else = { title:b_andorhal = { save_scope_as = province } }
 			}
 
 			is_valid = {
@@ -533,7 +546,12 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				top_liege.capital_province = { save_scope_as = province }
+				# is_single_location = yes requires every phase to resolve to the same province
+				if = {
+					limit = { exists = global_var:plague_center }
+					global_var:plague_center = { save_scope_as = province }
+				}
+				else = { title:b_andorhal = { save_scope_as = province } }
 			}
 
 			is_valid = {

--- a/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
+++ b/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
@@ -343,7 +343,6 @@
 			ai_will_do = { value = 100 }
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
@@ -380,7 +379,6 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
@@ -419,7 +417,6 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
@@ -455,7 +452,6 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
@@ -501,7 +497,6 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }
@@ -547,7 +542,6 @@
 
 			location_source = scripted
 			select_scripted_location = {
-				# is_single_location = yes requires every phase to resolve to the same province
 				if = {
 					limit = { exists = global_var:plague_center }
 					global_var:plague_center = { save_scope_as = province }

--- a/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
+++ b/common/activities/activity_types/wc_activity_arthas_expedition_non_dlc.txt
@@ -399,7 +399,8 @@
 			on_phase_active = {
 				if = {
 					limit = { this = scope:host }
-					scope:activity = { var:malganis = { add_character_flag = wear_armor } }
+					find_malganis_effect = yes
+					scope:malganis = { add_character_flag = wear_armor }
 
 					scope:activity = {
 						progress_activity_phase_after = { days = 25 }
@@ -597,6 +598,7 @@
 							}
 						}
 						# Kill father
+						global_var:plagued_king = { save_scope_as = plagued_king }
 						trigger_event = { id = wc_arthas_story.85 days = 43 }
 					}
 					else_if = {
@@ -609,6 +611,7 @@
 							}
 						}
 						# Hug father
+						global_var:plagued_king = { save_scope_as = plagued_king }
 						trigger_event = { id = wc_arthas_story.100 days = 43 }
 					}
 				}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed Arthas's Expedition (without Tours & Tournaments) never being able to start.
- Fixed script errors at the end of Arthas's Expedition (without Tours & Tournaments), on both endings.
- Changelog generated by Claude.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- wc_activity_arthas_expedition_non_dlc.txt: all 6 phases now resolve to the same scripted location (plague_center, else b_andorhal) instead of 6 different provinces copy-pasted from the grand/DLC version.
- Hearthglen phase: added the missing find_malganis_effect = yes call before using scope:malganis; it was reading scope:activity.var:malganis, which is never set on that code path, throwing a script error.
- Lordaeron phase: re-save global_var:plagued_king to scope:plagued_king right before triggering wc_arthas_story.85/.100, matching the DLC file.
- Changelog generated by Claude.

<!--
Before the merge, we recommend you to do these tests with your branch.
-->
## Tests:
- [ ] There are no errors in `wc` files in `Documents\Paradox Interactive\Crusader Kings III\logs\error.log` except `portrait_decals.cpp:101`
- [ ] The mod takes less than 5.5 GB in the Task Manager (Windows)

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
- Test the arthas expedition without Tours and Tournaments DLC.